### PR TITLE
nitrates(sécu): patchs deps vulnérables + reflected-XSS admin

### DIFF
--- a/envergo/nitrates/views_admin_ouverture.py
+++ b/envergo/nitrates/views_admin_ouverture.py
@@ -8,6 +8,8 @@ Vit dans l'app nitrates (comme l'éditeur d'arbre YAML), accessible depuis le
 header de l'admin nitrates.
 """
 
+import json
+
 from django.contrib.admin.views.decorators import staff_member_required
 from django.http import HttpResponse, HttpResponseBadRequest
 from django.shortcuts import render
@@ -94,13 +96,12 @@ def ouverture_toggle(request):
         est_ouvert=est_ouvert
     )
     if not updated:
-        return HttpResponseBadRequest(f"Département {code!r} inconnu.")
+        return HttpResponseBadRequest("Département inconnu.")
 
     etat = "ouvert" if est_ouvert else "fermé"
     resp = HttpResponse(status=204)
-    resp["HX-Trigger"] = '{"showToast": {"message": "Département %s : %s"}}' % (
-        code,
-        etat,
+    resp["HX-Trigger"] = json.dumps(
+        {"showToast": {"message": "Département %s : %s" % (code, etat)}}
     )
     return resp
 
@@ -129,8 +130,11 @@ def ouverture_toggle_region(request):
     etat = "ouverte" if est_ouvert else "fermée"
     resp = HttpResponse(status=204)
     resp["HX-Refresh"] = "true"
-    resp["HX-Trigger"] = (
-        '{"showToast": {"message": "Région %s %s (%d départements)"}}'
-        % (region_code, etat, n)
+    resp["HX-Trigger"] = json.dumps(
+        {
+            "showToast": {
+                "message": "Région %s %s (%d départements)" % (region_code, etat, n)
+            }
+        }
     )
     return resp

--- a/package-lock.json
+++ b/package-lock.json
@@ -9522,9 +9522,10 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -36,6 +36,9 @@
     "stylelint": "^16.14.1",
     "stylelint-config-standard-scss": "^14.0.0"
   },
+  "overrides": {
+    "ws": "^8.21.0"
+  },
   "browserslist": [
     "last 2 versions"
   ],

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -34,13 +34,13 @@ certifi==2025.8.3
     #   fiona
     #   pyproj
     #   requests
-cffi==1.17.1
+cffi==2.1.0
     # via
     #   argon2-cffi-bindings
     #   cryptography
 charset-normalizer==3.4.2
     # via requests
-cryptography==45.0.7
+cryptography==48.0.1
     # via mozilla-django-oidc
 click==8.2.1
     # via
@@ -63,7 +63,7 @@ cligj==0.7.2
     # via fiona
 dacite==1.9.2
     # via -r base.in
-django==4.2.28
+django==4.2.30
     # via
     #   -r base.in
     #   django-allauth
@@ -147,7 +147,7 @@ packaging==25.0
     #   kombu
 phonenumbers==9.0.10
     # via django-phonenumber-field
-pillow==11.3.0
+pillow==12.2.0
     # via -r base.in
 pip-tools==7.5.0
     # via -r base.in
@@ -161,9 +161,9 @@ psycopg[binary]==3.2.9
     # via -r base.in
 psycopg-binary==3.2.9
     # via psycopg
-pycparser==2.22
+pycparser==3.0
     # via cffi
-pyjwt==2.10.1
+pyjwt==2.13.0
     # via mozilla-django-oidc
 pyproj==3.7.2
     # via -r base.in
@@ -183,7 +183,7 @@ pytz==2025.2
     # via -r base.in
 pyyaml==6.0.2
     # via -r base.in
-py7zr==1.1.0
+py7zr==1.1.3
     # via -r base.in
     # transitive deps (texttable, pycryptodomex, brotli, psutil,
     # backports.zstd, pyppmd, pybcj, multivolumefile, inflate64)
@@ -238,7 +238,7 @@ tzdata==2025.2
     # via
     #   faker
     #   kombu
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -r base.in
     #   django-anymail
@@ -250,7 +250,7 @@ vine==5.1.0
     #   kombu
 wcwidth==0.2.13
     # via prompt-toolkit
-wheel==0.45.1
+wheel==0.46.2
     # via pip-tools
 whitenoise==6.9.0
     # via -r base.in

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -78,7 +78,7 @@ django==4.2.30
     #   django-otp
     #   django-phonenumber-field
     #   django-redis
-django-allauth==65.10.0
+django-allauth==65.14.1
     # via -r base.in
 django-anymail[sendinblue]==13.0.1
     # via -r base.in
@@ -118,7 +118,7 @@ graphql-core==3.2.6
     # via gql
 hiredis==3.2.1
     # via -r base.in
-idna==3.10
+idna==3.15
     # via
     #   anyio
     #   requests
@@ -202,7 +202,7 @@ referencing==0.37.0
     # via
     #   jsonschema
     #   jsonschema-specifications
-requests==2.32.4
+requests==2.33.0
     # via
     #   django-anymail
     #   requests-toolbelt
@@ -224,7 +224,7 @@ six==1.17.0
     # via python-dateutil
 sniffio==1.3.1
     # via anyio
-sqlparse==0.5.3
+sqlparse==0.5.4
     # via django
 text-unidecode==1.3
     # via python-slugify

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -136,7 +136,7 @@ django==4.2.30
     #   django-redis
     #   django-stubs
     #   django-stubs-ext
-django-allauth==65.10.0
+django-allauth==65.14.1
     # via -r base.txt
 django-anymail[sendinblue]==13.0.1
     # via -r base.txt
@@ -194,7 +194,7 @@ faker==37.5.3
     # via
     #   -r base.txt
     #   factory-boy
-filelock==3.18.0
+filelock==3.20.3
     # via virtualenv
 fiona==1.10.1
     # via -r base.txt
@@ -214,7 +214,7 @@ hiredis==3.2.1
     # via -r base.txt
 identify==2.6.12
     # via pre-commit
-idna==3.10
+idna==3.15
     # via
     #   -r base.txt
     #   anyio
@@ -415,7 +415,7 @@ referencing==0.37.0
     #   jsonschema-specifications
 regex==2025.7.34
     # via djlint
-requests==2.32.4
+requests==2.33.0
     # via
     #   -r base.txt
     #   django-anymail
@@ -447,7 +447,7 @@ sniffio==1.3.1
     # via
     #   -r base.txt
     #   anyio
-sqlparse==0.5.3
+sqlparse==0.5.4
     # via
     #   -r base.txt
     #   django
@@ -496,7 +496,7 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.33.1
+virtualenv==20.36.1
     # via pre-commit
 watchdog==6.0.0
     # via -r local.in
@@ -504,7 +504,7 @@ wcwidth==0.2.13
     # via
     #   -r base.txt
     #   prompt-toolkit
-werkzeug==3.1.3
+werkzeug==3.1.6
     # via -r local.in
 wheel==0.46.2
     # via

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -55,7 +55,7 @@ certifi==2025.8.3
     #   fiona
     #   pyproj
     #   requests
-cffi==1.17.1
+cffi==2.1.0
     # via
     #   -r base.txt
     #   argon2-cffi-bindings
@@ -66,7 +66,7 @@ charset-normalizer==3.4.2
     # via
     #   -r base.txt
     #   requests
-cryptography==45.0.7
+cryptography==48.0.1
     # via
     #   -r base.txt
     #   mozilla-django-oidc
@@ -117,7 +117,7 @@ dill==0.4.0
     # via pylint
 distlib==0.4.0
     # via virtualenv
-django==4.2.28
+django==4.2.30
     # via
     #   -r base.txt
     #   django-allauth
@@ -304,7 +304,7 @@ phonenumbers==9.0.10
     # via
     #   -r base.txt
     #   django-phonenumber-field
-pillow==11.3.0
+pillow==12.2.0
     # via -r base.txt
 pip-tools==7.5.0
     # via -r base.txt
@@ -338,13 +338,13 @@ pure-eval==0.2.3
     # via stack-data
 pycodestyle==2.14.0
     # via flake8
-pycparser==2.22
+pycparser==3.0
     # via
     #   -r base.txt
     #   cffi
 pyflakes==3.4.0
     # via flake8
-pyjwt==2.10.1
+pyjwt==2.13.0
     # via
     #   -r base.txt
     #   mozilla-django-oidc
@@ -485,7 +485,7 @@ tzdata==2025.2
     #   -r base.txt
     #   faker
     #   kombu
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -r base.txt
     #   django-anymail
@@ -506,7 +506,7 @@ wcwidth==0.2.13
     #   prompt-toolkit
 werkzeug==3.1.3
     # via -r local.in
-wheel==0.45.1
+wheel==0.46.2
     # via
     #   -r base.txt
     #   pip-tools

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -114,7 +114,7 @@ django==4.2.30
     #   django-phonenumber-field
     #   django-redis
     #   django-storages
-django-allauth==65.10.0
+django-allauth==65.14.1
     # via -r base.txt
 django-anymail[sendinblue]==13.0.1
     # via -r base.txt
@@ -162,7 +162,7 @@ gunicorn==23.0.0
     # via -r production.in
 hiredis==3.2.1
     # via -r base.txt
-idna==3.10
+idna==3.15
     # via
     #   -r base.txt
     #   anyio
@@ -278,7 +278,7 @@ referencing==0.37.0
     #   -r base.txt
     #   jsonschema
     #   jsonschema-specifications
-requests==2.32.4
+requests==2.33.0
     # via
     #   -r base.txt
     #   django-anymail
@@ -312,7 +312,7 @@ sniffio==1.3.1
     # via
     #   -r base.txt
     #   anyio
-sqlparse==0.5.3
+sqlparse==0.5.4
     # via
     #   -r base.txt
     #   django

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -56,7 +56,7 @@ certifi==2025.8.3
     #   pyproj
     #   requests
     #   sentry-sdk
-cffi==1.17.1
+cffi==2.1.0
     # via
     #   -r base.txt
     #   argon2-cffi-bindings
@@ -65,7 +65,7 @@ charset-normalizer==3.4.2
     # via
     #   -r base.txt
     #   requests
-cryptography==45.0.7
+cryptography==48.0.1
     # via
     #   -r base.txt
     #   mozilla-django-oidc
@@ -98,7 +98,7 @@ cligj==0.7.2
     #   fiona
 dacite==1.9.2
     # via -r base.txt
-django==4.2.28
+django==4.2.30
     # via
     #   -r base.txt
     #   django-allauth
@@ -207,7 +207,7 @@ phonenumbers==9.0.10
     # via
     #   -r base.txt
     #   django-phonenumber-field
-pillow==11.3.0
+pillow==12.2.0
     # via -r base.txt
 pip-tools==7.5.0
     # via -r base.txt
@@ -227,11 +227,11 @@ psycopg-binary==3.2.9
     # via
     #   -r base.txt
     #   psycopg
-pycparser==2.22
+pycparser==3.0
     # via
     #   -r base.txt
     #   cffi
-pyjwt==2.10.1
+pyjwt==2.13.0
     # via
     #   -r base.txt
     #   mozilla-django-oidc
@@ -259,7 +259,7 @@ pytz==2025.2
     # via -r base.txt
 pyyaml==6.0.2
     # via -r base.txt
-py7zr==1.1.0
+py7zr==1.1.3
     # via -r base.txt
 qrcode==8.2
     # via
@@ -332,7 +332,7 @@ tzdata==2025.2
     #   -r base.txt
     #   faker
     #   kombu
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -r base.txt
     #   botocore
@@ -349,7 +349,7 @@ wcwidth==0.2.13
     # via
     #   -r base.txt
     #   prompt-toolkit
-wheel==0.45.1
+wheel==0.46.2
     # via
     #   -r base.txt
     #   pip-tools


### PR DESCRIPTION
Traite les alertes Dependabot + CodeQL (critical/high priorisés).

Deps pip : cryptography→48.0.1, django→4.2.30, pillow→12.2.0, pyjwt→2.13.0,
urllib3→2.7.0, + allauth/werkzeug/requests/idna. Résolution graphe + tests OK.
npm : ws≥8.21 via overrides (2 alertes high transitives).
Code : reflected-XSS dans l'admin ouverture géo — HX-Trigger construit par
concat → passé en json.dumps, plus de reflet de la valeur POST brute.

Non traité (à dismisser avec justif) : black (dev-only), decompress (transitive
dev abandonnée amont), findings Envergo upstream hors périmètre nitrates.

Tests : suite nitrates 1180 passed, 0 failed. Les 5 rouges Envergo sont
préexistants (identiques sur la base sans ces patchs).
