### PR TITLE
nitrates(sécurité): findings pentest restants F3/F4 (#150)

### DIFF
--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -46,6 +46,14 @@ SECURE_SSL_REDIRECT = env.bool("DJANGO_SECURE_SSL_REDIRECT", default=True)
 SESSION_COOKIE_SECURE = True
 # https://docs.djangoproject.com/en/dev/ref/settings/#csrf-cookie-secure
 CSRF_COOKIE_SECURE = True
+# nitrates(securite): SameSite explicite pour le flow OIDC ProConnect (F4, refs #150).
+# "Lax" : le callback ProConnect est une navigation top-level GET, donc compatible ;
+# "Strict" casserait le retour d'authentification. REVERT_AT_MERGE_TIME_FOR_UPSTREAM_ENVERGO
+SESSION_COOKIE_SAMESITE = "Lax"
+CSRF_COOKIE_SAMESITE = "Lax"
+# nitrates(securite): origines de confiance CSRF figées sur les hôtes autorisés,
+# en https (F4, refs #150). REVERT_AT_MERGE_TIME_FOR_UPSTREAM_ENVERGO
+CSRF_TRUSTED_ORIGINS = [f"https://{host}" for host in ALLOWED_HOSTS]
 # https://docs.djangoproject.com/en/dev/topics/security/#ssl-https
 # https://docs.djangoproject.com/en/dev/ref/settings/#secure-hsts-seconds
 # TODO: set this to 60 seconds first and then to 518400 once you prove the former works
@@ -291,7 +299,10 @@ SELF_DECLARATION_FORM_ID = env("DJANGO_SELF_DECLARATION_FORM_ID", default="")
 
 TRANSFER_EVAL_EMAIL_FORM_ID = env("DJANGO_TRANSFER_EVAL_EMAIL_FORM_ID", default="")
 
-ADMIN_OTP_REQUIRED = env.bool("DJANGO_ADMIN_OTP_REQUIRED", default=True)
+# nitrates(securite): OTP admin forcé en dur en prod (F4, refs #150) — plus de
+# lecture d'env var qui, mal positionnée, ferait sauter l'OTP silencieusement.
+# REVERT_AT_MERGE_TIME_FOR_UPSTREAM_ENVERGO
+ADMIN_OTP_REQUIRED = True
 
 # This should never be used, it's better to use the more specific `FROM_EMAIL` setting below
 # However, in we were to forget to manually set the `from` header in an outgoing email,

--- a/envergo/nitrates/auth.py
+++ b/envergo/nitrates/auth.py
@@ -35,6 +35,15 @@ class ProConnectBackend(OIDCAuthenticationBackend):
         if not email:
             return self.UserModel.objects.none()
 
+        # Fallback email : n'existe que pour la 1re connexion, avant que
+        # `proconnect_sub` soit persiste (ensuite le match se fait sur `sub`).
+        # On ne fait confiance a l'email que s'il est verifie par l'IdP, pour
+        # ne pas rattacher un compte pre-provisionne sur un email non prouve
+        # (F3 pentest 2026-06-18, refs #150). Aucune creation ici : create_user
+        # leve SuspiciousOperation, donc le pire cas reste borne.
+        if claims.get("email_verified") is False:
+            return self.UserModel.objects.none()
+
         return self.UserModel.objects.filter(email__iexact=email)
 
     def create_user(self, claims):

--- a/envergo/nitrates/tests/test_proconnect_backend.py
+++ b/envergo/nitrates/tests/test_proconnect_backend.py
@@ -76,6 +76,26 @@ def test_filter_email_case_insensitive(backend):
 
 
 @pytest.mark.django_db
+def test_filter_email_fallback_rejects_unverified_email(backend):
+    """F3 (refs #150) : le fallback email ne matche pas si l'IdP dit
+    explicitement que l'email n'est pas verifie."""
+    User.objects.create(email="known@example.com", name="Foo", is_staff=True)
+    claims = {"sub": "x", "email": "known@example.com", "email_verified": False}
+    users = backend.filter_users_by_claims(claims)
+    assert users.count() == 0
+
+
+@pytest.mark.django_db
+def test_filter_email_fallback_ok_when_verified_absent(backend):
+    """F3 : compat -- si le claim email_verified est absent (certains flux ne
+    l'envoient pas), on ne bloque pas, le fallback email reste actif."""
+    user = User.objects.create(email="known@example.com", name="Foo", is_staff=True)
+    claims = {"sub": "x", "email": "known@example.com"}
+    users = backend.filter_users_by_claims(claims)
+    assert list(users) == [user]
+
+
+@pytest.mark.django_db
 def test_update_user_persists_sub_first_login(backend):
     """A la 1ere connexion, on persiste le sub pour les futures reconnexions."""
     user = User.objects.create(email="known@example.com", name="Foo", is_staff=True)


### PR DESCRIPTION
Clôture des findings restants du pentest interne du 2026-06-18 (#150).
F1 (critique) et F2 étaient déjà faits et mergés dans la 0.4.0 ; il restait F3 et F4.

## F4 — durcissement config prod
- `SESSION_COOKIE_SAMESITE` / `CSRF_COOKIE_SAMESITE` = `Lax` (explicite pour le flow OIDC ProConnect ; `Strict` casserait le callback).
- `CSRF_TRUSTED_ORIGINS` figé sur `ALLOWED_HOSTS` en https.
- `ADMIN_OTP_REQUIRED` forcé en dur à `True` (plus de lecture d'env var qui, mal positionnée, ferait sauter l'OTP silencieusement).

## F3 — matching email à la 1re connexion ProConnect
Le fallback email (avant persistance du `proconnect_sub`) ne matche plus un compte pré-provisionné si l'IdP marque explicitement `email_verified=False`. Compat préservée si le claim est absent. Aucune création spontanée (create_user lève déjà SuspiciousOperation). +2 tests.

## Transigé (hors code)
F4 — bucket S3 media public-read : c'est une bucket policy (IaC), pas du code. Le bucket dev est public-read volontairement (screenshots de validation) ; le durcissement prod est au backlog Tofu. Non bloquant pour cette carte.

Les modifs de `production.py` (fichier upstream Envergo) portent le marqueur `REVERT_AT_MERGE_TIME_FOR_UPSTREAM_ENVERGO`, comme F1.
