### PR TITLE
develop → main : pentest F3/F4 + lot UI form/infobulle/calendrier

### DIFF
--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -46,6 +46,14 @@ SECURE_SSL_REDIRECT = env.bool("DJANGO_SECURE_SSL_REDIRECT", default=True)
 SESSION_COOKIE_SECURE = True
 # https://docs.djangoproject.com/en/dev/ref/settings/#csrf-cookie-secure
 CSRF_COOKIE_SECURE = True
+# nitrates(securite): SameSite explicite pour le flow OIDC ProConnect (F4, refs #150).
+# "Lax" : le callback ProConnect est une navigation top-level GET, donc compatible ;
+# "Strict" casserait le retour d'authentification. REVERT_AT_MERGE_TIME_FOR_UPSTREAM_ENVERGO
+SESSION_COOKIE_SAMESITE = "Lax"
+CSRF_COOKIE_SAMESITE = "Lax"
+# nitrates(securite): origines de confiance CSRF figées sur les hôtes autorisés,
+# en https (F4, refs #150). REVERT_AT_MERGE_TIME_FOR_UPSTREAM_ENVERGO
+CSRF_TRUSTED_ORIGINS = [f"https://{host}" for host in ALLOWED_HOSTS]
 # https://docs.djangoproject.com/en/dev/topics/security/#ssl-https
 # https://docs.djangoproject.com/en/dev/ref/settings/#secure-hsts-seconds
 # TODO: set this to 60 seconds first and then to 518400 once you prove the former works
@@ -291,7 +299,10 @@ SELF_DECLARATION_FORM_ID = env("DJANGO_SELF_DECLARATION_FORM_ID", default="")
 
 TRANSFER_EVAL_EMAIL_FORM_ID = env("DJANGO_TRANSFER_EVAL_EMAIL_FORM_ID", default="")
 
-ADMIN_OTP_REQUIRED = env.bool("DJANGO_ADMIN_OTP_REQUIRED", default=True)
+# nitrates(securite): OTP admin forcé en dur en prod (F4, refs #150) — plus de
+# lecture d'env var qui, mal positionnée, ferait sauter l'OTP silencieusement.
+# REVERT_AT_MERGE_TIME_FOR_UPSTREAM_ENVERGO
+ADMIN_OTP_REQUIRED = True
 
 # This should never be used, it's better to use the more specific `FROM_EMAIL` setting below
 # However, in we were to forget to manually set the `from` header in an outgoing email,

--- a/envergo/nitrates/auth.py
+++ b/envergo/nitrates/auth.py
@@ -35,6 +35,15 @@ class ProConnectBackend(OIDCAuthenticationBackend):
         if not email:
             return self.UserModel.objects.none()
 
+        # Fallback email : n'existe que pour la 1re connexion, avant que
+        # `proconnect_sub` soit persiste (ensuite le match se fait sur `sub`).
+        # On ne fait confiance a l'email que s'il est verifie par l'IdP, pour
+        # ne pas rattacher un compte pre-provisionne sur un email non prouve
+        # (F3 pentest 2026-06-18, refs #150). Aucune creation ici : create_user
+        # leve SuspiciousOperation, donc le pire cas reste borne.
+        if claims.get("email_verified") is False:
+            return self.UserModel.objects.none()
+
         return self.UserModel.objects.filter(email__iexact=email)
 
     def create_user(self, claims):

--- a/envergo/nitrates/tests/test_proconnect_backend.py
+++ b/envergo/nitrates/tests/test_proconnect_backend.py
@@ -76,6 +76,26 @@ def test_filter_email_case_insensitive(backend):
 
 
 @pytest.mark.django_db
+def test_filter_email_fallback_rejects_unverified_email(backend):
+    """F3 (refs #150) : le fallback email ne matche pas si l'IdP dit
+    explicitement que l'email n'est pas verifie."""
+    User.objects.create(email="known@example.com", name="Foo", is_staff=True)
+    claims = {"sub": "x", "email": "known@example.com", "email_verified": False}
+    users = backend.filter_users_by_claims(claims)
+    assert users.count() == 0
+
+
+@pytest.mark.django_db
+def test_filter_email_fallback_ok_when_verified_absent(backend):
+    """F3 : compat -- si le claim email_verified est absent (certains flux ne
+    l'envoient pas), on ne bloque pas, le fallback email reste actif."""
+    user = User.objects.create(email="known@example.com", name="Foo", is_staff=True)
+    claims = {"sub": "x", "email": "known@example.com"}
+    users = backend.filter_users_by_claims(claims)
+    assert list(users) == [user]
+
+
+@pytest.mark.django_db
 def test_update_user_persists_sub_first_login(backend):
     """A la 1ere connexion, on persiste le sub pour les futures reconnexions."""
     user = User.objects.create(email="known@example.com", name="Foo", is_staff=True)

--- a/envergo/nitrates/tests/test_tooltip_dsfr_recap.py
+++ b/envergo/nitrates/tests/test_tooltip_dsfr_recap.py
@@ -1,0 +1,88 @@
+"""#248 : la justification d'une periode « autorise sous condition » s'affiche
+via le composant infobulle DSFR (icone DSFR + affichage au clic/hover gere par
+le JS DSFR), et non plus via le `title` natif du navigateur.
+
+On rend le fragment de recap comme le fait `_panneau_resultat.html` et on
+verifie la structure DSFR (fr-btn--tooltip + fr-tooltip role=tooltip), ainsi que
+l'absence du title natif et du glyphe ⓘ.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+from django.template import Context, Template
+
+pytestmark = pytest.mark.django_db
+
+
+# Reproduit le bloc de recap de _panneau_resultat.html (#159 + #248).
+_FRAGMENT = """
+{% load nitrates_tags %}
+{% periodes_par_section regle as sections_periodes %}
+{% for section in sections_periodes %}
+  <ul>
+    {% for puce in section.periodes %}
+      <li>
+        {{ puce.phrase }}
+        {% if puce.justification %}
+          <button class="fr-btn--tooltip fr-btn periodes-info" type="button"
+                  aria-describedby="tooltip-periode-{{ forloop.parentloop.counter }}-{{ forloop.counter }}">
+            Justification
+          </button>
+          <span class="fr-tooltip fr-placement"
+                id="tooltip-periode-{{ forloop.parentloop.counter }}-{{ forloop.counter }}"
+                role="tooltip" aria-hidden="true">{{ puce.justification }}</span>
+        {% endif %}
+      </li>
+    {% endfor %}
+  </ul>
+{% endfor %}
+"""
+
+
+def _regle_autorisation_sous_condition():
+    return SimpleNamespace(
+        type="autorisation_sous_condition",
+        periodes=[{"du": "15/12", "au": "15/01"}],
+        texte_condition="Autorisé sous condition entre le 15/12 et le 15/01 (ICPE A).",
+    )
+
+
+def _render(regle):
+    return Template(_FRAGMENT).render(Context({"regle": regle}))
+
+
+def test_justification_rendue_en_tooltip_dsfr():
+    html = _render(_regle_autorisation_sous_condition())
+    # Composant DSFR present : bouton declencheur + tooltip lie.
+    assert 'class="fr-btn--tooltip fr-btn periodes-info"' in html
+    assert 'class="fr-tooltip fr-placement"' in html
+    assert 'role="tooltip"' in html
+    # Le declencheur pointe vers le tooltip : le meme id sert d'aria-describedby
+    # (bouton) et d'id (tooltip), quel que soit le numero de section/puce.
+    import re
+
+    m = re.search(r'aria-describedby="(tooltip-periode-\d+-\d+)"', html)
+    assert m, "aria-describedby du bouton tooltip absent"
+    assert f'id="{m.group(1)}"' in html
+    # Le texte de justification est bien dans le tooltip.
+    assert "Autorisé sous condition entre le 15/12 et le 15/01 (ICPE A)." in html
+
+
+def test_plus_de_title_natif_ni_glyphe_i():
+    html = _render(_regle_autorisation_sous_condition())
+    # Plus de tooltip natif navigateur ni du vieux glyphe ⓘ.
+    assert "title=" not in html
+    assert "ⓘ" not in html
+
+
+def test_pas_de_tooltip_sans_justification():
+    # Interdiction pure : pas de texte_condition -> pas de tooltip.
+    regle = SimpleNamespace(
+        type="interdiction",
+        periodes=[{"du": "15/11", "au": "15/01"}],
+        texte_condition=None,
+    )
+    html = _render(regle)
+    assert "fr-btn--tooltip" not in html
+    assert "fr-tooltip" not in html

--- a/envergo/static/nitrates/calculatrice-calendrier.js
+++ b/envergo/static/nitrates/calculatrice-calendrier.js
@@ -1391,6 +1391,7 @@
     // construction de la phrase de justification (conditionToText), seulement
     // son emplacement d'affichage.
     const pucesParRegime = {}; // regime -> [html <li>...]
+    let tooltipSeq = 0; // ids uniques des infobulles DSFR (#248)
     for (const seg of segments) {
       const regime = seg.regime;
       if (!REGIME_COULEUR_ZONE[regime]) continue; // libre/vert : gere a part
@@ -1406,7 +1407,13 @@
         const src = periodeSourcePourSegment(seg, actives);
         const condTxt = justificationInterdiction(src);
         if (condTxt) {
-          ligne += ` <span class="calc-cal__recap-info" tabindex="0" role="img" aria-label="${escapeHtml(condTxt)}" data-tooltip="${escapeHtml(condTxt)}">ⓘ</span>`;
+          // #248 : infobulle DSFR (bouton + tooltip role=tooltip, clic + hover
+          // geres par le JS DSFR), a la place du picto ⓘ + data-tooltip custom.
+          const tid = `tooltip-calc-recap-${tooltipSeq++}`;
+          const esc = escapeHtml(condTxt);
+          ligne +=
+            ` <button class="fr-btn--tooltip fr-btn calc-cal__recap-info" type="button" aria-describedby="${tid}">Justification</button>` +
+            `<span class="fr-tooltip fr-placement" id="${tid}" role="tooltip" aria-hidden="true">${esc}</span>`;
         }
       }
       (pucesParRegime[regime] = pucesParRegime[regime] || []).push(

--- a/envergo/static/nitrates/calendrier.css
+++ b/envergo/static/nitrates/calendrier.css
@@ -753,10 +753,24 @@ ul.calc-cal__recap-list {
 
 /* Picto info ⓘ : porte la justification en tooltip (#159, data-tooltip +
    bindTooltips). Discret, cliquable/focusable pour l'accessibilite. */
-.calc-cal__recap-info {
-  cursor: help;
-  color: var(--blue-france-sun-113-625, #000091);
-  margin-left: 0.15rem;
+
+/* #248 : declencheur d'infobulle DSFR du recap du calendrier dynamique.
+   Meme traitement que .periodes-info (statique) : icone DSFR agrandie et
+   bouton centre verticalement sur le texte de la puce. */
+.calc-cal__recap-info.fr-btn--tooltip {
+  margin-left: 0.25rem;
+  min-height: 1.25rem;
+  max-height: 1.25rem;
+  min-width: 1.25rem;
+  max-width: 1.25rem; /* garde overflow:hidden du label "Justification" */
+  padding: 0;
+  vertical-align: -0.3em;
+}
+
+.calc-cal__recap-info.fr-btn--tooltip::before {
+  --icon-size: 1.25rem;
+
+  margin: 0;
 }
 
 /* ─── Tooltip survol calendrier (issue #28) ─────────────────────────── */

--- a/envergo/static/nitrates/calendrier_bornes_layout.js
+++ b/envergo/static/nitrates/calendrier_bornes_layout.js
@@ -1,0 +1,112 @@
+/* #255 — anti-collision des labels de dates du calendrier STATIQUE.
+ *
+ * Le calendrier statique (templatetag calendrier_epandage / _calendrier.html)
+ * empilait les dates de facon binaire cote Python (date fixe = row0, pheno =
+ * row1). Deux dates fixes proches restaient donc sur la meme ligne et se
+ * chevauchaient (cf. ticket #255, colza type_III).
+ *
+ * On reprend la MEME logique que le calendrier dynamique
+ * (calculatrice-calendrier.js `layoutBornesRows`) : placement greedy
+ * gauche->droite par MESURE REELLE du DOM (les largeurs de texte ne sont
+ * connues qu'apres rendu, donc impossible a calculer cote Python). Chaque
+ * label est pose sur la 1ere row ou il ne chevauche aucun label deja place
+ * (avec un petit jeu horizontal). Le trait ::before s'allonge via la classe
+ * --rowN, et la hauteur du conteneur .period s'ajuste a la row max utilisee.
+ */
+(function () {
+  "use strict";
+
+  const ROW_STEP_PX = 18; // pas vertical des classes --rowN (doit matcher le CSS)
+  const ROW_GAP_PX = 6; // jeu horizontal mini entre 2 labels d'une meme row
+
+  function layoutOne(container) {
+    const labels = [
+      ...container.querySelectorAll(".calendrier-epandage__period-date"),
+    ];
+    if (labels.length === 0) return;
+
+    // Reset : tout en row0, on retire les classes --rowN posees (Python ou
+    // passe precedente) pour re-mesurer sur une base propre.
+    labels.forEach((el) => {
+      el.classList.remove(
+        "calendrier-epandage__period-date--row2",
+        "calendrier-epandage__period-date--row3",
+        "calendrier-epandage__period-date--row4",
+      );
+    });
+
+    // Mesure apres reset, tri par bord gauche.
+    const measured = labels
+      .map((el) => {
+        const r = el.getBoundingClientRect();
+        return { el, left: r.left, right: r.right };
+      })
+      .sort((a, b) => a.left - b.left);
+
+    // Greedy : 1ere row libre (0 = au plus pres de la barre) ou l'intervalle
+    // [left,right] ne touche pas le dernier label pose sur cette row.
+    const rowsLastRight = [];
+    let maxRow = 0;
+    for (const m of measured) {
+      let row = 0;
+      while (
+        rowsLastRight[row] !== undefined &&
+        m.left < rowsLastRight[row] + ROW_GAP_PX
+      ) {
+        row += 1;
+      }
+      rowsLastRight[row] = m.right;
+      if (row > maxRow) maxRow = row;
+      // row0 = pas de classe ; row>=1 -> --row{row+1} (row2/row3/row4).
+      if (row >= 1) {
+        m.el.classList.add(
+          `calendrier-epandage__period-date--row${row + 1}`,
+        );
+      }
+    }
+
+    // Hauteur du conteneur ajustee a la row la plus profonde utilisee.
+    container.style.height = `${20 + maxRow * ROW_STEP_PX + 8}px`;
+  }
+
+  function layoutAll() {
+    // Uniquement les calendriers STATIQUES : ceux geres par le JS dynamique
+    // (calc-cal) ont deja leur propre anti-collision.
+    document
+      .querySelectorAll(
+        ".calendrier-epandage:not(.calc-cal) .calendrier-epandage__period",
+      )
+      .forEach(layoutOne);
+  }
+
+  function schedule() {
+    // rAF pour mesurer apres que le layout CSS est applique.
+    if (typeof requestAnimationFrame === "function") {
+      requestAnimationFrame(layoutAll);
+    } else {
+      layoutAll();
+    }
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", schedule);
+  } else {
+    schedule();
+  }
+
+  // Recalage au resize (les largeurs de labels changent avec la largeur de la
+  // barre), debounce leger.
+  let t = null;
+  window.addEventListener("resize", function () {
+    if (t) clearTimeout(t);
+    t = setTimeout(schedule, 120);
+  });
+
+  // Le calendrier statique est souvent (re)injecte par htmx apres relance de la
+  // simulation : on relaye les evenements htmx pour re-layouter.
+  document.body.addEventListener("htmx:afterSwap", schedule);
+  document.body.addEventListener("htmx:afterSettle", schedule);
+
+  // Expose pour un appel manuel eventuel.
+  window.nitratesLayoutBornesStatique = layoutAll;
+})();

--- a/envergo/static/nitrates/simulateur.css
+++ b/envergo/static/nitrates/simulateur.css
@@ -897,9 +897,25 @@ ul.periodes-liste {
 /* #248 : declencheur d'infobulle DSFR (bouton) inline dans la liste des
    periodes. On garde l'icone/le comportement DSFR, on aligne juste le bouton
    sur le texte de la puce. */
+
+/* #248 : declencheur d'infobulle DSFR inline dans une liste de periodes.
+   L'icone DSFR par defaut (--icon-size: 1rem) est trop petite et le bouton
+   (min-height: 2rem) s'aligne mal sur la ligne de texte. On agrandit l'icone
+   et on centre le bouton verticalement sur le texte de la puce. */
 .periodes-info.fr-btn--tooltip {
-  margin-left: 0.15rem;
-  vertical-align: middle;
+  margin-left: 0.25rem;
+  min-height: 1.25rem;
+  max-height: 1.25rem;
+  min-width: 1.25rem;
+  max-width: 1.25rem; /* garde overflow:hidden du label "Justification" */
+  padding: 0;
+  vertical-align: -0.3em; /* centre l'icone sur la hauteur de la ligne (24px) */
+}
+
+.periodes-info.fr-btn--tooltip::before {
+  --icon-size: 1.25rem; /* 20px au lieu de 16px */
+
+  margin: 0;
 }
 
 /* ─── Focus clavier visible sur tous les boutons/liens d'action (Carte #154,

--- a/envergo/static/nitrates/simulateur.css
+++ b/envergo/static/nitrates/simulateur.css
@@ -893,10 +893,12 @@ ul.periodes-liste {
   list-style-position: outside;
 }
 
-.periodes-info {
-  cursor: help;
-  color: #000091;
+/* #248 : declencheur d'infobulle DSFR (bouton) inline dans la liste des
+   periodes. On garde l'icone/le comportement DSFR, on aligne juste le bouton
+   sur le texte de la puce. */
+.periodes-info.fr-btn--tooltip {
   margin-left: 0.15rem;
+  vertical-align: middle;
 }
 
 /* ─── Focus clavier visible sur tous les boutons/liens d'action (Carte #154,

--- a/envergo/static/nitrates/simulateur.css
+++ b/envergo/static/nitrates/simulateur.css
@@ -198,6 +198,17 @@
     background-color 0.12s ease;
 }
 
+/* #247 : espacement de 10px entre les options radio d'une meme question, pour
+   qu'elles ne soient pas collees. Le conteneur des options ([data-cascade] cote
+   form principal, ou le groupe QC) empile les .fr-radio-group ; on les aere avec
+   un gap homogene -> bloc compact et regulier. */
+.form-question-group [data-cascade],
+.form-question-group .qc-question {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
 .form-question-group .fr-radio-group:focus-within {
   box-shadow: inset 0 0 0 2px var(--outline-color, #0a76f6);
   background-color: rgb(10 118 246 / 6%);

--- a/envergo/static/nitrates/simulateur.css
+++ b/envergo/static/nitrates/simulateur.css
@@ -199,14 +199,15 @@
 }
 
 /* #247 : espacement de 10px entre les options radio d'une meme question, pour
-   qu'elles ne soient pas collees. Le conteneur des options ([data-cascade] cote
-   form principal, ou le groupe QC) empile les .fr-radio-group ; on les aere avec
-   un gap homogene -> bloc compact et regulier. */
-.form-question-group [data-cascade],
-.form-question-group .qc-question {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
+   qu'elles ne soient pas collees. On ajoute une marge entre deux options
+   consecutives (le combinateur `+` ne cible que des options qui SE SUIVENT
+   dans le flux). IMPORTANT : ne PAS mettre `display:flex/gap` sur le conteneur
+   [data-cascade] -> ca reafficherait les radios masques par le hack couvert en
+   2 questions (.couvert-split__origin-hidden { display:none }) et casserait le
+   formulaire. On garde donc le flux normal et un simple margin-top. */
+.form-question-group [data-cascade] .fr-radio-group + .fr-radio-group,
+.form-question-group .qc-question .fr-radio-group + .fr-radio-group {
+  margin-top: 10px;
 }
 
 .form-question-group .fr-radio-group:focus-within {

--- a/envergo/templates/nitrates/fragments/_panneau_form.html
+++ b/envergo/templates/nitrates/fragments/_panneau_form.html
@@ -151,7 +151,7 @@ dans les deux cas.
       <h2 class="form-section-title">Culture</h2>
 
       <div class="form-question-group">
-        <p class="form-question-text">Quelle est l'occupation du sol en cours ou à venir sur la parcelle ? *</p>
+        <p class="form-question-text">Sur quelle culture ou couvert prévoyez-vous d'épandre ? *</p>
         <div data-cascade="categorie_culture"></div>
       </div>
 

--- a/envergo/templates/nitrates/fragments/_panneau_resultat.html
+++ b/envergo/templates/nitrates/fragments/_panneau_resultat.html
@@ -131,11 +131,20 @@ Structure inspiree de la maquette site-nitrates-maquette/index.html :
                   <li>
                     {{ puce.phrase }}
                     {% if puce.justification %}
-                      <span class="periodes-info"
-                            tabindex="0"
-                            role="img"
-                            aria-label="{{ puce.justification }}"
-                            title="{{ puce.justification }}">ⓘ</span>
+                      {% comment %}
+                      #248 : infobulle DSFR (icone DSFR + affichage au clic +
+                      hover, gere par le JS DSFR) a la place du title natif du
+                      navigateur. Id unique par puce via les compteurs de boucle.
+                      {% endcomment %}
+                      <button class="fr-btn--tooltip fr-btn periodes-info"
+                              type="button"
+                              aria-describedby="tooltip-periode-{{ forloop.parentloop.counter }}-{{ forloop.counter }}">
+                        Justification
+                      </button>
+                      <span class="fr-tooltip fr-placement"
+                            id="tooltip-periode-{{ forloop.parentloop.counter }}-{{ forloop.counter }}"
+                            role="tooltip"
+                            aria-hidden="true">{{ puce.justification }}</span>
                     {% endif %}
                   </li>
                 {% endfor %}

--- a/envergo/templates/nitrates/simulateur.html
+++ b/envergo/templates/nitrates/simulateur.html
@@ -63,6 +63,8 @@
   <script defer src="{% static_v 'nitrates/form_autoscroll.js' %}"></script>
   {# Reset/flush du resultat au changement d'un champ apres soumission (#135). #}
   <script defer src="{% static_v 'nitrates/reset_form.js' %}"></script>
+  {# #255 : anti-collision des dates du calendrier statique (logique du dynamique) #}
+  <script defer src="{% static_v 'nitrates/calendrier_bornes_layout.js' %}"></script>
   {# Reformatage cosmetique front-only de questions a rallonge (#192) : swap du #}
   {# texte brut vers une version paragraphee, sans toucher a l'arbre. #}
   <script defer src="{% static_v 'nitrates/question_reformat.js' %}"></script>


### PR DESCRIPTION
Intégration develop → main. Deux lots.

## Sécurité — findings pentest F3/F4 (#150)
- SameSite explicite (session + CSRF) pour le flow OIDC, `CSRF_TRUSTED_ORIGINS` figé sur `ALLOWED_HOSTS`, `ADMIN_OTP_REQUIRED` forcé en dur.
- Fallback email ProConnect rejeté si `email_verified=False`.

## UI form + infobulle + calendrier
- **#247** espacement 10px entre les options radio (+ fix régression : ne réaffiche plus les radios masqués du couvert en 2 questions).
- **#248** infobulle DSFR (clic + hover, icône DSFR) à la place du `title` natif / picto ⓘ — calendrier statique ET dynamique, icône agrandie et centrée.
- **#249** nouvel intitulé de la question 1 (« Sur quelle culture ou couvert prévoyez-vous d'épandre ? »).
- **#255** anti-collision des dates du calendrier statique (reprise de la logique du dynamique).

Tests : pytest + JS verts. Vérifié en réel sur le simulateur (parcours réels + captures).
