### PR TITLE
fix: ADMIN_OTP_REQUIRED pilotable par env

### DIFF
--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -299,10 +299,11 @@ SELF_DECLARATION_FORM_ID = env("DJANGO_SELF_DECLARATION_FORM_ID", default="")
 
 TRANSFER_EVAL_EMAIL_FORM_ID = env("DJANGO_TRANSFER_EVAL_EMAIL_FORM_ID", default="")
 
-# nitrates(securite): OTP admin forcé en dur en prod (F4, refs #150) — plus de
-# lecture d'env var qui, mal positionnée, ferait sauter l'OTP silencieusement.
-# REVERT_AT_MERGE_TIME_FOR_UPSTREAM_ENVERGO
-ADMIN_OTP_REQUIRED = True
+# nitrates(securite): OTP admin (F4, refs #150). Défaut True (sécurisé), mais
+# pilotable par env pour les environnements de test/UAT où les comptes n'ont pas
+# encore de device TOTP provisionné (sinon boucle de login post-ProConnect).
+# En prod : ne PAS positionner la var (reste True). REVERT_AT_MERGE_TIME_FOR_UPSTREAM_ENVERGO
+ADMIN_OTP_REQUIRED = env.bool("DJANGO_ADMIN_OTP_REQUIRED", default=True)
 
 # This should never be used, it's better to use the more specific `FROM_EMAIL` setting below
 # However, in we were to forget to manually set the `from` header in an outgoing email,

--- a/envergo/nitrates/fixtures/initial_referentiels.json
+++ b/envergo/nitrates/fixtures/initial_referentiels.json
@@ -7,7 +7,7 @@
     "champs_prefill": {
       "occupation_sol": "sol_non_cultive"
     },
-    "ordre_affichage": 0
+    "ordre_affichage": 2
   }
 },
 {
@@ -16,7 +16,7 @@
     "identifiant": "culture_hiver",
     "libelle_public": "Culture d'hiver (culture principale implantée l'année civile en cours et récoltée l'année suivante)",
     "champs_prefill": {},
-    "ordre_affichage": 1
+    "ordre_affichage": 3
   }
 },
 {
@@ -25,7 +25,7 @@
     "identifiant": "culture_printemps",
     "libelle_public": "Culture de printemps (culture principale implantée et récoltée pendant la même année civile)",
     "champs_prefill": {},
-    "ordre_affichage": 2
+    "ordre_affichage": 4
   }
 },
 {
@@ -34,7 +34,7 @@
     "identifiant": "prairies_ou_luzerne",
     "libelle_public": "Prairies ou luzerne",
     "champs_prefill": {},
-    "ordre_affichage": 3
+    "ordre_affichage": 5
   }
 },
 {
@@ -43,7 +43,7 @@
     "identifiant": "autres_cultures_principales",
     "libelle_public": "Autres cultures principales (cultures pérennes, vergers, vignes, cultures maraîchères et cultures porte-graines)",
     "champs_prefill": {},
-    "ordre_affichage": 4
+    "ordre_affichage": 6
   }
 },
 {
@@ -52,7 +52,7 @@
     "identifiant": "couvert_intercultures_longue",
     "libelle_public": "Couvert d'interculture longue",
     "champs_prefill": {},
-    "ordre_affichage": 5
+    "ordre_affichage": 0
   }
 },
 {
@@ -61,7 +61,7 @@
     "identifiant": "couvert_intercultures_courte",
     "libelle_public": "Couvert d'interculture courte",
     "champs_prefill": {},
-    "ordre_affichage": 6
+    "ordre_affichage": 1
   }
 },
 {

--- a/envergo/static/nitrates/form_autoscroll.js
+++ b/envergo/static/nitrates/form_autoscroll.js
@@ -74,13 +74,16 @@
   }
 
   // Map : id de l'element qui se revele -> doit-on viser sa section parente ?
-  // - sections entieres (#section-culture via #form-after-localisation,
-  //   #categorie_fertilisant-wrapper dans #section-fertilisant) : oui, on
-  //   cadre sur le titre de section.
+  // - sections entieres (#categorie_fertilisant-wrapper dans #section-fertilisant)
+  //   : oui, on cadre sur le titre de section.
   // - wrappers intermediaires (sous_culture_form, sous_fertilisant) : non, on
   //   cadre pile sur la nouvelle question.
+  //
+  // #263 : PAS de scroll vers #section-culture apres la recherche par
+  // localisation. On veut que l'agriculteur reste sur la carte pour affiner
+  // son point / trouver sa parcelle, au lieu d'etre emmene direct au formulaire
+  // (surtout genant sur petit ecran). Le point par defaut reste pose.
   var ETAPES = [
-    { id: "section-culture", section: false },
     { id: "sous_culture_form-wrapper", section: false },
     { id: "section-fertilisant", section: false },
     { id: "categorie_fertilisant-wrapper", section: false },
@@ -111,25 +114,10 @@
     obs.observe(el, { attributes: true, attributeFilter: ["hidden"] });
   });
 
-  // Cas special "section-culture" : c'est #form-after-localisation qui change
-  // de `hidden` (au clic carte), pas #section-culture directement. On observe
-  // donc le conteneur et on scrolle vers la section Culture qu'il contient.
-  var zoneApresLoc = document.getElementById("form-after-localisation");
-  if (zoneApresLoc) {
-    var dejaRevele = estVisible(zoneApresLoc);
-    var obsLoc = new MutationObserver(function () {
-      if (estVisible(zoneApresLoc) && !dejaRevele) {
-        dejaRevele = true;
-        scrollVers(
-          document.getElementById("section-culture") || zoneApresLoc
-        );
-      }
-    });
-    obsLoc.observe(zoneApresLoc, {
-      attributes: true,
-      attributeFilter: ["hidden"],
-    });
-  }
+  // #263 : plus de scroll auto vers #section-culture au moment ou la zone
+  // apres-localisation se revele (clic carte / recherche). L'utilisateur reste
+  // sur la carte pour affiner son point. Le scroll ne reprend qu'a partir du
+  // choix de la categorie de culture (etapes ci-dessus).
 
   // Dernier pas : apres le choix du sous-fertilisant (fin de cascade), aucune
   // nouvelle etape ne se revele -> on amene au bouton de soumission. On ecoute

--- a/envergo/templates/nitrates/fragments/_panneau_form.html
+++ b/envergo/templates/nitrates/fragments/_panneau_form.html
@@ -148,7 +148,7 @@ dans les deux cas.
 
     {# ─── Culture ────────────────────────────────────────────────────── #}
     <div class="form-section" id="section-culture" style="margin-top: 40px;">
-      <h2 class="form-section-title">Culture</h2>
+      <h2 class="form-section-title">Culture ou couvert</h2>
 
       <div class="form-question-group">
         <p class="form-question-text">Sur quelle culture ou couvert prévoyez-vous d'épandre ? *</p>


### PR DESCRIPTION
Le forçage en dur `ADMIN_OTP_REQUIRED=True` (F4 #150) exige un device TOTP vérifié après login ProConnect. Sur les environnements de test (dev/staging), aucun compte n'a de device provisionné, ce qui provoque une boucle de login post-callback (accès admin impossible).

On repasse en `env.bool("DJANGO_ADMIN_OTP_REQUIRED", default=True)` : la prod reste protégée par défaut (ne pas poser la var), et les envs de test peuvent désactiver l'OTP via `DJANGO_ADMIN_OTP_REQUIRED=False`.