### PR TITLE
Arbre national : couvert courte types 0/I/II en autorisé sous conditions

### DIFF
--- a/envergo/nitrates/specs/arbres_actifs/national.yaml
+++ b/envergo/nitrates/specs/arbres_actifs/national.yaml
@@ -2615,10 +2615,9 @@ plafonnements:
 regles_partagees:
 - regle:
     id: r_cie_courte_types_0_I_II
-    type: libre
+    type: autorisation_sous_condition
     message: Couvert d'interculture courte, types 0, I (Ia ou Ib) ou II.
     periodes:
     - au: 30/06
       du: 01/07
-      regime: libre
     code_prescription: pc15


### PR DESCRIPTION
Correction de la grammaire d'une règle partagée de l'arbre national (couvert d'interculture courte).

La règle `r_cie_courte_types_0_I_II` portait une prescription conditionnée (pc15) mais était déclarée `type: libre` + `regime: libre` → le calendrier d'épandage s'affichait tout vert (« autorisé »), masquant qu'il y a une prescription à lire toute l'année.

Passée en `autorisation_sous_condition` (période sans regime, hérite du type) → calendrier orange « autorisé sous conditions ». La PC est conservée, l'encart plafond redondant n'apparaît pas.

Modif dans le fichier canonique `specs/arbres_actifs/national.yaml` (GitOps #50). Round-trip `dump_active_trees --check` OK. Vérifié en réel sur le parcours cie_courte + type_II.
