### PR TITLE
nitrates(sécu): active le header CSP en enforce (#261)

### DIFF
--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -328,54 +328,56 @@ FROM_EMAIL = {
 
 SERVER_EMAIL = env("DJANGO_SERVER_EMAIL", default=FROM_EMAIL["amenagement"]["admin"])
 
-# Whenever we are confident the csp policy is ok, move the rules from the "report only"
-# settings to this setting.
-SECURE_CSP = {}
+# Politique CSP resserrée au périmètre réel de nitrates (#261).
+#
+# On N'hérite PAS des origines Envergo (crisp.chat, sentry-cdn,
+# demarches-simplifiees...) : le fork nitrates n'utilise aucun de ces services.
+# On n'autorise que ce que le simulateur appelle réellement, pour ne pas
+# élargir la surface d'attaque par défaut.
+#
+# Surface réseau externe réelle (audit des templates + JS du simulateur) :
+#   - data.geopf.fr        : tuiles carto IGN/Géoplateforme (WMTS) + géocodage
+#   - api-adresse.data.gouv.fr, geo.api.gouv.fr : autocomplétion / commune (BAN)
+#   - Cellar S3            : médias (captures de validation)
+#   - sentry.incubateur.net : monitoring erreurs
+#   - Matomo beta.gouv     : stats (à implémenter prochainement, autorisé en amont)
+# Tout le reste (scripts, styles, fonts) est servi en propre ('self').
+# 'unsafe-inline' reste nécessaire tant que des <script>/style inline existent
+# dans les templates (migration vers nonce = chantier séparé).
+#
+# L'admin (éditeur YAML CodeMirror via cdnjs/unpkg) élargit cette politique
+# au cas par cas via csp_update, pas ici — cf. views_admin_yaml.
+_GEOPF = "https://data.geopf.fr"  # IGN / Géoplateforme (carto + géocodage)
+_BAN = "https://api-adresse.data.gouv.fr"  # Base Adresse Nationale
+_GEO_API = "https://geo.api.gouv.fr"  # Reverse commune
+_CELLAR_S3 = "https://*.cellar-c2.services.clever-cloud.com"  # Médias validation
+_SENTRY = "https://sentry.incubateur.net"  # Monitoring erreurs (loader JS + envoi)
+_MATOMO = "https://*.beta.gouv.fr"  # Stats Matomo (à venir)
 
-SECURE_CSP_REPORT_ONLY = {
+_CSP_POLICY = {
     "default-src": [CSP.SELF],
-    "script-src": [
-        CSP.SELF,
-        CSP.UNSAFE_INLINE,
-        "https://*.crisp.chat",
-        "https://sentry.incubateur.net",
-        "https://browser.sentry-cdn.com",
-        "https://*.data.gouv.fr",
-        "https://*.beta.gouv.fr",
-    ],
-    "connect-src": [
-        CSP.SELF,
-        "https://data.geopf.fr",  # New address autocomplete api
-        "https://*.data.gouv.fr",  # Address autocomplete api
-        "https://geo.api.gouv.fr",  # Reverse geocode commune (nitrates simulateur)
-        "https://*.beta.gouv.fr",  # Stats
-        "https://sentry.incubateur.net",
-        "https://*.crisp.chat",
-        "wss://*.crisp.chat",
-    ],
-    "style-src": [CSP.SELF, CSP.UNSAFE_INLINE, "https://*.crisp.chat"],
-    "img-src": [
-        CSP.SELF,
-        "https://data.geopf.fr",  # Leaflet geoportail images
-        "https://*.s3.fr-par.scw.cloud",
-        "data:",
-        "https://*.crisp.chat",
-        "https://static.demarches-simplifiees.fr",
-    ],
-    "font-src": [CSP.SELF, "https://*.crisp.chat"],
-    "media-src": [CSP.SELF, "https://*.s3.fr-par.scw.cloud", "https://*.crisp.chat"],
-    "frame-src": [
-        CSP.SELF,
-        "https://*.crisp.chat",
-        "https://*.data.gouv.fr",  # Matomo iframe opt-out
-        "https://*.beta.gouv.fr",
-    ],
-    "worker-src": [CSP.SELF, "blob:", "https://*.crisp.chat"],
+    "script-src": [CSP.SELF, CSP.UNSAFE_INLINE, _SENTRY, _MATOMO],
+    "connect-src": [CSP.SELF, _GEOPF, _BAN, _GEO_API, _SENTRY, _MATOMO],
+    "style-src": [CSP.SELF, CSP.UNSAFE_INLINE],
+    "img-src": [CSP.SELF, _GEOPF, _CELLAR_S3, "data:", _MATOMO],
+    "font-src": [CSP.SELF],
+    "media-src": [CSP.SELF, _CELLAR_S3],
+    "frame-src": [CSP.SELF, _MATOMO],  # iframe opt-out CNIL Matomo
+    "worker-src": [CSP.SELF, "blob:"],
     "object-src": [CSP.NONE],
     "base-uri": [CSP.SELF],
     "form-action": [CSP.SELF],
     "report-uri": "/csp/reports/",
 }
+
+# Enforce la politique (header Content-Security-Policy). Peut être basculé en
+# report-only seul via DJANGO_SECURE_CSP_ENFORCE=false en cas de régression.
+if env.bool("DJANGO_SECURE_CSP_ENFORCE", default=True):
+    SECURE_CSP = _CSP_POLICY
+else:
+    SECURE_CSP = {}
+
+SECURE_CSP_REPORT_ONLY = _CSP_POLICY
 
 RATELIMIT_IP_META_KEY = "HTTP_X_REAL_IP"
 

--- a/envergo/nitrates/tests/test_csp_header.py
+++ b/envergo/nitrates/tests/test_csp_header.py
@@ -1,0 +1,101 @@
+"""CSP nitrates : header enforce + périmètre resserré + exception admin (#261).
+
+Le staging tourne sous config.settings.production, où SECURE_CSP est désormais
+peuplé (promu depuis le report-only), resserré au périmètre réel de nitrates.
+"""
+
+from django.http import HttpResponse
+from django.test import override_settings
+
+from envergo.decorators.csp import csp_update
+from envergo.middleware.csp import ContentSecurityPolicyMiddleware
+
+CSP_ENFORCE = "Content-Security-Policy"
+CSP_REPORT_ONLY = "Content-Security-Policy-Report-Only"
+
+POLICY = {
+    "default-src": ["'self'"],
+    "script-src": ["'self'", "'unsafe-inline'"],
+    "img-src": ["'self'", "https://data.geopf.fr"],
+    "object-src": ["'none'"],
+    "report-uri": "/csp/reports/",
+}
+
+
+def _run_middleware(rf, response=None):
+    request = rf.get("/")
+    middleware = ContentSecurityPolicyMiddleware(lambda req: HttpResponse("ok"))
+    middleware.process_request(request)
+    return middleware.process_response(request, response or HttpResponse("ok"))
+
+
+@override_settings(SECURE_CSP=POLICY, SECURE_CSP_REPORT_ONLY=POLICY)
+def test_enforce_header_present_when_policy_set(rf):
+    """SECURE_CSP peuplé -> header enforce présent."""
+    response = _run_middleware(rf)
+    assert CSP_ENFORCE in response
+    assert "default-src 'self'" in response[CSP_ENFORCE]
+    assert "object-src 'none'" in response[CSP_ENFORCE]
+
+
+@override_settings(SECURE_CSP={}, SECURE_CSP_REPORT_ONLY=POLICY)
+def test_enforce_header_absent_when_policy_empty(rf):
+    """SECURE_CSP vide -> pas de header enforce, report-only seul (pré-#261)."""
+    response = _run_middleware(rf)
+    assert CSP_ENFORCE not in response
+    assert CSP_REPORT_ONLY in response
+
+
+class TestProductionPolicyScope:
+    """La politique de production ne doit PAS hériter des origines Envergo.
+
+    On lit le bloc _CSP_POLICY dans le source (le module production.py entier
+    n'est pas importable en test : il dépend de sentry_sdk / secrets absents).
+    """
+
+    def _policy_source(self):
+        from pathlib import Path
+
+        import config
+
+        # config/__init__.py -> config/settings/production.py, sans importer
+        # le module (qui tirerait sentry_sdk et les secrets prod). On borne au
+        # bloc CSP (définitions _GEOPF/_BAN... + dict _CSP_POLICY).
+        prod = Path(config.__file__).parent / "settings" / "production.py"
+        src = prod.read_text()
+        start = src.index("_GEOPF = ")
+        end = src.index("SECURE_CSP_REPORT_ONLY", start)
+        return src[start:end]
+
+    def test_ign_and_ban_present(self):
+        pol = self._policy_source()
+        assert "data.geopf.fr" in pol  # IGN / Géoplateforme
+        assert "api-adresse.data.gouv.fr" in pol  # BAN
+        assert "geo.api.gouv.fr" in pol  # commune
+
+    def test_no_envergo_third_parties(self):
+        # Gardés volontairement : sentry.incubateur.net (monitoring) et
+        # *.beta.gouv.fr (Matomo, à implémenter). Ce ne sont pas des dépendances
+        # tierces Envergo. On vérifie l'absence des services Envergo non utilisés.
+        pol = self._policy_source()
+        for banned in (
+            "crisp.chat",
+            "demarches-simplifiees",
+            "scw.cloud",
+            "sentry-cdn",
+        ):
+            assert banned not in pol, f"{banned} ne devrait pas être dans la CSP"
+
+
+@override_settings(SECURE_CSP=POLICY)
+def test_admin_yaml_view_extends_policy_with_cdns(rf):
+    """csp_update sur la vue admin ajoute cdnjs/unpkg sans toucher au global."""
+
+    @csp_update(config={"script-src": ["https://cdnjs.cloudflare.com"]})
+    def _view(request):
+        return HttpResponse("ok")
+
+    response = _run_middleware(rf, response=_view(rf.get("/")))
+    script = response[CSP_ENFORCE]
+    assert "cdnjs.cloudflare.com" in script  # exception admin
+    assert "'self'" in script  # base préservée

--- a/envergo/nitrates/views_admin_yaml.py
+++ b/envergo/nitrates/views_admin_yaml.py
@@ -19,6 +19,7 @@ from pygments import highlight
 from pygments.formatters import HtmlFormatter
 from pygments.lexers import YamlLexer
 
+from envergo.decorators.csp import csp_update
 from envergo.nitrates.models import DecisionTree
 from envergo.nitrates.permissions import can_activate_tree, can_edit_active
 from envergo.nitrates.yaml_admin.flatten import iter_entries
@@ -34,8 +35,21 @@ from envergo.nitrates.yaml_tree import load_tree_admin, load_tree_raw
 _VUES = {"arbre", "brut", "split"}
 _MODES = {"lecture", "edition"}
 
+# L'admin nitrates charge deux CDN : htmx depuis unpkg (layout base.html) et
+# CodeMirror depuis cdnjs (éditeur YAML, CSS + JS). La CSP globale nitrates est
+# volontairement stricte ('self' pour scripts/styles) pour le simulateur
+# public ; on élargit uniquement pour cette vue admin (derrière login) au lieu
+# d'ouvrir ces CDN à tout le public.
+_CDNJS = "https://cdnjs.cloudflare.com"  # CodeMirror (éditeur YAML)
+_UNPKG = "https://unpkg.com"  # htmx (layout admin)
+_CSP_ADMIN_YAML = {
+    "script-src": [_CDNJS, _UNPKG],
+    "style-src": [_CDNJS],
+}
+
 
 @method_decorator(staff_member_required, name="dispatch")
+@method_decorator(csp_update(_CSP_ADMIN_YAML), name="dispatch")
 class YamlTreeView(TemplateView):
     template_name = "nitrates_admin/yaml_tree/tree.html"
 


### PR DESCRIPTION
Ferme #261.

Le scan ZAP remonte un medium "CSP Header Not Set" : on n'émettait que le
report-only. Ce PR active l'enforce, avec une politique resserrée au périmètre
réel de nitrates : IGN/Géoplateforme, BAN, Cellar, Sentry, Matomo. On retire
les origines Envergo inutilisées (crisp, demarches-simplifiees…).

L'admin (CodeMirror, htmx) garde ses CDN via une exception par-vue.
Flag DJANGO_SECURE_CSP_ENFORCE (défaut true) pour repasser en report-only sans
redéploiement si besoin.
