### PR TITLE
Deploy dev : fix #272 templates manquants (parcours couvert)

### DIFF
--- a/envergo/static/nitrates/cascade.js
+++ b/envergo/static/nitrates/cascade.js
@@ -349,7 +349,22 @@
   }
 
   function parcoursComplet() {
+    // Partie culture (#272) : les champs cascade categorie_culture /
+    // sous_culture_form sont désormais pilotés en coulisse par le flow
+    // question_couvert_flow.js et rendus dans des conteneurs MASQUÉS -> ils ne
+    // passent plus le test de visibilité. On gate donc la partie culture sur le
+    // hidden input `occupation_sol`, qui n'est renseigné qu'une fois le flow
+    // arrivé à une branche valide (sous_culture résolu, ou sol_non_cultivé).
+    if (occupationSolHidden && !occupationSolHidden.value) return false;
+
+    // Dates couvert (Q4 #272) obligatoires quand posées : le flow marque le form
+    // tant que semis/destruction ne sont pas tous deux saisis.
+    const form = document.getElementById("form-simulateur");
+    if (form && form.hasAttribute("data-couvert-dates-incompletes")) return false;
+
+    // Partie fertilisant : gating inchangé sur les champs visibles.
     for (const champ of FIELDS) {
+      if (champ === "categorie_culture" || champ === "sous_culture_form") continue;
       const container = containers[champ];
       if (!estVisible(container)) continue;
       if (!currentValue(champ)) return false;

--- a/envergo/static/nitrates/reset_form.js
+++ b/envergo/static/nitrates/reset_form.js
@@ -383,6 +383,36 @@
     // lat/lng/code_insee ne sont pas des radios -> deja exclus.
     if (!rendurServeurAffiche()) return;
 
+    // Radios UI-only du flow culture/couvert (#272) : name prefixe `cflow_`.
+    // Ils PILOTENT les vrais champs cascade (categorie_culture /
+    // sous_culture_form), mais sur la PAGE RESULTAT la recomposition peut
+    // echouer silencieusement (ex interculture longue : la date de destruction
+    // qui infere la branche n'est plus saisie a gauche, elle est masquee ->
+    // pas de recompose) et le resultat resterait affiche sur un etat
+    // incoherent, avec des QC obsoletes. Des qu'un radio du flow change apres
+    // resultat : on INVALIDE le resultat (elague resultat + QC, ré-affiche le
+    // bouton) et on repasse le formulaire en mode SAISIE (retrait de
+    // data-resultat-affiche) -> le flow re-revele alors ses dates Q4 a gauche
+    // pour que l'utilisateur complete un parcours coherent avant de relancer.
+    if (target.name && target.name.indexOf("cflow_") === 0) {
+      const ordreC = ordreParcoursDOM();
+      setTimeout(() => {
+        elaguerResultat();
+        form.removeAttribute("data-resultat-affiche");
+        // Signale au flow de repasser en mode saisie (re-affiche Q4 dates).
+        document.dispatchEvent(new Event("nitrates:retour-saisie"));
+        // Elague l'aval de la partie culture : on repart de categorie_culture,
+        // dont on reprend la valeur COURANTE (le flow l'a repilotee) -> tout
+        // sous_culture / fertilisant / QC en aval est retire de l'URL.
+        reconstruireUrl(
+          "categorie_culture",
+          ordreC,
+          valeurCocheePour("categorie_culture")
+        );
+      }, 0);
+      return;
+    }
+
     // GARDE-FOU anti-boucle (#135) : si le radio modifie est DANS le bloc QC
     // en attente, c'est l'utilisateur qui REPOND a la question bloquante. On ne
     // touche a RIEN : subsidiaires_cascade.js gere la cascade conditionnelle,

--- a/envergo/templates/nitrates/fragments/_panneau_form.html
+++ b/envergo/templates/nitrates/fragments/_panneau_form.html
@@ -17,7 +17,10 @@ login au clic sur "Lancer la simulation". MoulinetteView sert les deux chemins
 (`/` via HomeView et `/simulateur/`), donc resoumettre sur place fonctionne
 dans les deux cas.
 {% endcomment %}
-<form id="form-simulateur" method="get" action="{{ request.path }}">
+<form id="form-simulateur"
+      method="get"
+      action="{{ request.path }}"
+      {% if afficher_resultat and not qc_en_attente %}data-resultat-affiche="1"{% endif %}>
 
   {# ─── Localisation ───────────────────────────────────────────────── #}
   <div class="form-section" id="section-localisation">
@@ -146,20 +149,89 @@ dans les deux cas.
   <div id="form-after-localisation"
        {% if not data.lat or not data.lng %}hidden{% endif %}>
 
-    {# ─── Culture ────────────────────────────────────────────────────── #}
+    {% comment %}
+    ─── Culture ou couvert (#272) ─────────────────────────────────────────
+    Refactor du parcours culture/couvert en questions successives (une a la
+    fois). Tout est piloté FRONT par question_couvert_flow.js :
+      Q1  destination_epandage  -> couvert | culture_principale
+      Q2  (couvert)  type_couvert  -> interculture longue / courte
+          (culture) categorie_culture réel (5 catégories, sol_non_cultivé en bas)
+      Q3  (couvert)  couvert récolté / non récolté
+      Q4  (couvert)  dates de semis + destruction (picker JJ/MM DSFR)
+
+    Les vrais champs cascade `categorie_culture` / `sous_culture_form` (source
+    de vérité soumise au backend, rendus par cascade.js) restent dans le DOM
+    mais sont masqués : le flow coche les bons radios et dispatch leur `change`
+    -> cascade.js prend le relais (résolution hidden inputs, cascade fertilisant),
+    exactement comme le faisait l'ancien couvert_split.js. Aucun changement
+    d'arbre ni de référentiels.
+
+    Pour l'interculture longue, la question historique « encore en place après
+    le 1ᵉʳ janvier ? » disparaît : elle est INFÉRÉE de la date de destruction
+    du couvert (Q4). Destruction ≥ 01/01 (inclus, année agricole) => couvert
+    toujours en place après le 1ᵉʳ janvier (branche …_apres_0101) ; sinon plus
+    en place après le 31/12 (branche …_avant_3112).
+    {% endcomment %}
     <div class="form-section" id="section-culture" style="margin-top: 40px;">
       <h2 class="form-section-title">Culture ou couvert</h2>
 
-      <div class="form-question-group">
-        <p class="form-question-text">Sur quelle culture ou couvert prévoyez-vous d'épandre ? *</p>
-        <div data-cascade="categorie_culture"></div>
+      {# Q1 — destination de l'épandage (regroupement UI front, 4 réponses -> 2 familles) #}
+      <div class="form-question-group" id="q_destination_epandage-wrapper">
+        <p class="form-question-text">Vous avez prévu d'épandre&nbsp;? *</p>
+        <div id="q_destination_epandage" class="couvert-flow__group"></div>
       </div>
 
-      <div class="form-question-group" id="sous_culture_form-wrapper" hidden>
-        <p class="form-question-text">Précisez le type de culture ou de couvert&nbsp;: *</p>
-        <div data-cascade="sous_culture_form"></div>
+      {# Q2 couvert — type d'interculture (longue / courte) #}
+      <div class="form-question-group" id="q_type_couvert-wrapper" hidden>
+        {# Texte adapté par question_couvert_flow.js selon Q1 : « Quel type de #}
+        {# couvert ? » (couvert) ou « Quelle catégorie de culture principale ? ». #}
+        <p class="form-question-text" id="q_type_couvert-label">Quel type de couvert&nbsp;? *</p>
+        <div id="q_type_couvert" class="couvert-flow__group"></div>
+      </div>
+
+      {# Q3 couvert — récolté / non récolté #}
+      <div class="form-question-group" id="q_couvert_recolte-wrapper" hidden>
+        <p class="form-question-text">Le couvert est-il récolté, fauché ou pâturé&nbsp;? *</p>
+        <div id="q_couvert_recolte" class="couvert-flow__group"></div>
+      </div>
+
+      {# Q3 culture principale — précision du type de culture (sous_culture) #}
+      <div class="form-question-group" id="q_sous_culture-wrapper" hidden>
+        <p class="form-question-text">Précisez le type de culture&nbsp;: *</p>
+        <div id="q_sous_culture" class="couvert-flow__group"></div>
+      </div>
+
+      {# Q4 couvert — dates de semis et destruction (picker JJ/MM DSFR, cf. #272) #}
+      <div class="form-question-group" id="q_dates_couvert-wrapper" hidden>
+        <p class="form-question-text">Quelles sont les dates prévues pour ce couvert&nbsp;? *</p>
+        <div id="q_dates_couvert" class="couvert-flow__dates"></div>
+      </div>
+
+      {% comment %}
+      Vrais champs cascade (source de vérité backend). Rendus par cascade.js ;
+      masqués (hidden) car pilotés par le flow ci-dessus. On garde le wrapper
+      #sous_culture_form-wrapper (id attendu par cascade.js) mais toujours caché.
+      {% endcomment %}
+      <div class="couvert-flow__origin-hidden" aria-hidden="true">
+        <div class="form-question-group" id="categorie_culture-wrapper">
+          <div data-cascade="categorie_culture"></div>
+        </div>
+        <div class="form-question-group" id="sous_culture_form-wrapper" hidden>
+          <div data-cascade="sous_culture_form"></div>
+        </div>
       </div>
     </div>
+
+    {# Hidden inputs des dates couvert (Q4) : remplis par le flow, consommés #}
+    {# par le backend (bornes calendrier date_semis/destruction_couvert). #}
+    <input type="hidden"
+           name="date_semis_couvert"
+           id="id_date_semis_couvert"
+           value="{{ data.date_semis_couvert|default:'' }}">
+    <input type="hidden"
+           name="date_destruction_couvert"
+           id="id_date_destruction_couvert"
+           value="{{ data.date_destruction_couvert|default:'' }}">
 
     {% comment %}
   Hidden inputs : occupation_sol + sous_culture sont resolus cote front

--- a/envergo/templates/nitrates/simulateur.html
+++ b/envergo/templates/nitrates/simulateur.html
@@ -57,8 +57,9 @@
   <script defer src="{% static_v 'nitrates/cascade.js' %}"></script>
   {# Barre de progression du parcours, fixee top (#154). #}
   <script defer src="{% static_v 'nitrates/progress.js' %}"></script>
-  {# Saisie en 2 questions du type de couvert interculture longue (hack UI). #}
-  <script defer src="{% static_v 'nitrates/couvert_split.js' %}"></script>
+  {# #272 : parcours culture/couvert en questions successives (Q1 destination -> #}
+  {# Q2 type -> Q3 récolté / sous-culture -> Q4 dates). Remplace couvert_split.js. #}
+  <script defer src="{% static_v 'nitrates/question_couvert_flow.js' %}"></script>
   {# Auto-scroll progressif entre les etapes du formulaire (#83). #}
   <script defer src="{% static_v 'nitrates/form_autoscroll.js' %}"></script>
   {# Reset/flush du resultat au changement d'un champ apres soumission (#135). #}


### PR DESCRIPTION
Propage le correctif #276 (templates + gating #272 jamais commités) de develop vers main pour que le déploiement dev de #272 soit réellement fonctionnel.

Sans ce correctif, le flow culture/couvert était chargé côté JS mais son markup HTML (questions Q1→Q4, data-resultat-affiche) était absent -> parcours cassé.