### PR TITLE
Deploy dev : #271 réagencement parcours résultat

### DIFF
--- a/envergo/nitrates/templatetags/nitrates_tags.py
+++ b/envergo/nitrates/templatetags/nitrates_tags.py
@@ -417,6 +417,25 @@ _SECTION_TITRE = {
 
 
 @register.simple_tag
+def nb_periodes_sous_condition(regle) -> int:
+    """Nombre de periodes « autorisation sous condition » d'une regle (#271).
+
+    Sert a accorder le libelle du bouton du drawer conditions (« cette periode »
+    vs « ces periodes »). On compte les periodes dont le regime effectif est
+    autorisation_sous_condition (regime explicite ou type de la regle).
+    """
+    if regle is None:
+        return 0
+    regle_type = getattr(regle, "type", None) or ""
+    periodes = getattr(regle, "periodes", None) or []
+    return sum(
+        1
+        for p in periodes
+        if (p.get("regime") or regle_type) == "autorisation_sous_condition"
+    )
+
+
+@register.simple_tag
 def periodes_par_section(regle) -> list[dict]:
     """Recap des periodes GROUPE PAR SECTION pour le calendrier statique (#159).
 

--- a/envergo/static/nitrates/calculatrice-calendrier.js
+++ b/envergo/static/nitrates/calculatrice-calendrier.js
@@ -1594,11 +1594,34 @@
   // laisse un conteneur [data-drawer-badges-asc] qu'on remplit ici.
   function majBadgesDrawer(regimeParJour) {
     const cible = document.querySelector("[data-drawer-badges-asc]");
-    if (!cible) return;
+    const lienCalc = document.querySelector("[data-drawer-lien-calc]");
     const segments = computeSegments(regimeParJour).filter(
       (s) => s.regime === "autorisation_sous_condition"
     );
-    if (!segments.length) {
+    const nb = segments.length;
+
+    // Lien déclencheur (calculatrice) : masqué s'il n'y a pas de période ASC,
+    // sinon libellé accordé au nombre. #271.
+    if (lienCalc) {
+      lienCalc.hidden = nb === 0;
+      const texte = lienCalc.querySelector("[data-drawer-lien-texte]");
+      if (texte) {
+        texte.textContent =
+          nb > 1
+            ? "Voir les conditions d'épandage spécifiques pour ces périodes"
+            : "Voir les conditions d'épandage spécifiques pour cette période";
+      }
+    }
+
+    // Titre « Période(s) d'application » du drawer, accordé au nombre.
+    const label = document.querySelector("[data-drawer-application-label]");
+    if (label) {
+      label.textContent =
+        (nb > 1 ? "Périodes d'application" : "Période d'application") + " :";
+    }
+
+    if (!cible) return;
+    if (!nb) {
       cible.innerHTML = "";
       return;
     }

--- a/envergo/static/nitrates/calculatrice-calendrier.js
+++ b/envergo/static/nitrates/calculatrice-calendrier.js
@@ -1584,6 +1584,39 @@
     layoutBornesRows();
     bindInputs();
     bindTooltips();
+    majBadgesDrawer(regimeParJour);
+  }
+
+  // #271 : réinjecte les dates des périodes d'autorisation sous condition
+  // (résolues depuis les dates saisies) dans le drawer « Conditions d'épandage »,
+  // sous forme de badges orange. Pour une règle calculatrice, ces dates sont
+  // event+offset (semis/destruction) que seul ce JS sait résoudre -> le template
+  // laisse un conteneur [data-drawer-badges-asc] qu'on remplit ici.
+  function majBadgesDrawer(regimeParJour) {
+    const cible = document.querySelector("[data-drawer-badges-asc]");
+    if (!cible) return;
+    const segments = computeSegments(regimeParJour).filter(
+      (s) => s.regime === "autorisation_sous_condition"
+    );
+    if (!segments.length) {
+      cible.innerHTML = "";
+      return;
+    }
+    cible.innerHTML = segments
+      .map((s) => {
+        const du = jourAgricoleToLisible(s.du);
+        const au = jourAgricoleToLisible(s.au);
+        return (
+          '<span class="drawer-conditions__date-badge">' +
+          '<span class="drawer-conditions__date-icon" aria-hidden="true">📅</span>' +
+          "du " +
+          escapeHtml(du) +
+          " au " +
+          escapeHtml(au) +
+          "</span>"
+        );
+      })
+      .join("");
   }
 
   // Anti-collision vertical des labels de bornes, par MESURE REELLE du DOM

--- a/envergo/static/nitrates/calculatrice-calendrier.js
+++ b/envergo/static/nitrates/calculatrice-calendrier.js
@@ -1474,6 +1474,28 @@
       pucesParRegime.libre = [`<li>${ligneAutorisation}</li>`];
     }
 
+    // #271 : lien vers le drawer des conditions PC, inséré DANS le <ul> de la
+    // section « autorisation sous condition » (comme un <li>), SOUS la/les
+    // période(s) ASC. Ainsi il reste rattaché à la bonne période (avant, un <p>
+    // hors calendrier pouvait suggérer un rattachement à une autre section).
+    // Rendu uniquement si la règle porte des prescriptions/note à montrer.
+    const ascPuces = pucesParRegime.autorisation_sous_condition || [];
+    const aDuContenu =
+      (data.codes_prescription && data.codes_prescription.length) || data.note;
+    if (ascPuces.length && aDuContenu) {
+      const pluriel = ascPuces.length > 1;
+      const texte = pluriel
+        ? "Voir les conditions d'épandage spécifiques pour ces périodes"
+        : "Voir les conditions d'épandage spécifiques pour cette période";
+      ascPuces.push(
+        '<li class="periodes-lien-conditions">' +
+          '<a href="#drawer-conditions" class="fr-link periodes-lien-conditions__link" data-drawer-open="drawer-conditions">' +
+          '<span class="periodes-lien-conditions__icon" aria-hidden="true">⚠️</span>' +
+          escapeHtml(texte) +
+          "</a></li>"
+      );
+    }
+
     // Rendu : une section par regime present, dans l'ordre SECTIONS_RECAP,
     // titre + liste a puces (maquette #159).
     const sectionsHtml = SECTIONS_RECAP.filter(
@@ -1594,26 +1616,12 @@
   // laisse un conteneur [data-drawer-badges-asc] qu'on remplit ici.
   function majBadgesDrawer(regimeParJour) {
     const cible = document.querySelector("[data-drawer-badges-asc]");
-    const lienCalc = document.querySelector("[data-drawer-lien-calc]");
     const segments = computeSegments(regimeParJour).filter(
       (s) => s.regime === "autorisation_sous_condition"
     );
     const nb = segments.length;
 
-    // Lien déclencheur (calculatrice) : masqué s'il n'y a pas de période ASC,
-    // sinon libellé accordé au nombre. #271.
-    if (lienCalc) {
-      lienCalc.hidden = nb === 0;
-      const texte = lienCalc.querySelector("[data-drawer-lien-texte]");
-      if (texte) {
-        texte.textContent =
-          nb > 1
-            ? "Voir les conditions d'épandage spécifiques pour ces périodes"
-            : "Voir les conditions d'épandage spécifiques pour cette période";
-      }
-    }
-
-    // Titre « Période(s) d'application » du drawer, accordé au nombre.
+    // Titre « Période(s) d'application » du drawer, accordé au nombre. #271.
     const label = document.querySelector("[data-drawer-application-label]");
     if (label) {
       label.textContent =

--- a/envergo/static/nitrates/construction.js
+++ b/envergo/static/nitrates/construction.js
@@ -37,6 +37,15 @@
       "nitrates-construction-visible",
       on
     );
+    // #271 : expose la hauteur RÉELLE du bandeau (elle varie : le texte passe
+    // sur plusieurs lignes en mobile) pour que ce qui se cale dessous (barre de
+    // progression, drawer) suive sa vraie hauteur au lieu d'une valeur figée.
+    var bar = root.querySelector(".nitrates-construction__bar") || root;
+    var h = on ? Math.round(bar.getBoundingClientRect().height) : 0;
+    document.documentElement.style.setProperty(
+      "--nitrates-construction-h",
+      h + "px"
+    );
   }
 
   function setScrolled(on) {

--- a/envergo/static/nitrates/drawer_conditions.js
+++ b/envergo/static/nitrates/drawer_conditions.js
@@ -1,0 +1,93 @@
+// #271 chantier 3 — Drawer « Conditions d'épandage ».
+//
+// Panneau latéral qui slide depuis la droite (2/3 desktop, plein écran mobile).
+// Ouvert par un bouton [data-drawer-open="<id>"], fermé par l'overlay, le bouton
+// « Fermer » ([data-drawer-close]) ou la touche Échap. Verrouille le scroll du
+// body tant qu'il est ouvert, et gère le focus (retour au déclencheur à la
+// fermeture) pour l'accessibilité.
+
+(function () {
+  "use strict";
+
+  var ouvert = null; // { drawer, declencheur }
+
+  function ouvrir(drawer, declencheur) {
+    if (ouvert) fermer();
+    // Reparente le drawer sous <body> : il est en position: fixed et pourrait
+    // sinon être clippé/piégé par un ancêtre (`.results-row { overflow: clip }`,
+    // transform du result-col…). On mémorise son emplacement d'origine pour le
+    // remettre à la fermeture (le contenu dépend de la règle rendue là).
+    if (drawer.parentNode !== document.body) {
+      drawer._ancre = document.createComment("drawer-conditions-ancre");
+      drawer.parentNode.insertBefore(drawer._ancre, drawer);
+      document.body.appendChild(drawer);
+    }
+    drawer.hidden = false;
+    // Force un reflow avant d'ajouter la classe --ouvert pour jouer la transition.
+    void drawer.offsetWidth;
+    drawer.classList.add("drawer-conditions--ouvert");
+    document.body.classList.add("drawer-open");
+    ouvert = { drawer: drawer, declencheur: declencheur };
+    // Focus sur le bouton Fermer (premier élément focusable du panneau).
+    var fermerBtn = drawer.querySelector("[data-drawer-close]");
+    if (fermerBtn && fermerBtn.focus) fermerBtn.focus();
+  }
+
+  function fermer() {
+    if (!ouvert) return;
+    var drawer = ouvert.drawer;
+    var declencheur = ouvert.declencheur;
+    drawer.classList.remove("drawer-conditions--ouvert");
+    document.body.classList.remove("drawer-open");
+    // Attendre la fin de la transition avant de remettre hidden (sinon coupure).
+    var fini = false;
+    var cacher = function () {
+      if (fini) return;
+      fini = true;
+      drawer.hidden = true;
+      drawer.removeEventListener("transitionend", cacher);
+    };
+    drawer.addEventListener("transitionend", cacher);
+    setTimeout(cacher, 400); // filet si transitionend ne se déclenche pas
+    ouvert = null;
+    // Remet le drawer à son emplacement d'origine (sous la règle) une fois caché,
+    // pour que le calendrier dynamique continue de cibler [data-drawer-badges-asc].
+    if (drawer._ancre && drawer._ancre.parentNode) {
+      setTimeout(function () {
+        if (!ouvert && drawer._ancre && drawer._ancre.parentNode) {
+          drawer._ancre.parentNode.insertBefore(drawer, drawer._ancre);
+          drawer._ancre.parentNode.removeChild(drawer._ancre);
+          drawer._ancre = null;
+        }
+      }, 420);
+    }
+    // Rendre le focus au bouton déclencheur.
+    if (declencheur && declencheur.focus) declencheur.focus();
+  }
+
+  // Délégation : ouverture / fermeture.
+  document.addEventListener("click", function (e) {
+    var openBtn = e.target.closest("[data-drawer-open]");
+    if (openBtn) {
+      var id = openBtn.getAttribute("data-drawer-open");
+      var drawer = document.getElementById(id);
+      if (drawer) {
+        e.preventDefault();
+        ouvrir(drawer, openBtn);
+      }
+      return;
+    }
+    if (e.target.closest("[data-drawer-close]")) {
+      e.preventDefault();
+      fermer();
+    }
+  });
+
+  // Échap ferme le drawer ouvert.
+  document.addEventListener("keydown", function (e) {
+    if (e.key === "Escape" && ouvert) {
+      e.preventDefault();
+      fermer();
+    }
+  });
+})();

--- a/envergo/static/nitrates/drawer_conditions.js
+++ b/envergo/static/nitrates/drawer_conditions.js
@@ -11,6 +11,18 @@
 
   var ouvert = null; // { drawer, declencheur }
 
+  // Hauteur VISIBLE du bandeau « site en construction » (page publique). 0 s'il
+  // est absent ou masqué (opacité ~0 tant qu'on n'a pas scrollé). Même mesure
+  // que scroll_resultat.js.
+  function hauteurBandeau() {
+    var bandeau = document.querySelector(".nitrates-construction__bar");
+    if (!bandeau) return 0;
+    var r = bandeau.getBoundingClientRect();
+    var style = window.getComputedStyle(bandeau);
+    if (r.height > 0 && parseFloat(style.opacity) > 0.1) return r.height;
+    return 0;
+  }
+
   function ouvrir(drawer, declencheur) {
     if (ouvert) fermer();
     // Reparente le drawer sous <body> : il est en position: fixed et pourrait
@@ -23,6 +35,15 @@
       document.body.appendChild(drawer);
     }
     drawer.hidden = false;
+    // #271 : sur la page publique `/`, un bandeau « site en construction » fixe
+    // occupe le haut (position: fixed, top: 0). Le drawer (top: 0 aussi) passait
+    // dessous -> son en-tête (Fermer) était caché. On décale donc le panneau ET
+    // l'overlay de la hauteur VISIBLE du bandeau.
+    var offsetHaut = hauteurBandeau();
+    var panel = drawer.querySelector(".drawer-conditions__panel");
+    var overlay = drawer.querySelector(".drawer-conditions__overlay");
+    if (panel) panel.style.top = offsetHaut + "px";
+    if (overlay) overlay.style.top = offsetHaut + "px";
     // Force un reflow avant d'ajouter la classe --ouvert pour jouer la transition.
     void drawer.offsetWidth;
     drawer.classList.add("drawer-conditions--ouvert");

--- a/envergo/static/nitrates/recap_choix.js
+++ b/envergo/static/nitrates/recap_choix.js
@@ -1,0 +1,170 @@
+// #271 chantier 2 — Encart récap des choix (colonne gauche, page résultat).
+//
+// Sur la page résultat, on ne montre plus le formulaire complet à gauche mais un
+// encart violet compact qui rappelle les choix de l'utilisateur, avec un bouton
+// « Modifier ». Ce module :
+//   1. masque le formulaire complet (#form-after-localisation) et affiche l'encart ;
+//   2. remplit l'encart en LANGAGE HUMAIN depuis l'état courant du form (les
+//      libellés déjà rendus : localisation, réponses du flow couvert/culture,
+//      dates, fertilisant) — pas de re-dérivation serveur ;
+//   3. câble « Modifier » : ré-affiche le formulaire, masque le résultat et
+//      repasse en mode saisie (réutilise reset_form.js #135).
+//
+// Rien n'est fait hors page résultat (l'encart n'est rendu par le template que
+// quand afficher_resultat est vrai).
+
+(function () {
+  "use strict";
+
+  var encart = document.getElementById("recap-choix");
+  if (!encart) return; // pas sur une page résultat
+
+  var form = document.getElementById("form-simulateur");
+  var formApres = document.getElementById("form-after-localisation");
+  var liste = encart.querySelector("[data-recap-liste]");
+  var btnModifier = encart.querySelector("[data-recap-modifier]");
+
+  // ─── Helpers de lecture des libellés (état courant du form) ─────────────
+
+  function texte(sel) {
+    var el = document.querySelector(sel);
+    var t = el ? (el.textContent || "").trim() : "";
+    return t && t !== "—" ? t : "";
+  }
+
+  // Libellé humain du radio coché d'un groupe (name), depuis son <label>.
+  function labelRadioCoche(name) {
+    var r = document.querySelector(
+      'input[type="radio"][name="' + name + '"]:checked'
+    );
+    if (!r) return "";
+    var lab = document.querySelector('label[for="' + r.id + '"]');
+    return lab ? (lab.textContent || "").trim() : "";
+  }
+
+  function valeurChamp(id) {
+    var el = document.getElementById(id);
+    return el ? (el.value || "").trim() : "";
+  }
+
+  // ─── Construction du récap ──────────────────────────────────────────────
+
+  function ligne(label, valeur) {
+    return { label: label, valeur: valeur };
+  }
+
+  function construireLignes() {
+    var lignes = [];
+
+    // Localisation : commune + département (depuis le bandeau localisation).
+    var commune = texte("#commune-display");
+    var dept = texte("#departement-display");
+    if (commune) {
+      lignes.push(ligne("Localisation", commune + (dept ? " (" + dept + ")" : "")));
+    }
+
+    // Culture ou couvert : on résume via les réponses du flow (#272).
+    var destination = labelRadioCoche("cflow_destination"); // couvert / culture principale
+    var typeCouvert = labelRadioCoche("cflow_type_couvert"); // interculture longue/courte OU catégorie culture
+    var recolte = labelRadioCoche("cflow_couvert_recolte"); // récolté / non
+    var sousCulture = labelRadioCoche("cflow_sous_culture"); // précision culture
+
+    if (destination) {
+      // Ligne « Culture ou couvert » : le type est le plus parlant.
+      var cultureVal = typeCouvert || destination;
+      lignes.push(ligne("Culture ou couvert", cultureVal));
+      if (recolte) lignes.push(ligne("Couvert", recolte));
+      if (sousCulture) lignes.push(ligne("Type de culture", sousCulture));
+    }
+
+    // Dates couvert (si renseignées).
+    var semis = valeurChamp("id_date_semis_couvert");
+    var destruction = valeurChamp("id_date_destruction_couvert");
+    if (semis || destruction) {
+      var d = [];
+      if (semis) d.push("semis " + semis);
+      if (destruction) d.push("destruction " + destruction);
+      lignes.push(ligne("Dates du couvert", d.join(" · ")));
+    }
+
+    // Fertilisant : catégorie + précision.
+    var catFert = labelRadioCoche("categorie_fertilisant");
+    var sousFert = labelRadioCoche("sous_fertilisant");
+    if (catFert || sousFert) {
+      lignes.push(ligne("Fertilisant", sousFert || catFert));
+    }
+
+    return lignes;
+  }
+
+  function rendre() {
+    var lignes = construireLignes();
+    liste.innerHTML = "";
+    lignes.forEach(function (l) {
+      var item = document.createElement("div");
+      item.className = "recap-choix__item";
+      var lab = document.createElement("span");
+      lab.className = "recap-choix__label";
+      lab.textContent = l.label;
+      var val = document.createElement("span");
+      val.className = "recap-choix__valeur";
+      val.textContent = l.valeur;
+      item.appendChild(lab);
+      item.appendChild(val);
+      liste.appendChild(item);
+    });
+  }
+
+  // ─── Bascule récap <-> formulaire ───────────────────────────────────────
+
+  // Affiche le récap et masque le formulaire complet (état page résultat).
+  function afficherRecap() {
+    if (formApres) formApres.hidden = true;
+    encart.hidden = false;
+    rendre();
+  }
+
+  // « Modifier » : ré-affiche le formulaire, masque l'encart, et invalide le
+  // résultat (retour en mode saisie). On délègue l'invalidation du résultat à
+  // reset_form.js : on retire l'attribut data-resultat-affiche, on enlève la
+  // colonne résultat et on repasse la grille en colonne unique, puis on notifie.
+  function modifier() {
+    encart.hidden = true;
+    if (formApres) formApres.hidden = false;
+
+    // Retire le résultat affiché (colonne droite + split) et repasse en saisie.
+    if (form) form.removeAttribute("data-resultat-affiche");
+    var resultCol = document.querySelector(".result-col");
+    if (resultCol) resultCol.remove();
+    var row = document.querySelector(".results-row");
+    if (row) row.classList.remove("layout--split");
+    // La colonne form reprend toute la largeur (on retire la contrainte 1/4).
+    var formCol = document.querySelector(".form-col");
+    if (formCol) formCol.classList.remove("fr-col-lg-3");
+    // Le bouton « Lancer la simulation » doit redevenir visible pour relancer.
+    var submitRow = document.getElementById("form-submit-row");
+    if (submitRow) submitRow.hidden = false;
+
+    // Notifie les autres modules (reset_form / flow) qu'on repasse en saisie.
+    document.dispatchEvent(new Event("nitrates:retour-saisie"));
+
+    // Recadre sur le formulaire (la première question).
+    var cible = document.getElementById("section-culture") || formApres;
+    if (cible && cible.scrollIntoView) {
+      cible.scrollIntoView({ behavior: "smooth", block: "start" });
+    }
+  }
+
+  if (btnModifier) btnModifier.addEventListener("click", modifier);
+
+  // Au chargement de la page résultat : masque le form, montre le récap.
+  // Les libellés (radios du flow + cascade fertilisant) sont rejoués de façon
+  // ASYNCHRONE (fetch référentiels puis rendu) -> on rend une première fois tout
+  // de suite (masque le form), puis on re-rend quand le flow signale qu'il a fini
+  // (nitrates:form-revealed) et via quelques essais différés en filet.
+  afficherRecap();
+  document.addEventListener("nitrates:form-revealed", rendre);
+  [150, 400, 900].forEach(function (ms) {
+    setTimeout(rendre, ms);
+  });
+})();

--- a/envergo/static/nitrates/recap_choix.js
+++ b/envergo/static/nitrates/recap_choix.js
@@ -56,11 +56,13 @@
   function construireLignes() {
     var lignes = [];
 
-    // Localisation : commune + département (depuis le bandeau localisation).
+    // Localisation : commune - région (sans le numéro de région, que personne ne
+    // connaît). Ex « Reims - Grand Est ». Le département (numéro) n'est pas repris
+    // ici : c'est la région en toutes lettres qui parle à l'utilisateur.
     var commune = texte("#commune-display");
-    var dept = texte("#departement-display");
+    var region = texte("#region-display").replace(/\s*\(\d+\)\s*$/, "").trim();
     if (commune) {
-      lignes.push(ligne("Localisation", commune + (dept ? " (" + dept + ")" : "")));
+      lignes.push(ligne("Localisation", commune + (region ? " - " + region : "")));
     }
 
     // Culture ou couvert : on résume via les réponses du flow (#272).

--- a/envergo/static/nitrates/simulateur.css
+++ b/envergo/static/nitrates/simulateur.css
@@ -1161,13 +1161,13 @@ html.nitrates-construction-visible .nitrates-progress {
    CETTE / CES période(s). L'item n'a pas de marqueur de liste. */
 li.periodes-lien-conditions {
   list-style: none;
-  margin-top: 0.35rem;
+  margin-top: 0.15rem;
 }
 
 /* Le lien est un <p> (cas calculatrice hors liste) : léger retrait pour
    s'aligner visuellement sous les puces. */
 p.periodes-lien-conditions {
-  margin: 0.35rem 0 0;
+  margin: 0.15rem 0 0;
   padding-left: 1.25rem;
 }
 
@@ -1176,6 +1176,11 @@ p.periodes-lien-conditions {
   align-items: baseline;
   gap: 0.4rem;
   font-weight: 600;
+
+  /* DSFR ajoute un padding vertical aux .fr-link -> gros blanc au-dessus du
+     lien. On le neutralise pour coller le lien à la période. */
+  padding-top: 0;
+  padding-bottom: 0;
 }
 
 .periodes-lien-conditions__icon {
@@ -1274,11 +1279,11 @@ body.drawer-open {
   padding: 0.3rem 0.7rem;
   border-radius: 4px;
 
-  /* Même orange que la zone « autorisé sous condition » du calendrier : on part
-     de --cal-orange-ink (#fa7a35) à faible opacité pour le fond, comme les
-     hachures, avec le contour plein de la même teinte. */
-  background: rgb(250 122 53 / 18%);
-  border: 1px solid var(--cal-orange-ink, #fa7a35);
+  /* EXACTEMENT l'orange des hachures « autorisé sous condition » du calendrier
+     (--cal-orange-ink #fa7a35), en fond PLEIN et SANS bordure (comme la
+     maquette designer). Texte foncé pour le contraste sur l'orange. */
+  background: var(--cal-orange-ink, #fa7a35);
+  border: none;
   color: var(--text-default-grey, #161616);
   font-size: 0.9rem;
   font-weight: 600;
@@ -1302,5 +1307,6 @@ body.drawer-open {
 }
 
 [data-fr-theme="dark"] .drawer-conditions__date-badge {
-  background: rgb(250 122 53 / 18%);
+  background: var(--cal-orange-ink, #fa7a35);
+  color: #161616;
 }

--- a/envergo/static/nitrates/simulateur.css
+++ b/envergo/static/nitrates/simulateur.css
@@ -1155,13 +1155,23 @@ html.nitrates-construction-visible .nitrates-progress {
    Panneau latéral qui slide depuis la droite. 2/3 de large sur desktop, plein
    écran sur mobile. Ouvert/fermé par drawer_conditions.js (classe --ouvert). */
 
-/* Bouton déclencheur : bien visible, façon appel à l'action près du calendrier. */
-.drawer-conditions__trigger {
-  margin-top: 1.5rem;
+/* Lien déclencheur (#271) : intégré dans la section « autorisation sous
+   condition », avec icône warning. Pas un gros bouton bleu (tache, illisible)
+   mais un lien clair qui rattache l'action à CETTE / CES période(s). */
+.periodes-lien-conditions {
+  margin: 0.5rem 0 0;
 }
 
-.drawer-conditions__trigger-icon {
-  margin-right: 0.4rem;
+.periodes-lien-conditions__link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-weight: 600;
+}
+
+.periodes-lien-conditions__icon {
+  font-size: 1.05rem;
+  line-height: 1;
 }
 
 /* Verrou du scroll body quand un drawer est ouvert. */
@@ -1214,18 +1224,13 @@ body.drawer-open {
   transform: translateX(0);
 }
 
+/* En-tête du drawer : plus de titre, juste le bouton Fermer aligné à droite. */
 .drawer-conditions__header {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  padding: 1.25rem 1.5rem;
-  border-bottom: 1px solid var(--border-default-grey, #ddd);
+  justify-content: flex-end;
+  padding: 1rem 1.5rem 0.5rem;
   flex: 0 0 auto;
-}
-
-.drawer-conditions__titre {
-  margin: 0;
 }
 
 .drawer-conditions__contenu {
@@ -1234,9 +1239,22 @@ body.drawer-open {
   flex: 1 1 auto;
 }
 
-/* Badges des dates de périodes ASC réinjectées : orange, façon calendrier, avec
-   icône 📅. Rappellent quand ces conditions s'appliquent. Placés en tête du
-   contenu (avant les blocs riches PC). */
+/* En-tête « Période(s) d'application : » + badges de dates. */
+.drawer-conditions__application {
+  margin-bottom: 1.25rem;
+}
+
+.drawer-conditions__application-label {
+  display: block;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+  color: var(--text-title-grey, #161616);
+}
+
+/* Badges des dates de périodes ASC réinjectées : ORANGE (cohérent avec la zone
+   « autorisé sous condition » du calendrier), icône 📅. NB : la var
+   --cal-orange-fill vaut en réalité le fond ROUGE partagé (choix maquette #130),
+   donc on pose ici un vrai orangé pâle + le contour orange --cal-orange-ink. */
 .drawer-conditions__date-badge {
   display: inline-flex;
   align-items: center;
@@ -1244,7 +1262,7 @@ body.drawer-open {
   margin: 0 0.5rem 0.5rem 0;
   padding: 0.3rem 0.7rem;
   border-radius: 4px;
-  background: var(--cal-orange-fill, #fddede);
+  background: #fdead9;
   border: 1px solid var(--cal-orange-ink, #fa7a35);
   color: var(--text-default-grey, #161616);
   font-size: 0.9rem;

--- a/envergo/static/nitrates/simulateur.css
+++ b/envergo/static/nitrates/simulateur.css
@@ -381,6 +381,12 @@ body {
   line-height: 1.3;
 }
 
+/* Questions complémentaires répondues : légère séparation du bloc principal. */
+.recap-choix__qc {
+  padding-top: 16px;
+  border-top: 1px solid rgb(106 106 244 / 35%);
+}
+
 .recap-choix__modifier {
   align-self: flex-start;
 }

--- a/envergo/static/nitrates/simulateur.css
+++ b/envergo/static/nitrates/simulateur.css
@@ -1150,3 +1150,124 @@ html.nitrates-construction-visible .nitrates-progress {
 [data-fr-theme="dark"] .nitrates-loc-loading__fill {
   background: #8585f6;
 }
+
+/* ─── #271 chantier 3 : drawer « Conditions d'épandage » ─────────────────────
+   Panneau latéral qui slide depuis la droite. 2/3 de large sur desktop, plein
+   écran sur mobile. Ouvert/fermé par drawer_conditions.js (classe --ouvert). */
+
+/* Bouton déclencheur : bien visible, façon appel à l'action près du calendrier. */
+.drawer-conditions__trigger {
+  margin-top: 1.5rem;
+}
+
+.drawer-conditions__trigger-icon {
+  margin-right: 0.4rem;
+}
+
+/* Verrou du scroll body quand un drawer est ouvert. */
+body.drawer-open {
+  overflow: hidden;
+}
+
+/* Conteneur plein écran (overlay + panneau). hidden -> display:none. */
+.drawer-conditions {
+  position: fixed;
+  inset: 0;
+  z-index: 2000;
+}
+
+.drawer-conditions[hidden] {
+  display: none;
+}
+
+.drawer-conditions__overlay {
+  position: absolute;
+  inset: 0;
+  background: rgb(22 22 22 / 45%);
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.drawer-conditions--ouvert .drawer-conditions__overlay {
+  opacity: 1;
+}
+
+/* Panneau : ancré à droite, 2/3 de large, translaté hors écran par défaut. */
+.drawer-conditions__panel {
+  position: absolute;
+  top: 0;
+  right: 0;
+  height: 100%;
+  width: 66.6667%;
+  max-width: 900px;
+  background: var(--background-default-grey, #fff);
+  color: var(--text-default-grey, #161616);
+  box-shadow: -4px 0 24px rgb(0 0 0 / 20%);
+  transform: translateX(100%);
+  transition: transform 0.32s ease;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.drawer-conditions--ouvert .drawer-conditions__panel {
+  transform: translateX(0);
+}
+
+.drawer-conditions__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1.25rem 1.5rem;
+  border-bottom: 1px solid var(--border-default-grey, #ddd);
+  flex: 0 0 auto;
+}
+
+.drawer-conditions__titre {
+  margin: 0;
+}
+
+.drawer-conditions__contenu {
+  padding: 1.5rem;
+  overflow-y: auto;
+  flex: 1 1 auto;
+}
+
+/* Badges des dates de périodes ASC réinjectées : orange, façon calendrier, avec
+   icône 📅. Rappellent quand ces conditions s'appliquent. Placés en tête du
+   contenu (avant les blocs riches PC). */
+.drawer-conditions__date-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  margin: 0 0.5rem 0.5rem 0;
+  padding: 0.3rem 0.7rem;
+  border-radius: 4px;
+  background: var(--cal-orange-fill, #fddede);
+  border: 1px solid var(--cal-orange-ink, #fa7a35);
+  color: var(--text-default-grey, #161616);
+  font-size: 0.9rem;
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+.drawer-conditions__date-icon {
+  font-size: 0.95rem;
+}
+
+/* Mobile : plein écran, slide identique. */
+@media (width < 768px) {
+  .drawer-conditions__panel {
+    width: 100%;
+    max-width: none;
+  }
+}
+
+[data-fr-theme="dark"] .drawer-conditions__panel {
+  background: var(--background-default-grey, #1e1e1e);
+}
+
+[data-fr-theme="dark"] .drawer-conditions__date-badge {
+  background: rgb(250 122 53 / 18%);
+}

--- a/envergo/static/nitrates/simulateur.css
+++ b/envergo/static/nitrates/simulateur.css
@@ -293,24 +293,16 @@
    .map-container au-dela de cette colonne, symetriquement, via des marges
    negatives calculees. On plafonne l'elargissement pour conserver des buffers
    lateraux (le panorama ne colle jamais aux bords de l'ecran). */
+
+/* #271 : la carte (#section-localisation) est désormais TOUJOURS pleine largeur,
+   sortie de la .results-row et placée au-dessus du split. Plus besoin du hack de
+   marges négatives « panorama » (l'ancienne carte vivait dans une colonne
+   étroite). On lui donne juste une hauteur confortable, identique en saisie et
+   en résultat. */
 @media (width >= 992px) {
-  .results-row:not(.layout--split) .map-container {
-    /* Deborde de part et d'autre de la colonne form (58.33%) pour viser une
-       largeur ~ 90% du container, centree. Le facteur (90/58.33 - 1)/2 ~ 0.272
-       de la largeur de la colonne, applique en marge negative de chaque cote. */
-    width: auto;
-    margin-left: calc(-27% + 0px);
-    margin-right: calc(-27% + 0px);
+  .nitrates-map {
+    height: 460px;
   }
-
-  .results-row:not(.layout--split) .nitrates-map {
-    height: 460px; /* un peu plus haut en panorama */
-  }
-}
-
-/* Mode resultat : carte petite (largeur = colonne etroite, hauteur reduite). */
-.results-row.layout--split .nitrates-map {
-  height: 300px;
 }
 
 /* Filet de securite global : on garantit qu'aucun overflow horizontal
@@ -485,11 +477,20 @@ body {
     max-width 0.55s ease;
 }
 
-/* Mode solo : le form prend ~58% (~fr-col-lg-7) et reste centre. */
+/* #271 : mode saisie (non-split). La carte étant désormais pleine largeur
+   au-dessus, la colonne des questions n'a plus besoin d'être limitée à ~58 % et
+   centrée (ça créait un décalage à gauche). On la garde pleine largeur mais on
+   borne la longueur de ligne pour le confort de lecture, alignée à gauche sous
+   la carte. */
 @media (width >= 992px) {
   .results-row:not(.layout--split) .form-col {
-    flex-basis: 58.3333%;
-    max-width: 58.3333%;
+    flex-basis: 100%;
+    max-width: 100%;
+  }
+
+  .results-row:not(.layout--split) .form-col .form-section,
+  .results-row:not(.layout--split) .form-col #form-after-localisation {
+    max-width: 760px;
   }
 }
 

--- a/envergo/static/nitrates/simulateur.css
+++ b/envergo/static/nitrates/simulateur.css
@@ -533,6 +533,13 @@ body {
   justify-content: center;
 }
 
+/* #271 : sur la page résultat, aérer entre la zone carte/localisation (au-dessus)
+   et le split (encart récap + résultat). Sans ça, le split est collé au panneau
+   Commune/Département/Région, ce qui fait serré. */
+.results-row.layout--split {
+  margin-top: 2rem;
+}
+
 .results-row .form-col {
   transition:
     flex-basis 0.55s ease,

--- a/envergo/static/nitrates/simulateur.css
+++ b/envergo/static/nitrates/simulateur.css
@@ -381,10 +381,14 @@ body {
   line-height: 1.3;
 }
 
-/* Questions complémentaires répondues : légère séparation du bloc principal. */
-.recap-choix__qc {
+/* Mention « + N questions complémentaires » : discrète, séparée du bloc
+   principal par un filet. On ne détaille pas les QC (cliquer Modifier pour). */
+.recap-choix__qc-note {
   padding-top: 16px;
   border-top: 1px solid rgb(106 106 244 / 35%);
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-title-grey, #161616);
 }
 
 .recap-choix__modifier {

--- a/envergo/static/nitrates/simulateur.css
+++ b/envergo/static/nitrates/simulateur.css
@@ -1091,7 +1091,9 @@ ul.periodes-liste {
    ~ min-height 1.25rem + padding 0.4rem*2 ~ 2.05rem. La transition sur `top`
    accompagne l'apparition/disparition du bandeau. */
 html.nitrates-construction-visible .nitrates-progress {
-  top: 2.05rem;
+  /* Se cale sous la hauteur RÉELLE du bandeau (varie selon le nombre de lignes,
+     surtout mobile). Fallback 2.05rem si la var n'est pas encore posée. #271 */
+  top: var(--nitrates-construction-h, 2.05rem);
 }
 
 .nitrates-progress.is-visible {
@@ -1226,9 +1228,14 @@ body.drawer-open {
 /* Panneau : ancré à droite, 2/3 de large, translaté hors écran par défaut. */
 .drawer-conditions__panel {
   position: absolute;
+
+  /* top/bottom (pas height:100%) : quand on décale le `top` en JS pour passer
+     sous le bandeau construction, la hauteur s'ajuste automatiquement grâce à
+     bottom:0 -> le contenu ne déborde plus sous le viewport et reste scrollable
+     jusqu'en bas (bug mobile #271). */
   top: 0;
+  bottom: 0;
   right: 0;
-  height: 100%;
   width: 66.6667%;
   max-width: 900px;
   background: var(--background-default-grey, #fff);

--- a/envergo/static/nitrates/simulateur.css
+++ b/envergo/static/nitrates/simulateur.css
@@ -1155,16 +1155,25 @@ html.nitrates-construction-visible .nitrates-progress {
    Panneau latéral qui slide depuis la droite. 2/3 de large sur desktop, plein
    écran sur mobile. Ouvert/fermé par drawer_conditions.js (classe --ouvert). */
 
-/* Lien déclencheur (#271) : intégré dans la section « autorisation sous
-   condition », avec icône warning. Pas un gros bouton bleu (tache, illisible)
-   mais un lien clair qui rattache l'action à CETTE / CES période(s). */
-.periodes-lien-conditions {
-  margin: 0.5rem 0 0;
+/* Lien déclencheur (#271) : intégré dans la liste des périodes « autorisation
+   sous condition », aligné SOUS la puce (même indentation que le texte). Pas un
+   gros bouton bleu (tache, illisible) mais un lien clair qui rattache l'action à
+   CETTE / CES période(s). L'item n'a pas de marqueur de liste. */
+li.periodes-lien-conditions {
+  list-style: none;
+  margin-top: 0.35rem;
+}
+
+/* Le lien est un <p> (cas calculatrice hors liste) : léger retrait pour
+   s'aligner visuellement sous les puces. */
+p.periodes-lien-conditions {
+  margin: 0.35rem 0 0;
+  padding-left: 1.25rem;
 }
 
 .periodes-lien-conditions__link {
   display: inline-flex;
-  align-items: center;
+  align-items: baseline;
   gap: 0.4rem;
   font-weight: 600;
 }
@@ -1224,11 +1233,13 @@ body.drawer-open {
   transform: translateX(0);
 }
 
-/* En-tête du drawer : plus de titre, juste le bouton Fermer aligné à droite. */
+/* En-tête du drawer : « Période(s) d'application : » à gauche, Fermer à droite,
+   sur UNE seule ligne (gain de hauteur). */
 .drawer-conditions__header {
   display: flex;
   align-items: center;
-  justify-content: flex-end;
+  justify-content: space-between;
+  gap: 1rem;
   padding: 1rem 1.5rem 0.5rem;
   flex: 0 0 auto;
 }
@@ -1244,10 +1255,10 @@ body.drawer-open {
   margin-bottom: 1.25rem;
 }
 
+/* Libellé « Période(s) d'application : » (désormais dans l'en-tête, à gauche du
+   bouton Fermer). */
 .drawer-conditions__application-label {
-  display: block;
   font-weight: 700;
-  margin-bottom: 0.5rem;
   color: var(--text-title-grey, #161616);
 }
 
@@ -1262,7 +1273,11 @@ body.drawer-open {
   margin: 0 0.5rem 0.5rem 0;
   padding: 0.3rem 0.7rem;
   border-radius: 4px;
-  background: #fdead9;
+
+  /* Même orange que la zone « autorisé sous condition » du calendrier : on part
+     de --cal-orange-ink (#fa7a35) à faible opacité pour le fond, comme les
+     hachures, avec le contour plein de la même teinte. */
+  background: rgb(250 122 53 / 18%);
   border: 1px solid var(--cal-orange-ink, #fa7a35);
   color: var(--text-default-grey, #161616);
   font-size: 0.9rem;

--- a/envergo/static/nitrates/simulateur.css
+++ b/envergo/static/nitrates/simulateur.css
@@ -337,6 +337,58 @@ body {
   margin: 0;
 }
 
+/* ─── #271 : encart récap des choix (colonne gauche, page résultat) ──────
+   Rappel compact et mauve des réponses de l'utilisateur, façon .qc-box, avec
+   un bouton « Modifier » pour revenir au formulaire. */
+.recap-choix {
+  background: #cecefc;
+  padding: 20px;
+  border-radius: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+/* display:flex ne doit pas court-circuiter l'attribut hidden (bouton Modifier). */
+.recap-choix[hidden] {
+  display: none !important;
+}
+
+.recap-choix__liste {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.recap-choix__item {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.recap-choix__label {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  color: var(--text-mention-grey, #666);
+  font-weight: 600;
+}
+
+.recap-choix__valeur {
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: var(--text-title-grey, #161616);
+  line-height: 1.3;
+}
+
+.recap-choix__modifier {
+  align-self: flex-start;
+}
+
+[data-fr-theme="dark"] .recap-choix {
+  background: rgb(133 133 246 / 20%);
+}
+
 /* ─── Recap QC repondues (sous le form principal, colonne gauche) ─── */
 
 .qc-recap__list {

--- a/envergo/static/nitrates/simulator.js
+++ b/envergo/static/nitrates/simulator.js
@@ -45,6 +45,116 @@
     document.dispatchEvent(new CustomEvent("nitrates:form-revealed"));
   }
 
+  // #271 : re-clic carte sur une page résultat. On ne réévalue le backend que si
+  // le SCOPE d'interprétation change ; sinon on garde le résultat affiché.
+  //
+  // Champs de scope comparés (ceux qui pilotent l'arbre / la région / les zones) :
+  //   en_zone_vulnerable, en_zar, region_code, zone_grand_est_1/2, et le code
+  //   INSEE (dont dépendent la zone montagne D113-14 et la note 5).
+  function scopeDepuisData(data, codeInsee) {
+    return {
+      zv: !!data.en_zone_vulnerable,
+      zar: !!data.en_zar,
+      region: data.region_code || "",
+      zge1: !!data.zone_grand_est_1,
+      zge2: !!data.zone_grand_est_2,
+      insee: codeInsee || "",
+    };
+  }
+
+  function scopeDepuisCatalog(cat, ancienInsee) {
+    if (!cat) return null;
+    return {
+      zv: !!cat.en_zone_vulnerable,
+      zar: !!cat.en_zar,
+      region: cat.region_code || "",
+      zge1: !!cat.zone_grand_est_1,
+      zge2: !!cat.zone_grand_est_2,
+      // Le catalog ne porte pas le code INSEE : on passe l'ancien code capturé
+      // AVANT écrasement du hidden (celui de la simulation en cours).
+      insee: ancienInsee || "",
+    };
+  }
+
+  function scopesDifferents(a, b) {
+    if (!a || !b) return true;
+    if (
+      a.zv !== b.zv ||
+      a.zar !== b.zar ||
+      a.region !== b.region ||
+      a.zge1 !== b.zge1 ||
+      a.zge2 !== b.zge2
+    ) {
+      return true;
+    }
+    // Code INSEE : ne le compare QUE si l'ancien est connu (une simulation
+    // lancée par clic carte l'a renseigné). Si l'ancien est vide (résultat
+    // rejoué depuis une URL sans code_insee), on ne déclenche pas une
+    // invalidation sur la seule commune -> les zones (ci-dessus) suffisent.
+    if (a.insee && a.insee !== b.insee) return true;
+    return false;
+  }
+
+  // Scope de RÉFÉRENCE de la simulation actuellement affichée. On l'établit à
+  // partir de la MÊME source que le re-clic (DebugView), pour comparer des
+  // valeurs cohérentes (le catalog moulinette peut diverger de DebugView sur
+  // certains champs, ex zone_grand_est_2 sans code_insee). Renseigné au 1er
+  // re-clic si absent (le scope de référence = celui du point qui a produit le
+  // résultat, dont les coordonnées sont dans les hidden lat/lng).
+  let scopeReference = null;
+
+  function gererReclicCarteResultat(data, nouveauInsee, ancienInsee) {
+    const form = document.getElementById("form-simulateur");
+    // Rien à faire si on n'est pas sur une page résultat affiché.
+    if (!form || !form.hasAttribute("data-resultat-affiche")) return;
+
+    const nouveau = scopeDepuisData(data, nouveauInsee);
+
+    // Établit la référence si pas encore connue : on interroge DebugView sur le
+    // point d'ORIGINE (lat/lng du résultat affiché, avant ce re-clic). Comme
+    // c'est asynchrone et qu'on veut une décision immédiate, on retombe sur le
+    // catalog moulinette pour cette première comparaison, puis on mémorise la
+    // référence DebugView pour les fois suivantes.
+    const ref =
+      scopeReference || scopeDepuisCatalog(window.NITRATES_CATALOG, ancienInsee);
+
+    if (!scopesDifferents(ref, nouveau)) {
+      // Même scope géographique : le résultat reste valide. On mémorise le
+      // nouveau scope comme référence (DebugView, cohérent) pour la suite.
+      scopeReference = nouveau;
+      return;
+    }
+
+    // Scope changé -> le résultat n'est plus valide. On l'invalide et on repasse
+    // en mode saisie, en forçant un re-clic « Lancer la simulation ».
+    form.removeAttribute("data-resultat-affiche");
+    const resultCol = document.querySelector(".result-col");
+    if (resultCol) resultCol.remove();
+    const row = document.querySelector(".results-row");
+    if (row) row.classList.remove("layout--split");
+    const formCol = document.querySelector(".form-col");
+    if (formCol) formCol.classList.remove("fr-col-lg-3");
+    // Masque l'encart récap, ré-affiche le formulaire complet.
+    const recap = document.getElementById("recap-choix");
+    if (recap) recap.hidden = true;
+    const formApres = document.getElementById("form-after-localisation");
+    if (formApres) formApres.hidden = false;
+    // Ré-affiche le bouton « Lancer la simulation » (masqué sur page résultat).
+    const submitRow = document.getElementById("form-submit-row");
+    if (submitRow) submitRow.hidden = false;
+    // Notifie les autres modules (recap_choix / reset_form / flow) du retour saisie.
+    document.dispatchEvent(new Event("nitrates:retour-saisie"));
+    // Le scope courant est désormais celui du nouveau point : on met à jour le
+    // catalog en mémoire pour les comparaisons suivantes (avant re-soumission).
+    window.NITRATES_CATALOG = Object.assign({}, window.NITRATES_CATALOG || {}, {
+      en_zone_vulnerable: nouveau.zv,
+      en_zar: nouveau.zar,
+      region_code: nouveau.region,
+      zone_grand_est_1: nouveau.zge1,
+      zone_grand_est_2: nouveau.zge2,
+    });
+  }
+
   // ─── Carte #57 : bornage geographique ────────────────────────────────
   // Quand la parcelle cliquee est dans un departement non ouvert, on masque
   // le formulaire et on affiche un message dedie (#form-region-fermee).
@@ -521,7 +631,16 @@
         // le form et utilise cote backend pour resoudre la zone
         // montagne (D113-14) sans charger les polygones communes.
         const codeInseeInput = document.getElementById("id_code_insee");
+        // #271 : on capture l'ANCIEN code INSEE (celui de la simulation en cours)
+        // AVANT de l'écraser, pour comparer les scopes.
+        const ancienInsee = codeInseeInput ? codeInseeInput.value || "" : "";
         if (codeInseeInput) codeInseeInput.value = communeInfo.code || "";
+        // #271 : gestion du re-clic carte quand un RÉSULTAT est déjà affiché.
+        // Si le nouveau point change le SCOPE d'interprétation (zones : ZV, ZAR,
+        // région, Grand Est 1/2, commune -> montagne/note5), le résultat n'est
+        // plus valide -> on l'invalide et on force un re-clic « Lancer ». Si le
+        // scope est identique, on garde l'affichage (rien à réévaluer).
+        gererReclicCarteResultat(data, communeInfo.code || "", ancienInsee);
         terminerChargementLoc();
       })
       .catch((err) => {
@@ -744,4 +863,27 @@
       }
     });
   }
+
+  // #271 : au chargement d'une PAGE RÉSULTAT, on établit le scope de RÉFÉRENCE
+  // en interrogeant DebugView pour le point du résultat (lat/lng des hidden).
+  // Ainsi la 1re comparaison au re-clic se fait DebugView vs DebugView (valeurs
+  // cohérentes), sans dépendre du catalog moulinette qui peut diverger.
+  (function initScopeReference() {
+    const form = document.getElementById("form-simulateur");
+    if (!form || !form.hasAttribute("data-resultat-affiche")) return;
+    const lat = (latInput.value || "").trim();
+    const lng = (lngInput.value || "").trim();
+    if (!lat || !lng) return;
+    const insee = (document.getElementById("id_code_insee") || {}).value || "";
+    const url =
+      `${window.NITRATES_DEBUG_URL}?lng=${lng}&lat=${lat}` +
+      (insee ? `&code_insee=${encodeURIComponent(insee)}` : "") +
+      (window.NITRATES_GEO_APPLIQUEE ? "&geo=1" : "");
+    fetch(url, { headers: { Accept: "application/json" } })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (data) scopeReference = scopeDepuisData(data, insee);
+      })
+      .catch(() => {});
+  })();
 })();

--- a/envergo/templates/nitrates/fragments/_drawer_conditions.html
+++ b/envergo/templates/nitrates/fragments/_drawer_conditions.html
@@ -21,17 +21,12 @@ périodes d'autorisation sous condition (fond orange, cohérent avec le calendri
   résolus côté client -> conteneur rempli par calculatrice-calendrier.js. Le
   titre singulier/pluriel est ajusté par le JS selon le nombre de badges.
 {% endcomment %}
-{% nb_periodes_sous_condition ev.regle as nb_asc %}
+{% comment %}
+Le libellé « Période(s) d'application : » est rendu dans l'en-tête du drawer
+(même ligne que Fermer, cf. _panneau_resultat.html). Ici, juste les badges de
+dates (fond orange, cohérent calendrier), en tête du contenu.
+{% endcomment %}
 <div class="drawer-conditions__application" data-drawer-application>
-  <span class="drawer-conditions__application-label"
-        data-drawer-application-label>
-    {% if nb_asc > 1 %}
-      Périodes d'application
-    {% else %}
-      Période d'application
-    {% endif %}
-    :
-  </span>
   {% if ev.regle.type == "calculatrice" %}
     <span class="drawer-conditions__badges" data-drawer-badges-asc></span>
   {% else %}

--- a/envergo/templates/nitrates/fragments/_drawer_conditions.html
+++ b/envergo/templates/nitrates/fragments/_drawer_conditions.html
@@ -14,30 +14,42 @@ s'appliquent, en écho au calendrier. Rendu seulement s'il y a des blocs PC.
 {% endcomment %}
 
 {% comment %}
-Dates des périodes d'autorisation sous condition (badges orange).
-- Règle NON calculatrice : les bornes sont des dates fixes -> rendues côté
-  serveur ici via periodes_par_section.
-- Règle calculatrice (couvert) : les bornes sont des events (semis/destruction
-  ± offset) résolus côté client par le calendrier dynamique -> on laisse un
-  conteneur que calculatrice-calendrier.js remplit avec les dates résolues.
+En-tête du drawer (#271) : « Période(s) d'application : » + badges des dates des
+périodes d'autorisation sous condition (fond orange, cohérent avec le calendrier).
+- Règle NON calculatrice : bornes = dates fixes -> rendues côté serveur ici.
+- Règle calculatrice (couvert) : bornes = events (semis/destruction ± offset)
+  résolus côté client -> conteneur rempli par calculatrice-calendrier.js. Le
+  titre singulier/pluriel est ajusté par le JS selon le nombre de badges.
 {% endcomment %}
-{% if ev.regle.type == "calculatrice" %}
-  <div class="drawer-conditions__badges" data-drawer-badges-asc></div>
-{% else %}
-  {% periodes_par_section ev.regle as sections_periodes %}
-  <div class="drawer-conditions__badges">
-    {% for section in sections_periodes %}
-      {% if section.titre == "Période d’autorisation sous condition" %}
-        {% for puce in section.periodes %}
-          <span class="drawer-conditions__date-badge">
-            <span class="drawer-conditions__date-icon" aria-hidden="true">📅</span>
-            {{ puce.phrase }}
-          </span>
-        {% endfor %}
-      {% endif %}
-    {% endfor %}
-  </div>
-{% endif %}
+{% nb_periodes_sous_condition ev.regle as nb_asc %}
+<div class="drawer-conditions__application" data-drawer-application>
+  <span class="drawer-conditions__application-label"
+        data-drawer-application-label>
+    {% if nb_asc > 1 %}
+      Périodes d'application
+    {% else %}
+      Période d'application
+    {% endif %}
+    :
+  </span>
+  {% if ev.regle.type == "calculatrice" %}
+    <span class="drawer-conditions__badges" data-drawer-badges-asc></span>
+  {% else %}
+    {% periodes_par_section ev.regle as sections_periodes %}
+    <span class="drawer-conditions__badges">
+      {% for section in sections_periodes %}
+        {% if section.titre == "Période d’autorisation sous condition" %}
+          {% for puce in section.periodes %}
+            <span class="drawer-conditions__date-badge">
+              <span class="drawer-conditions__date-icon" aria-hidden="true">📅</span>
+              {{ puce.phrase }}
+            </span>
+          {% endfor %}
+        {% endif %}
+      {% endfor %}
+    </span>
+  {% endif %}
+</div>
 
 {% comment %}
 Prescription(s) conditionnée(s) : contenu riche PC (#136). Même logique que

--- a/envergo/templates/nitrates/fragments/_drawer_conditions.html
+++ b/envergo/templates/nitrates/fragments/_drawer_conditions.html
@@ -1,0 +1,83 @@
+{% load nitrates_tags %}
+
+{% comment %}
+#271 chantier 3 — Drawer « Conditions d'épandage ».
+
+Panneau latéral (slide depuis la droite, 2/3 sur desktop, plein écran mobile)
+qui porte les prescriptions conditionnées (blocs riches PC) + la note. Ouvert
+par le bouton « Voir les conditions d'épandage pour cette/ces période(s) »
+placé près des zones orange du calendrier (cf. _panneau_resultat.html).
+
+En tête du contenu, on RÉINJECTE les dates des périodes d'autorisation sous
+condition (badges orange, icône 📅) : elles rappellent quand ces conditions
+s'appliquent, en écho au calendrier. Rendu seulement s'il y a des blocs PC.
+{% endcomment %}
+
+{% comment %}
+Dates des périodes d'autorisation sous condition (badges orange).
+- Règle NON calculatrice : les bornes sont des dates fixes -> rendues côté
+  serveur ici via periodes_par_section.
+- Règle calculatrice (couvert) : les bornes sont des events (semis/destruction
+  ± offset) résolus côté client par le calendrier dynamique -> on laisse un
+  conteneur que calculatrice-calendrier.js remplit avec les dates résolues.
+{% endcomment %}
+{% if ev.regle.type == "calculatrice" %}
+  <div class="drawer-conditions__badges" data-drawer-badges-asc></div>
+{% else %}
+  {% periodes_par_section ev.regle as sections_periodes %}
+  <div class="drawer-conditions__badges">
+    {% for section in sections_periodes %}
+      {% if section.titre == "Période d’autorisation sous condition" %}
+        {% for puce in section.periodes %}
+          <span class="drawer-conditions__date-badge">
+            <span class="drawer-conditions__date-icon" aria-hidden="true">📅</span>
+            {{ puce.phrase }}
+          </span>
+        {% endfor %}
+      {% endif %}
+    {% endfor %}
+  </div>
+{% endif %}
+
+{% comment %}
+Prescription(s) conditionnée(s) : contenu riche PC (#136). Même logique que
+l'ancien rendu inline du panneau résultat, désormais dans le drawer.
+{% endcomment %}
+{% if ev.regle.codes_prescription %}
+  {% for cp in ev.regle.codes_prescription %}
+    {% with pc=codes_prescription|get_item:cp %}
+      {% if pc.blocs %}
+        <div class="fr-accordions-group fr-mt-3w">{% compile_blocs pc.blocs id_prefix=cp %}</div>
+      {% elif pc and not ev.regle.message %}
+        <h4 class="fr-h6 fr-mt-3w">{{ pc.mots_cles|default:cp }}</h4>
+        {% if pc.texte_court %}
+          <p>
+            {{ pc.texte_court|linebreaksbr }}
+            {% if pc.texte_redaction_initiale %}
+              <a href="#accordion-texte-init-{{ cp }}"
+                 class="fr-link fr-link--sm nitrates-voir-plus"
+                 data-target="accordion-texte-init-{{ cp }}">voir plus</a>
+            {% endif %}
+          </p>
+        {% endif %}
+      {% elif not pc and not ev.regle.message %}
+        <p class="fr-text--sm">
+          <strong>Code prescription :</strong> {{ cp }}
+        </p>
+      {% endif %}
+    {% endwith %}
+  {% endfor %}
+{% endif %}
+
+{% if ev.regle.note %}
+  {% with note=notes_referentiel|get_item:ev.regle.note %}
+    {% if note %}
+      <h4 class="fr-h6 fr-mt-2w">{{ note.libelle_court|default:ev.regle.note }}</h4>
+      {% if note.condition_declenchement %}<p>{{ note.condition_declenchement|linebreaksbr }}</p>{% endif %}
+    {% else %}
+      <p class="fr-text--sm">
+        <strong>Note :</strong> {{ ev.regle.note }}
+      </p>
+    {% endif %}
+  {% endwith %}
+{% endif %}

--- a/envergo/templates/nitrates/fragments/_panneau_form.html
+++ b/envergo/templates/nitrates/fragments/_panneau_form.html
@@ -164,8 +164,27 @@ questions/résultat. djLint (H025) croit à tort le <form> orphelin à cause des
         <p class="form-region-fermee__texte">Revenez bientôt&nbsp;: votre secteur sera prochainement pris en charge.</p>
       </section>
 
+      {% comment %}
+    #271 chantier 2 — encart récap : sur la page résultat, la colonne gauche
+    n'affiche plus le formulaire complet mais un encart violet compact qui
+    rappelle les choix (rempli côté JS par recap_choix.js depuis l'état du form),
+    avec un bouton « Modifier » qui ré-affiche le formulaire et masque le
+    résultat (via reset_form.js #135). Rendu seulement en page résultat.
+      {% endcomment %}
+      {% if afficher_resultat and not qc_en_attente %}
+        <aside id="recap-choix"
+               class="recap-choix"
+               aria-label="Récapitulatif de vos choix">
+          <div class="recap-choix__liste" data-recap-liste></div>
+          <button type="button"
+                  class="fr-btn fr-btn--secondary fr-btn--sm recap-choix__modifier"
+                  data-recap-modifier>Modifier</button>
+        </aside>
+      {% endif %}
+
       <div id="form-after-localisation"
-           {% if not data.lat or not data.lng %}hidden{% endif %}>
+           {% if not data.lat or not data.lng %}hidden{% endif %}
+           {% if afficher_resultat and not qc_en_attente %}data-recap-actif="1"{% endif %}>
 
         {% comment %}
     ─── Culture ou couvert (#272) ─────────────────────────────────────────

--- a/envergo/templates/nitrates/fragments/_panneau_form.html
+++ b/envergo/templates/nitrates/fragments/_panneau_form.html
@@ -17,6 +17,13 @@ login au clic sur "Lancer la simulation". MoulinetteView sert les deux chemins
 (`/` via HomeView et `/simulateur/`), donc resoumettre sur place fonctionne
 dans les deux cas.
 {% endcomment %}
+{# djlint:off H025 #}
+{% comment %}
+#271 : le <form> enveloppe la carte (pleine largeur) PUIS la grille
+questions/résultat. djLint (H025) croit à tort le <form> orphelin à cause des
+{% if %} imbriqués entre l'ouverture et la fermeture ; le tag est bien apparié
+(cf. </form> en fin de fichier). On désactive donc H025 sur ce fichier.
+{% endcomment %}
 <form id="form-simulateur"
       method="get"
       action="{{ request.path }}"
@@ -109,47 +116,58 @@ dans les deux cas.
            id="id_code_insee"
            value="{{ data.code_insee|default:'' }}">
   </div>
+  {# /#section-localisation : carte pleine largeur, au-dessus du split (#271) #}
 
   {% comment %}
+  #271 : sous la carte, le reste du parcours (questions à gauche, résultat à
+  droite) vit dans une grille. En mode saisie : colonne unique pleine largeur.
+  En mode résultat (afficher_resultat, pas de QC en attente) : split
+  encart-recap 1/4 (fr-col-lg-3) + résultat 3/4 (fr-col-lg-9).
+  {% endcomment %}
+  <div class="fr-grid-row fr-grid-row--gutters results-row{% if afficher_resultat and not qc_en_attente %} layout--split{% endif %}"
+       style="align-items: flex-start">
+
+    <div class="fr-col-12 {% if afficher_resultat and not qc_en_attente %}fr-col-lg-3{% endif %} form-col">
+
+      {% comment %}
   Issues #89 + #96 : tant que l'utilisateur n'a pas clique sur la carte,
   on cache les sections Culture / Fertilisant / Submit et on affiche un
   message d'invite. Decache au clic carte (cf. simulator.js).
   L'attribut hidden initial est applique cote serveur en fonction de
   data.lat / data.lng (utile sur rechargement avec params dans l'URL).
-  {% endcomment %}
-  {% if data.lat and data.lng %}
-    {% with form_locked=False %}
-    {% endwith %}
-  {% else %}
-    <div id="form-locked-message" class="form-locked-message" role="status">
-      <p>
-        <strong>Cliquez sur la carte</strong> pour saisir votre localisation.
-        Le formulaire de simulation s'affichera dès que votre parcelle sera renseignée.
-      </p>
-    </div>
-  {% endif %}
+      {% endcomment %}
+      {% if data.lat and data.lng %}
+        {% with form_locked=False %}{% endwith %}
+      {% else %}
+        <div id="form-locked-message" class="form-locked-message" role="status">
+          <p>
+            <strong>Cliquez sur la carte</strong> pour saisir votre localisation.
+            Le formulaire de simulation s'affichera dès que votre parcelle sera renseignée.
+          </p>
+        </div>
+      {% endif %}
 
-  {% comment %}
+      {% comment %}
     Carte #57 — bornage géographique. Masqué par défaut ; révélé par
     simulator.js (afficherMessageFerme) quand la parcelle cliquée est dans
     un département où le simulateur n'est pas encore ouvert.
-  {% endcomment %}
-  <section id="form-region-fermee"
-           class="form-region-fermee"
-           role="status"
-           hidden>
-    <p class="form-region-fermee__titre">
-      <span class="form-region-fermee__cadenas" aria-hidden="true">🔒</span>
-      Le simulateur n'est pas encore ouvert dans
-      <strong id="form-region-fermee-lieu">votre secteur</strong>.
-    </p>
-    <p class="form-region-fermee__texte">Revenez bientôt&nbsp;: votre secteur sera prochainement pris en charge.</p>
-  </section>
+      {% endcomment %}
+      <section id="form-region-fermee"
+               class="form-region-fermee"
+               role="status"
+               hidden>
+        <p class="form-region-fermee__titre">
+          <span class="form-region-fermee__cadenas" aria-hidden="true">🔒</span>
+          Le simulateur n'est pas encore ouvert dans
+          <strong id="form-region-fermee-lieu">votre secteur</strong>.
+        </p>
+        <p class="form-region-fermee__texte">Revenez bientôt&nbsp;: votre secteur sera prochainement pris en charge.</p>
+      </section>
 
-  <div id="form-after-localisation"
-       {% if not data.lat or not data.lng %}hidden{% endif %}>
+      <div id="form-after-localisation"
+           {% if not data.lat or not data.lng %}hidden{% endif %}>
 
-    {% comment %}
+        {% comment %}
     ─── Culture ou couvert (#272) ─────────────────────────────────────────
     Refactor du parcours culture/couvert en questions successives (une a la
     fois). Tout est piloté FRONT par question_couvert_flow.js :
@@ -171,148 +189,148 @@ dans les deux cas.
     du couvert (Q4). Destruction ≥ 01/01 (inclus, année agricole) => couvert
     toujours en place après le 1ᵉʳ janvier (branche …_apres_0101) ; sinon plus
     en place après le 31/12 (branche …_avant_3112).
-    {% endcomment %}
-    <div class="form-section" id="section-culture" style="margin-top: 40px;">
-      <h2 class="form-section-title">Culture ou couvert</h2>
+        {% endcomment %}
+        <div class="form-section" id="section-culture" style="margin-top: 40px;">
+          <h2 class="form-section-title">Culture ou couvert</h2>
 
-      {# Q1 — destination de l'épandage (regroupement UI front, 4 réponses -> 2 familles) #}
-      <div class="form-question-group" id="q_destination_epandage-wrapper">
-        <p class="form-question-text">Vous avez prévu d'épandre&nbsp;? *</p>
-        <div id="q_destination_epandage" class="couvert-flow__group"></div>
-      </div>
+          {# Q1 — destination de l'épandage (regroupement UI front, 4 réponses -> 2 familles) #}
+          <div class="form-question-group" id="q_destination_epandage-wrapper">
+            <p class="form-question-text">Vous avez prévu d'épandre&nbsp;? *</p>
+            <div id="q_destination_epandage" class="couvert-flow__group"></div>
+          </div>
 
-      {# Q2 couvert — type d'interculture (longue / courte) #}
-      <div class="form-question-group" id="q_type_couvert-wrapper" hidden>
-        {# Texte adapté par question_couvert_flow.js selon Q1 : « Quel type de #}
-        {# couvert ? » (couvert) ou « Quelle catégorie de culture principale ? ». #}
-        <p class="form-question-text" id="q_type_couvert-label">Quel type de couvert&nbsp;? *</p>
-        <div id="q_type_couvert" class="couvert-flow__group"></div>
-      </div>
+          {# Q2 couvert — type d'interculture (longue / courte) #}
+          <div class="form-question-group" id="q_type_couvert-wrapper" hidden>
+            {# Texte adapté par question_couvert_flow.js selon Q1 : « Quel type de #}
+            {# couvert ? » (couvert) ou « Quelle catégorie de culture principale ? ». #}
+            <p class="form-question-text" id="q_type_couvert-label">Quel type de couvert&nbsp;? *</p>
+            <div id="q_type_couvert" class="couvert-flow__group"></div>
+          </div>
 
-      {# Q3 couvert — récolté / non récolté #}
-      <div class="form-question-group" id="q_couvert_recolte-wrapper" hidden>
-        <p class="form-question-text">Le couvert est-il récolté, fauché ou pâturé&nbsp;? *</p>
-        <div id="q_couvert_recolte" class="couvert-flow__group"></div>
-      </div>
+          {# Q3 couvert — récolté / non récolté #}
+          <div class="form-question-group" id="q_couvert_recolte-wrapper" hidden>
+            <p class="form-question-text">Le couvert est-il récolté, fauché ou pâturé&nbsp;? *</p>
+            <div id="q_couvert_recolte" class="couvert-flow__group"></div>
+          </div>
 
-      {# Q3 culture principale — précision du type de culture (sous_culture) #}
-      <div class="form-question-group" id="q_sous_culture-wrapper" hidden>
-        <p class="form-question-text">Précisez le type de culture&nbsp;: *</p>
-        <div id="q_sous_culture" class="couvert-flow__group"></div>
-      </div>
+          {# Q3 culture principale — précision du type de culture (sous_culture) #}
+          <div class="form-question-group" id="q_sous_culture-wrapper" hidden>
+            <p class="form-question-text">Précisez le type de culture&nbsp;: *</p>
+            <div id="q_sous_culture" class="couvert-flow__group"></div>
+          </div>
 
-      {# Q4 couvert — dates de semis et destruction (picker JJ/MM DSFR, cf. #272) #}
-      <div class="form-question-group" id="q_dates_couvert-wrapper" hidden>
-        <p class="form-question-text">Quelles sont les dates prévues pour ce couvert&nbsp;? *</p>
-        <div id="q_dates_couvert" class="couvert-flow__dates"></div>
-      </div>
+          {# Q4 couvert — dates de semis et destruction (picker JJ/MM DSFR, cf. #272) #}
+          <div class="form-question-group" id="q_dates_couvert-wrapper" hidden>
+            <p class="form-question-text">Quelles sont les dates prévues pour ce couvert&nbsp;? *</p>
+            <div id="q_dates_couvert" class="couvert-flow__dates"></div>
+          </div>
 
-      {% comment %}
+          {% comment %}
       Vrais champs cascade (source de vérité backend). Rendus par cascade.js ;
       masqués (hidden) car pilotés par le flow ci-dessus. On garde le wrapper
       #sous_culture_form-wrapper (id attendu par cascade.js) mais toujours caché.
-      {% endcomment %}
-      <div class="couvert-flow__origin-hidden" aria-hidden="true">
-        <div class="form-question-group" id="categorie_culture-wrapper">
-          <div data-cascade="categorie_culture"></div>
+          {% endcomment %}
+          <div class="couvert-flow__origin-hidden" aria-hidden="true">
+            <div class="form-question-group" id="categorie_culture-wrapper">
+              <div data-cascade="categorie_culture"></div>
+            </div>
+            <div class="form-question-group" id="sous_culture_form-wrapper" hidden>
+              <div data-cascade="sous_culture_form"></div>
+            </div>
+          </div>
         </div>
-        <div class="form-question-group" id="sous_culture_form-wrapper" hidden>
-          <div data-cascade="sous_culture_form"></div>
-        </div>
-      </div>
-    </div>
 
-    {# Hidden inputs des dates couvert (Q4) : remplis par le flow, consommés #}
-    {# par le backend (bornes calendrier date_semis/destruction_couvert). #}
-    <input type="hidden"
-           name="date_semis_couvert"
-           id="id_date_semis_couvert"
-           value="{{ data.date_semis_couvert|default:'' }}">
-    <input type="hidden"
-           name="date_destruction_couvert"
-           id="id_date_destruction_couvert"
-           value="{{ data.date_destruction_couvert|default:'' }}">
+        {# Hidden inputs des dates couvert (Q4) : remplis par le flow, consommés #}
+        {# par le backend (bornes calendrier date_semis/destruction_couvert). #}
+        <input type="hidden"
+               name="date_semis_couvert"
+               id="id_date_semis_couvert"
+               value="{{ data.date_semis_couvert|default:'' }}">
+        <input type="hidden"
+               name="date_destruction_couvert"
+               id="id_date_destruction_couvert"
+               value="{{ data.date_destruction_couvert|default:'' }}">
 
-    {% comment %}
+        {% comment %}
   Hidden inputs : occupation_sol + sous_culture sont resolus cote front
   via mapping_sous_culture_vers_branche, et envoyes au backend pour
   piloter le parcours d'arbre. Les `flags` (ex culture_irriguee_type
   pour mais, prairie_permanente pour PC16) sont aussi injectes en hidden
   au moment du submit.
-    {% endcomment %}
-    <input type="hidden"
-           name="occupation_sol"
-           id="id_occupation_sol"
-           value="{{ data.occupation_sol|default:'' }}">
-    <input type="hidden"
-           name="sous_culture"
-           id="id_sous_culture"
-           value="{{ data.sous_culture|default:'' }}">
-    <input type="hidden"
-           name="culture_irriguee_type"
-           id="id_culture_irriguee_type"
-           value="{{ data.culture_irriguee_type|default:'' }}">
-    <input type="hidden"
-           name="prairie_permanente"
-           id="id_prairie_permanente"
-           value="{{ data.prairie_permanente|default:'' }}">
+        {% endcomment %}
+        <input type="hidden"
+               name="occupation_sol"
+               id="id_occupation_sol"
+               value="{{ data.occupation_sol|default:'' }}">
+        <input type="hidden"
+               name="sous_culture"
+               id="id_sous_culture"
+               value="{{ data.sous_culture|default:'' }}">
+        <input type="hidden"
+               name="culture_irriguee_type"
+               id="id_culture_irriguee_type"
+               value="{{ data.culture_irriguee_type|default:'' }}">
+        <input type="hidden"
+               name="prairie_permanente"
+               id="id_prairie_permanente"
+               value="{{ data.prairie_permanente|default:'' }}">
 
-    {% comment %}
+        {% comment %}
     Section Fertilisant : cachee tant qu'aucune de ses questions n'est visible
     (la cascade Culture n'est pas encore complete). Sinon un titre orphelin
     « Fertilisant » s'affiche seul au-dessus du bouton (#160). cascade.js
     revele/cache #section-fertilisant en meme temps que categorie_fertilisant.
-    {% endcomment %}
-    <div class="form-section"
-         id="section-fertilisant"
-         style="margin-top: 40px"
-         hidden>
-      <h2 class="form-section-title">Fertilisant</h2>
+        {% endcomment %}
+        <div class="form-section"
+             id="section-fertilisant"
+             style="margin-top: 40px"
+             hidden>
+          <h2 class="form-section-title">Fertilisant</h2>
 
-      <div class="form-question-group" id="categorie_fertilisant-wrapper" hidden>
-        <p class="form-question-text">Quel fertilisant souhaitez-vous épandre ? *</p>
-        <div data-cascade="categorie_fertilisant"></div>
-      </div>
+          <div class="form-question-group" id="categorie_fertilisant-wrapper" hidden>
+            <p class="form-question-text">Quel fertilisant souhaitez-vous épandre ? *</p>
+            <div data-cascade="categorie_fertilisant"></div>
+          </div>
 
-      <div class="form-question-group" id="sous_fertilisant-wrapper" hidden>
-        <p class="form-question-text">Précisez la catégorie de fertilisant utilisé&nbsp;: *</p>
-        <div data-cascade="sous_fertilisant"></div>
-        <p class="fr-hint-text" style="margin: 0;">Le type réglementaire (type_0/Ia/Ib/II/III) est résolu automatiquement.</p>
-      </div>
+          <div class="form-question-group" id="sous_fertilisant-wrapper" hidden>
+            <p class="form-question-text">Précisez la catégorie de fertilisant utilisé&nbsp;: *</p>
+            <div data-cascade="sous_fertilisant"></div>
+            <p class="fr-hint-text" style="margin: 0;">Le type réglementaire (type_0/Ia/Ib/II/III) est résolu automatiquement.</p>
+          </div>
 
-      {# type_fertilisant resolu cote front via mapping_sous_fertilisant_vers_type #}
-      <input type="hidden"
-             name="type_fertilisant"
-             id="id_type_fertilisant"
-             value="{{ data.type_fertilisant|default:'' }}">
-      {# Flags de pre-remplissage (carte #98) : effluents peu charges issus / #}
-      {# non issus d'elevage pre-repondent ces questions complementaires de #}
-      {# l'arbre, qui sont alors inferees au lieu d'etre posees. #}
-      <input type="hidden"
-             name="effluent_peu_charge"
-             id="id_effluent_peu_charge"
-             value="{{ data.effluent_peu_charge|default:'' }}">
-      <input type="hidden"
-             name="effluent_peu_charge_elevage"
-             id="id_effluent_peu_charge_elevage"
-             value="{{ data.effluent_peu_charge_elevage|default:'' }}">
-    </div>
+          {# type_fertilisant resolu cote front via mapping_sous_fertilisant_vers_type #}
+          <input type="hidden"
+                 name="type_fertilisant"
+                 id="id_type_fertilisant"
+                 value="{{ data.type_fertilisant|default:'' }}">
+          {# Flags de pre-remplissage (carte #98) : effluents peu charges issus / #}
+          {# non issus d'elevage pre-repondent ces questions complementaires de #}
+          {# l'arbre, qui sont alors inferees au lieu d'etre posees. #}
+          <input type="hidden"
+                 name="effluent_peu_charge"
+                 id="id_effluent_peu_charge"
+                 value="{{ data.effluent_peu_charge|default:'' }}">
+          <input type="hidden"
+                 name="effluent_peu_charge_elevage"
+                 id="id_effluent_peu_charge_elevage"
+                 value="{{ data.effluent_peu_charge_elevage|default:'' }}">
+        </div>
 
-    {% comment %}
+        {% comment %}
   Questions complementaires (#112) : rendues SOUS le formulaire, dans un seul
   bloc violet (repondues editables + en attente). Tant qu'une QC est en
   attente (qc_en_attente), le panel resultat de droite est masque et on reste
   en colonne unique. Une fois tout repondu, ce bloc reste affiche en recap et
   le resultat apparait a droite.
-    {% endcomment %}
-    {% if qc_en_attente or qc_repondues %}
-      <div class="form-section questions-complementaires-box"
-           style="margin-top: 32px">{% include "nitrates/fragments/_qc_sous_form.html" %}</div>
-    {% endif %}
+        {% endcomment %}
+        {% if qc_en_attente or qc_repondues %}
+          <div class="form-section questions-complementaires-box"
+               style="margin-top: 32px">{% include "nitrates/fragments/_qc_sous_form.html" %}</div>
+        {% endif %}
 
-    {% include "nitrates/fragments/_form_hidden_passthrough.html" %}
+        {% include "nitrates/fragments/_form_hidden_passthrough.html" %}
 
-    {% comment %}
+        {% comment %}
     Bouton de soumission. 3 etats :
       - parcours en cours (pas de resultat)  -> « Lancer la simulation »
       - une QC en attente                    -> « Suivant »
@@ -320,19 +338,34 @@ dans les deux cas.
         relancer tant que l'utilisateur n'a rien change. reset_form.js (#135)
         le revele + remet « Lancer la simulation » des qu'un champ est modifie.
     Le conteneur porte un id pour que reset_form.js puisse le re-afficher.
-    {% endcomment %}
-    <div id="form-submit-row"
-         style="margin-top: 32px"
-         {% if afficher_resultat and not qc_en_attente %}hidden{% endif %}>
-      <button type="submit" class="fr-btn">
-        {% if qc_en_attente %}
-          Suivant
-        {% else %}
-          Lancer la simulation
-        {% endif %}
-      </button>
+        {% endcomment %}
+        <div id="form-submit-row"
+             style="margin-top: 32px"
+             {% if afficher_resultat and not qc_en_attente %}hidden{% endif %}>
+          <button type="submit" class="fr-btn">
+            {% if qc_en_attente %}
+              Suivant
+            {% else %}
+              Lancer la simulation
+            {% endif %}
+          </button>
+        </div>
+
+      </div>
+      {# /#form-after-localisation #}
+
     </div>
+    {# /.form-col (colonne gauche : questions en saisie / encart recap en resultat) #}
+
+    {% comment %}
+    Colonne droite (#271) : résultat final, 3/4 de large, seulement quand un
+    résultat est prêt et qu'aucune QC n'est en attente. Inclus DANS le <form>
+    pour rester dans la même grille que la colonne gauche sous la carte.
+    {% endcomment %}
+    {% if afficher_resultat and not qc_en_attente %}
+      <div class="fr-col-12 fr-col-lg-9 result-col">{% include "nitrates/fragments/_panneau_resultat.html" %}</div>
+    {% endif %}
 
   </div>
-  {# /#form-after-localisation #}
+  {# /.results-row #}
 </form>

--- a/envergo/templates/nitrates/fragments/_panneau_form.html
+++ b/envergo/templates/nitrates/fragments/_panneau_form.html
@@ -179,18 +179,13 @@ questions/résultat. djLint (H025) croit à tort le <form> orphelin à cause des
           <div class="recap-choix__liste" data-recap-liste></div>
 
           {% comment %}
-          Questions complémentaires répondues : rendues côté serveur (données
-          dynamiques peu synthétisables). On les liste telles quelles (question ->
-          réponse humaine), à la fin du récap.
+          Questions complémentaires : on NE détaille PAS (dynamique, peu
+          synthétisable). On mentionne juste leur nombre ; pour les voir/modifier,
+          l'utilisateur clique « Modifier ».
           {% endcomment %}
           {% if qc_repondues %}
-            <div class="recap-choix__liste recap-choix__qc">
-              {% for qc in qc_repondues %}
-                <div class="recap-choix__item">
-                  <span class="recap-choix__label">{{ qc.texte }}</span>
-                  <span class="recap-choix__valeur">{{ qc.libelle }}</span>
-                </div>
-              {% endfor %}
+            <div class="recap-choix__qc-note">
+              + {{ qc_repondues|length }} question{{ qc_repondues|length|pluralize }} complémentaire{{ qc_repondues|length|pluralize }}
             </div>
           {% endif %}
 

--- a/envergo/templates/nitrates/fragments/_panneau_form.html
+++ b/envergo/templates/nitrates/fragments/_panneau_form.html
@@ -175,7 +175,25 @@ questions/résultat. djLint (H025) croit à tort le <form> orphelin à cause des
         <aside id="recap-choix"
                class="recap-choix"
                aria-label="Récapitulatif de vos choix">
+          {# Choix culture/couvert/fertilisant : remplis côté JS depuis l'état du form. #}
           <div class="recap-choix__liste" data-recap-liste></div>
+
+          {% comment %}
+          Questions complémentaires répondues : rendues côté serveur (données
+          dynamiques peu synthétisables). On les liste telles quelles (question ->
+          réponse humaine), à la fin du récap.
+          {% endcomment %}
+          {% if qc_repondues %}
+            <div class="recap-choix__liste recap-choix__qc">
+              {% for qc in qc_repondues %}
+                <div class="recap-choix__item">
+                  <span class="recap-choix__label">{{ qc.texte }}</span>
+                  <span class="recap-choix__valeur">{{ qc.libelle }}</span>
+                </div>
+              {% endfor %}
+            </div>
+          {% endif %}
+
           <button type="button"
                   class="fr-btn fr-btn--secondary fr-btn--sm recap-choix__modifier"
                   data-recap-modifier>Modifier</button>

--- a/envergo/templates/nitrates/fragments/_panneau_resultat.html
+++ b/envergo/templates/nitrates/fragments/_panneau_resultat.html
@@ -195,44 +195,53 @@ Structure inspiree de la maquette site-nitrates-maquette/index.html :
           compris les blocs riches -> la PC15 d'une regle avec message
           (ex CIE courte types 0/I/II) ne s'affichait pas.
           {% endcomment %}
-          {% if ev.regle.codes_prescription %}
-            {% for cp in ev.regle.codes_prescription %}
-              {% with pc=codes_prescription|get_item:cp %}
-                {% if pc.blocs %}
-                  <div class="fr-accordions-group fr-mt-3w">{% compile_blocs pc.blocs id_prefix=cp %}</div>
-                {% elif pc and not ev.regle.message %}
-                  <h4 class="fr-h6 fr-mt-3w">{{ pc.mots_cles|default:cp }}</h4>
-                  {% if pc.texte_court %}
-                    <p>
-                      {{ pc.texte_court|linebreaksbr }}
-                      {% if pc.texte_redaction_initiale %}
-                        <a href="#accordion-texte-init-{{ cp }}"
-                           class="fr-link fr-link--sm nitrates-voir-plus"
-                           data-target="accordion-texte-init-{{ cp }}">voir plus</a>
-                      {% endif %}
-                    </p>
-                  {% endif %}
-                {% elif not pc and not ev.regle.message %}
-                  <p class="fr-text--sm">
-                    <strong>Code prescription :</strong> {{ cp }}
-                  </p>
-                {% endif %}
-              {% endwith %}
-            {% endfor %}
-          {% endif %}
-
-          {# Note réglementaire : libelle long resolu via referentiels #}
-          {% if ev.regle.note %}
-            {% with note=notes_referentiel|get_item:ev.regle.note %}
-              {% if note %}
-                <h4 class="fr-h6 fr-mt-2w">{{ note.libelle_court|default:ev.regle.note }}</h4>
-                {% if note.condition_declenchement %}<p>{{ note.condition_declenchement|linebreaksbr }}</p>{% endif %}
+          {% comment %}
+          #271 chantier 3 — les prescriptions conditionnées (blocs riches PC) et
+          la note ne s'affichent plus inline (trop de texte qui noie le résultat)
+          mais dans un DRAWER latéral, ouvert par le bouton ci-dessous. Le bouton
+          et le drawer ne sont rendus que s'il y a du contenu conditionné à
+          montrer (codes_prescription ou note). Le libellé s'accorde au nombre de
+          périodes d'autorisation sous condition.
+          {% endcomment %}
+          {% if ev.regle.codes_prescription or ev.regle.note %}
+            {% nb_periodes_sous_condition ev.regle as nb_asc %}
+            <button type="button"
+                    class="fr-btn drawer-conditions__trigger"
+                    data-drawer-open="drawer-conditions"
+                    aria-haspopup="dialog"
+                    aria-controls="drawer-conditions">
+              <span class="drawer-conditions__trigger-icon" aria-hidden="true">📅</span>
+              Voir les conditions d'épandage pour
+              {% if nb_asc > 1 %}
+                ces périodes
               {% else %}
-                <p class="fr-text--sm">
-                  <strong>Note :</strong> {{ ev.regle.note }}
-                </p>
+                cette période
               {% endif %}
-            {% endwith %}
+            </button>
+
+            {% comment %}
+            Drawer latéral (#271 chantier 3) : slide depuis la droite (2/3
+            desktop, plein écran mobile). Contenu = prescriptions conditionnées
+            + note + dates ASC réinjectées (badges orange). Fermé par défaut ;
+            piloté par drawer_conditions.js.
+            {% endcomment %}
+            <div id="drawer-conditions"
+                 class="drawer-conditions"
+                 role="dialog"
+                 aria-modal="true"
+                 aria-labelledby="drawer-conditions-titre"
+                 hidden>
+              <div class="drawer-conditions__overlay" data-drawer-close></div>
+              <div class="drawer-conditions__panel">
+                <div class="drawer-conditions__header">
+                  <h2 id="drawer-conditions-titre" class="drawer-conditions__titre fr-h4">Conditions d'épandage</h2>
+                  <button type="button"
+                          class="fr-btn fr-btn--tertiary-no-outline fr-btn--icon-left fr-icon-close-line drawer-conditions__fermer"
+                          data-drawer-close>Fermer</button>
+                </div>
+                <div class="drawer-conditions__contenu">{% include "nitrates/fragments/_drawer_conditions.html" %}</div>
+              </div>
+            </div>
           {% endif %}
 
           {# Marqueur a_completer #}

--- a/envergo/templates/nitrates/fragments/_panneau_resultat.html
+++ b/envergo/templates/nitrates/fragments/_panneau_resultat.html
@@ -100,23 +100,13 @@ Structure inspiree de la maquette site-nitrates-maquette/index.html :
           (calendrier_dynamique_couvert), sinon le templatetag standard 12 mois.
           {% endcomment %}
           {% if ev.regle.type == "calculatrice" and ev.regle.composant == "calendrier_dynamique_couvert" %}
-            {% include "nitrates/fragments/_calculatrice_calendrier.html" %}
             {% comment %}
-            #271 : lien vers le drawer pour les règles CALCULATRICE (couvert),
-            placé JUSTE sous le calendrier dynamique (près de son recap ASC), pas
-            après le panneau debug. Affiché/masqué + accordé (singulier/pluriel)
-            par calculatrice-calendrier.js selon la présence d'une période ASC.
+            #271 : pour les couverts (calculatrice), le lien vers le drawer est
+            généré par calculatrice-calendrier.js DANS le <ul> de la section
+            « autorisation sous condition » de son recap (rattaché à la bonne
+            période). Rien à rendre ici hors du composant.
             {% endcomment %}
-            {% if ev.regle.codes_prescription or ev.regle.note %}
-              <p class="periodes-lien-conditions" data-drawer-lien-calc hidden>
-                <a href="#drawer-conditions"
-                   class="fr-link periodes-lien-conditions__link"
-                   data-drawer-open="drawer-conditions">
-                  <span class="periodes-lien-conditions__icon" aria-hidden="true">⚠️</span>
-                  <span data-drawer-lien-texte>Voir les conditions d'épandage spécifiques pour cette période</span>
-                </a>
-              </p>
-            {% endif %}
+            {% include "nitrates/fragments/_calculatrice_calendrier.html" %}
           {% else %}
             {% calendrier_epandage ev.regle %}
           {% endif %}

--- a/envergo/templates/nitrates/fragments/_panneau_resultat.html
+++ b/envergo/templates/nitrates/fragments/_panneau_resultat.html
@@ -101,6 +101,22 @@ Structure inspiree de la maquette site-nitrates-maquette/index.html :
           {% endcomment %}
           {% if ev.regle.type == "calculatrice" and ev.regle.composant == "calendrier_dynamique_couvert" %}
             {% include "nitrates/fragments/_calculatrice_calendrier.html" %}
+            {% comment %}
+            #271 : lien vers le drawer pour les règles CALCULATRICE (couvert),
+            placé JUSTE sous le calendrier dynamique (près de son recap ASC), pas
+            après le panneau debug. Affiché/masqué + accordé (singulier/pluriel)
+            par calculatrice-calendrier.js selon la présence d'une période ASC.
+            {% endcomment %}
+            {% if ev.regle.codes_prescription or ev.regle.note %}
+              <p class="periodes-lien-conditions" data-drawer-lien-calc hidden>
+                <a href="#drawer-conditions"
+                   class="fr-link periodes-lien-conditions__link"
+                   data-drawer-open="drawer-conditions">
+                  <span class="periodes-lien-conditions__icon" aria-hidden="true">⚠️</span>
+                  <span data-drawer-lien-texte>Voir les conditions d'épandage spécifiques pour cette période</span>
+                </a>
+              </p>
+            {% endif %}
           {% else %}
             {% calendrier_epandage ev.regle %}
           {% endif %}
@@ -133,17 +149,23 @@ Structure inspiree de la maquette site-nitrates-maquette/index.html :
               plusieurs périodes ASC, le lien est placé EN HAUT (au pluriel) ;
               si une seule, il est placé SOUS la période (au singulier).
               {% endcomment %}
-              {% if section.titre == "Période d’autorisation sous condition" and nb_asc > 1 and ev.regle.codes_prescription %}
-                <p class="periodes-lien-conditions">
-                  <a href="#drawer-conditions"
-                     class="fr-link periodes-lien-conditions__link"
-                     data-drawer-open="drawer-conditions">
-                    <span class="periodes-lien-conditions__icon" aria-hidden="true">⚠️</span>
-                    Voir les conditions d'épandage spécifiques pour ces périodes
-                  </a>
-                </p>
-              {% endif %}
+              {% comment %}
+              #271 : lien vers le drawer, ALIGNÉ sous la période ASC (même
+              indentation que le texte des puces). Placé dans la liste : au-dessus
+              des puces si plusieurs périodes (au pluriel), juste après l'unique
+              puce sinon (au singulier). L'item n'a pas de marqueur (liseré vide).
+              {% endcomment %}
               <ul class="fr-mb-0 periodes-liste">
+                {% if section.titre == "Période d’autorisation sous condition" and nb_asc > 1 and ev.regle.codes_prescription %}
+                  <li class="periodes-lien-conditions">
+                    <a href="#drawer-conditions"
+                       class="fr-link periodes-lien-conditions__link"
+                       data-drawer-open="drawer-conditions">
+                      <span class="periodes-lien-conditions__icon" aria-hidden="true">⚠️</span>
+                      Voir les conditions d'épandage spécifiques pour ces périodes
+                    </a>
+                  </li>
+                {% endif %}
                 {% for puce in section.periodes %}
                   <li>
                     {{ puce.phrase }}
@@ -165,17 +187,17 @@ Structure inspiree de la maquette site-nitrates-maquette/index.html :
                     {% endif %}
                   </li>
                 {% endfor %}
+                {% if section.titre == "Période d’autorisation sous condition" and nb_asc == 1 and ev.regle.codes_prescription %}
+                  <li class="periodes-lien-conditions">
+                    <a href="#drawer-conditions"
+                       class="fr-link periodes-lien-conditions__link"
+                       data-drawer-open="drawer-conditions">
+                      <span class="periodes-lien-conditions__icon" aria-hidden="true">⚠️</span>
+                      Voir les conditions d'épandage spécifiques pour cette période
+                    </a>
+                  </li>
+                {% endif %}
               </ul>
-              {% if section.titre == "Période d’autorisation sous condition" and nb_asc == 1 and ev.regle.codes_prescription %}
-                <p class="periodes-lien-conditions">
-                  <a href="#drawer-conditions"
-                     class="fr-link periodes-lien-conditions__link"
-                     data-drawer-open="drawer-conditions">
-                    <span class="periodes-lien-conditions__icon" aria-hidden="true">⚠️</span>
-                    Voir les conditions d'épandage spécifiques pour cette période
-                  </a>
-                </p>
-              {% endif %}
             {% endfor %}
           {% endif %}
 
@@ -233,22 +255,6 @@ Structure inspiree de la maquette site-nitrates-maquette/index.html :
           {% endcomment %}
           {% if ev.regle.codes_prescription or ev.regle.note %}
             {% comment %}
-            Lien de secours pour les règles CALCULATRICE (couvert) : le recap ASC
-            est rendu côté JS, qui affiche/masque ce lien selon la présence d'une
-            période ASC et pose le bon libellé (singulier/pluriel).
-            {% endcomment %}
-            {% if ev.regle.type == "calculatrice" %}
-              <p class="periodes-lien-conditions" data-drawer-lien-calc hidden>
-                <a href="#drawer-conditions"
-                   class="fr-link periodes-lien-conditions__link"
-                   data-drawer-open="drawer-conditions">
-                  <span class="periodes-lien-conditions__icon" aria-hidden="true">⚠️</span>
-                  <span data-drawer-lien-texte>Voir les conditions d'épandage spécifiques pour cette période</span>
-                </a>
-              </p>
-            {% endif %}
-
-            {% comment %}
             Drawer latéral (#271 chantier 3) : slide depuis la droite (2/3
             desktop, plein écran mobile). Contenu = prescriptions conditionnées
             + note + dates ASC réinjectées (badges orange). Fermé par défaut ;
@@ -262,7 +268,19 @@ Structure inspiree de la maquette site-nitrates-maquette/index.html :
                  hidden>
               <div class="drawer-conditions__overlay" data-drawer-close></div>
               <div class="drawer-conditions__panel">
+                {% nb_periodes_sous_condition ev.regle as nb_asc_h %}
                 <div class="drawer-conditions__header">
+                  {# « Période(s) d'application : » sur la MÊME ligne que Fermer #}
+                  {# (gain de hauteur). Accord ajusté aussi par le JS (couvert). #}
+                  <span class="drawer-conditions__application-label"
+                        data-drawer-application-label>
+                    {% if nb_asc_h > 1 %}
+                      Périodes
+                    {% else %}
+                      Période
+                    {% endif %}
+                    d'application :
+                  </span>
                   <button type="button"
                           class="fr-btn fr-btn--tertiary-no-outline fr-btn--icon-left fr-icon-close-line drawer-conditions__fermer"
                           data-drawer-close>Fermer</button>

--- a/envergo/templates/nitrates/fragments/_panneau_resultat.html
+++ b/envergo/templates/nitrates/fragments/_panneau_resultat.html
@@ -124,8 +124,25 @@ Structure inspiree de la maquette site-nitrates-maquette/index.html :
           {% endcomment %}
           {% if ev.regle.type != "calculatrice" %}
             {% periodes_par_section ev.regle as sections_periodes %}
+            {% nb_periodes_sous_condition ev.regle as nb_asc %}
             {% for section in sections_periodes %}
               <p class="periodes-section-titre">{{ section.titre }} :</p>
+              {% comment %}
+              #271 : dans la section « autorisation sous condition », un lien
+              (avec icône warning) renvoie vers le drawer des conditions PC. Si
+              plusieurs périodes ASC, le lien est placé EN HAUT (au pluriel) ;
+              si une seule, il est placé SOUS la période (au singulier).
+              {% endcomment %}
+              {% if section.titre == "Période d’autorisation sous condition" and nb_asc > 1 and ev.regle.codes_prescription %}
+                <p class="periodes-lien-conditions">
+                  <a href="#drawer-conditions"
+                     class="fr-link periodes-lien-conditions__link"
+                     data-drawer-open="drawer-conditions">
+                    <span class="periodes-lien-conditions__icon" aria-hidden="true">⚠️</span>
+                    Voir les conditions d'épandage spécifiques pour ces périodes
+                  </a>
+                </p>
+              {% endif %}
               <ul class="fr-mb-0 periodes-liste">
                 {% for puce in section.periodes %}
                   <li>
@@ -149,6 +166,16 @@ Structure inspiree de la maquette site-nitrates-maquette/index.html :
                   </li>
                 {% endfor %}
               </ul>
+              {% if section.titre == "Période d’autorisation sous condition" and nb_asc == 1 and ev.regle.codes_prescription %}
+                <p class="periodes-lien-conditions">
+                  <a href="#drawer-conditions"
+                     class="fr-link periodes-lien-conditions__link"
+                     data-drawer-open="drawer-conditions">
+                    <span class="periodes-lien-conditions__icon" aria-hidden="true">⚠️</span>
+                    Voir les conditions d'épandage spécifiques pour cette période
+                  </a>
+                </p>
+              {% endif %}
             {% endfor %}
           {% endif %}
 
@@ -197,27 +224,29 @@ Structure inspiree de la maquette site-nitrates-maquette/index.html :
           {% endcomment %}
           {% comment %}
           #271 chantier 3 — les prescriptions conditionnées (blocs riches PC) et
-          la note ne s'affichent plus inline (trop de texte qui noie le résultat)
-          mais dans un DRAWER latéral, ouvert par le bouton ci-dessous. Le bouton
-          et le drawer ne sont rendus que s'il y a du contenu conditionné à
-          montrer (codes_prescription ou note). Le libellé s'accorde au nombre de
-          périodes d'autorisation sous condition.
+          la note ne s'affichent plus inline (trop de texte) mais dans un DRAWER
+          latéral, ouvert par un LIEN placé dans la section « autorisation sous
+          condition » (cf. plus haut pour les règles non calculatrice ; pour les
+          calculatrice/couverts, le lien est injecté par le calendrier dynamique
+          près de son recap ASC). Le drawer n'est rendu que s'il y a du contenu
+          conditionné (codes_prescription ou note).
           {% endcomment %}
           {% if ev.regle.codes_prescription or ev.regle.note %}
-            {% nb_periodes_sous_condition ev.regle as nb_asc %}
-            <button type="button"
-                    class="fr-btn drawer-conditions__trigger"
-                    data-drawer-open="drawer-conditions"
-                    aria-haspopup="dialog"
-                    aria-controls="drawer-conditions">
-              <span class="drawer-conditions__trigger-icon" aria-hidden="true">📅</span>
-              Voir les conditions d'épandage pour
-              {% if nb_asc > 1 %}
-                ces périodes
-              {% else %}
-                cette période
-              {% endif %}
-            </button>
+            {% comment %}
+            Lien de secours pour les règles CALCULATRICE (couvert) : le recap ASC
+            est rendu côté JS, qui affiche/masque ce lien selon la présence d'une
+            période ASC et pose le bon libellé (singulier/pluriel).
+            {% endcomment %}
+            {% if ev.regle.type == "calculatrice" %}
+              <p class="periodes-lien-conditions" data-drawer-lien-calc hidden>
+                <a href="#drawer-conditions"
+                   class="fr-link periodes-lien-conditions__link"
+                   data-drawer-open="drawer-conditions">
+                  <span class="periodes-lien-conditions__icon" aria-hidden="true">⚠️</span>
+                  <span data-drawer-lien-texte>Voir les conditions d'épandage spécifiques pour cette période</span>
+                </a>
+              </p>
+            {% endif %}
 
             {% comment %}
             Drawer latéral (#271 chantier 3) : slide depuis la droite (2/3
@@ -229,12 +258,11 @@ Structure inspiree de la maquette site-nitrates-maquette/index.html :
                  class="drawer-conditions"
                  role="dialog"
                  aria-modal="true"
-                 aria-labelledby="drawer-conditions-titre"
+                 aria-label="Conditions d'épandage en période d'autorisation sous condition"
                  hidden>
               <div class="drawer-conditions__overlay" data-drawer-close></div>
               <div class="drawer-conditions__panel">
                 <div class="drawer-conditions__header">
-                  <h2 id="drawer-conditions-titre" class="drawer-conditions__titre fr-h4">Conditions d'épandage</h2>
                   <button type="button"
                           class="fr-btn fr-btn--tertiary-no-outline fr-btn--icon-left fr-icon-close-line drawer-conditions__fermer"
                           data-drawer-close>Fermer</button>

--- a/envergo/templates/nitrates/simulateur.html
+++ b/envergo/templates/nitrates/simulateur.html
@@ -76,6 +76,8 @@
     <script defer src="{% static_v 'nitrates/scroll_resultat.js' %}"></script>
     {# #271 : encart recap des choix (colonne gauche) + bouton Modifier. #}
     <script defer src="{% static_v 'nitrates/recap_choix.js' %}"></script>
+    {# #271 : drawer lateral « Conditions d'epandage » (notes PC + dates ASC). #}
+    <script defer src="{% static_v 'nitrates/drawer_conditions.js' %}"></script>
   {% endif %}
 {% endblock %}
 

--- a/envergo/templates/nitrates/simulateur.html
+++ b/envergo/templates/nitrates/simulateur.html
@@ -74,6 +74,8 @@
     {# Recadre la vue apres soumission : QC en attente -> bloc QC en haut ; #}
     {# resultat final -> section Localisation/resultat en haut (#112). #}
     <script defer src="{% static_v 'nitrates/scroll_resultat.js' %}"></script>
+    {# #271 : encart recap des choix (colonne gauche) + bouton Modifier. #}
+    <script defer src="{% static_v 'nitrates/recap_choix.js' %}"></script>
   {% endif %}
 {% endblock %}
 

--- a/envergo/templates/nitrates/simulateur.html
+++ b/envergo/templates/nitrates/simulateur.html
@@ -139,26 +139,14 @@
     </div>
 
     {% comment %}
-    Section formulaire + resultats.
-    Le panel resultat (colonne droite + layout--split) n'apparait QUE quand un
-    resultat final est pret, c'est-a-dire qu'il reste aucune question
-    complementaire a poser (qc_en_attente == False). Tant qu'une QC est en
-    attente, on reste en colonne unique : le formulaire occupe toute la largeur
-    et les questions complementaires sont rendues sous lui (#112).
+    Section formulaire + resultats (#271).
+    Toute la mise en page (carte pleine largeur en haut + split
+    encart-recap 1/4 / resultat 3/4 en dessous) est portee par
+    _panneau_form.html, qui enveloppe le <form> autour des deux colonnes pour
+    que la carte puisse sortir en pleine largeur sans casser la soumission.
+    Le panel resultat n'apparait QUE quand un resultat final est pret (aucune
+    QC en attente). Tant qu'une QC est en attente, colonne unique (#112).
     {% endcomment %}
-    <div class="fr-grid-row fr-grid-row--gutters results-row{% if afficher_resultat and not qc_en_attente %} layout--split{% endif %}"
-         style="align-items: flex-start">
-
-      {# Colonne gauche : form + carte (+ QC sous le form si en attente) #}
-      <div class="fr-col-12 {% if afficher_resultat and not qc_en_attente %}fr-col-lg-5{% endif %} form-col">
-        {% include "nitrates/fragments/_panneau_form.html" %}
-      </div>
-
-      {# Colonne droite : resultat final, seulement si plus aucune QC en attente #}
-      {% if afficher_resultat and not qc_en_attente %}
-        <div class="fr-col-12 fr-col-lg-7 result-col">{% include "nitrates/fragments/_panneau_resultat.html" %}</div>
-      {% endif %}
-
-    </div>
+    {% include "nitrates/fragments/_panneau_form.html" %}
   </div>
 {% endblock %}


### PR DESCRIPTION
Propagation de #271 (PR #299, mergée sur develop) vers main pour déclencher le déploiement sur nitrates-dev via la CI/CD.

Contenu : réagencement du parcours résultat (carte pleine largeur en haut, split 1/4-3/4, encart récap mauve + Modifier, drawer « Conditions d'épandage » avec badges de dates orange, gestion du re-clic carte selon le scope, adaptations mobile / bandeau construction). Pur front (JS/CSS/HTML) + un templatetag.
