### PR TITLE
build: sort la compression d'images du build de déploiement

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -95,10 +95,16 @@ function vendorScripts() {
     .pipe(dest(paths.js, { sourcemaps: '.' }));
 }
 
-// Image compression
+// Image compression (optimisation ponctuelle des sources, PAS dans le build de
+// déploiement). gulp-imagemin -> optipng-bin télécharge un binaire précompilé au
+// build ; ce binaire est régulièrement indisponible/incompatible et fait planter
+// `gulp build` sur Scalingo (spawn optipng ENOENT). On sort donc cette tâche du
+// build : elle recompresse des SOURCES en place, ce n'est pas un livrable. À
+// lancer manuellement au besoin : `npx gulp imgCompression`.
 async function imgCompression() {
   const imagemin = (await import("gulp-imagemin")).default;
   return src(`${paths.images}/*.{png,svg,jpg}`, { encoding: false })
+    .pipe(plumber()) // ne crashe pas le process si un optimiseur échoue
     .pipe(imagemin()) // Compresses PNG, JPEG, SVG images.
     .pipe(dest(paths.images));
 }
@@ -145,11 +151,16 @@ function watchPaths() {
   );
 }
 
-// Generate all assets
-const build = parallel(styles, scripts, imgCompression);
+// Generate all assets déployés (CSS + JS). La compression d'images est
+// volontairement HORS build (cf. imgCompression) car elle dépend d'un binaire
+// externe fragile (optipng) qui casse le build Scalingo.
+const build = parallel(styles, scripts);
 
 // Set up dev environment
 const dev = parallel(initBrowserSync, watchPaths);
+
+// Tâche manuelle d'optimisation d'images (hors build de déploiement).
+task('imgCompression', imgCompression);
 
 task('default', series(build, dev));
 task('build', build);


### PR DESCRIPTION
Le build front (`gulp build`) plantait sur Scalingo (`spawn optipng ENOENT`), ce qui faisait échouer le déploiement dev (PR #300 / #271).

La tâche `imgCompression` utilise `gulp-imagemin` → `optipng-bin`, qui télécharge un binaire précompilé externe au build ; ce binaire est régulièrement indisponible et casse le build. Sans rapport avec le code déployé : le `package-lock.json` était identique entre le dernier déploiement OK (#277) et l'échec (#300).

Correctif :
- `imgCompression` sortie du build de déploiement (elle recompresse des sources en place, ce n'est pas un livrable).
- Conservée en tâche manuelle : `npx gulp imgCompression`.
- `plumber` ajouté en filet pour ne pas crasher le process si un optimiseur échoue.

Vérifié : `gulp build` passe en local, et le déploiement dev est repassé (SHA 125f57f60, build success).