### PR TITLE
PC plafond couvert (PC12-15) hors drawer, inline sous calendrier

### DIFF
--- a/envergo/nitrates/templatetags/nitrates_tags.py
+++ b/envergo/nitrates/templatetags/nitrates_tags.py
@@ -416,6 +416,56 @@ _SECTION_TITRE = {
 }
 
 
+# PC « plafond sur couvert » (PC12 à PC15 et leurs futures fusions/overrides).
+# Ces prescriptions s'appliquent sur tout le 2nd semestre (automne + hiver), PAS
+# seulement sur la periode d'autorisation sous condition : elles restent donc
+# affichees INLINE sous le calendrier (et NON dans le drawer conditions, #271).
+#
+# Regexp volontairement LARGE (forward-compatible avec les dev d'override et de
+# fusion de PC a venir) : matche pc12/pc13/pc14/pc15 apparaissant comme un token
+# dans l'identifiant, quelle que soit la decoration autour. Couvre ainsi :
+#   pc12, pc13, pc14, pc15, pc15_fusion, pc12_pc15_fusion, pc13_ge_override, ...
+_PC_PLAFOND_COUVERT_RE = re.compile(r"pc1[2-5](?:\b|_)", re.IGNORECASE)
+
+
+@register.filter
+def est_pc_plafond_couvert(cp) -> bool:
+    """True si l'identifiant de PC `cp` designe un plafond sur couvert (PC12-15
+    et fusions/overrides). Cf. _PC_PLAFOND_COUVERT_RE (matching large)."""
+    if not cp:
+        return False
+    return bool(_PC_PLAFOND_COUVERT_RE.search(str(cp)))
+
+
+@register.simple_tag
+def codes_prescription_plafond_couvert(regle) -> list:
+    """Sous-liste des codes_prescription de `regle` qui sont des plafonds sur
+    couvert (a rendre INLINE sous le calendrier)."""
+    codes = getattr(regle, "codes_prescription", None) or []
+    return [cp for cp in codes if est_pc_plafond_couvert(cp)]
+
+
+@register.simple_tag
+def codes_prescription_hors_plafond(regle) -> list:
+    """Sous-liste des codes_prescription de `regle` qui NE sont PAS des plafonds
+    sur couvert (a rendre dans le drawer conditions, #271)."""
+    codes = getattr(regle, "codes_prescription", None) or []
+    return [cp for cp in codes if not est_pc_plafond_couvert(cp)]
+
+
+@register.simple_tag
+def drawer_conditions_a_du_contenu(regle) -> bool:
+    """True si le drawer « conditions » a quelque chose a montrer : au moins une
+    PC HORS plafond couvert, ou une note. Les PC plafond couvert etant rendues
+    inline sous le calendrier, une regle qui n'a QUE des PC plafond ne doit PAS
+    afficher le lien / drawer (#271, CR 2026-08)."""
+    if regle is None:
+        return False
+    if getattr(regle, "note", None):
+        return True
+    return len(codes_prescription_hors_plafond(regle)) > 0
+
+
 @register.simple_tag
 def nb_periodes_sous_condition(regle) -> int:
     """Nombre de periodes « autorisation sous condition » d'une regle (#271).

--- a/envergo/static/nitrates/calculatrice-calendrier.js
+++ b/envergo/static/nitrates/calculatrice-calendrier.js
@@ -88,6 +88,12 @@
     non_applicable: "ne s'applique pas",
   };
 
+  // PC « plafond sur couvert » (PC12-15 & fusions/overrides). Miroir de la
+  // regexp Python _PC_PLAFOND_COUVERT_RE (nitrates_tags.py) : matching LARGE,
+  // forward-compatible avec les futurs override/fusion de PC. Ces PC sont
+  // rendues inline sous le calendrier (pas dans le drawer, CR 2026-08).
+  const EST_PC_PLAFOND_COUVERT = /pc1[2-5](?:$|_|\b)/i;
+
   // Titre de section du récap (#159, maquette : regroupement par régime, une
   // liste à puces par section). Ordre = du moins au plus restrictif, pour
   // s'aligner sur le récap des cultures principales (autorisation d'abord,
@@ -1479,9 +1485,17 @@
     // période(s) ASC. Ainsi il reste rattaché à la bonne période (avant, un <p>
     // hors calendrier pouvait suggérer un rattachement à une autre section).
     // Rendu uniquement si la règle porte des prescriptions/note à montrer.
+    //
+    // CR 2026-08 : on EXCLUT les PC « plafond sur couvert » (PC12-15 & fusions/
+    // overrides) : elles s'appliquent sur tout le 2nd semestre, pas seulement sur
+    // la période ASC -> rendues inline sous le calendrier (côté template), pas
+    // dans le drawer. Le lien n'apparaît donc que s'il reste des PC HORS plafond
+    // ou une note.
     const ascPuces = pucesParRegime.autorisation_sous_condition || [];
-    const aDuContenu =
-      (data.codes_prescription && data.codes_prescription.length) || data.note;
+    const pcHorsPlafond = (data.codes_prescription || []).filter(
+      (cp) => !EST_PC_PLAFOND_COUVERT.test(String(cp))
+    );
+    const aDuContenu = pcHorsPlafond.length > 0 || data.note;
     if (ascPuces.length && aDuContenu) {
       const pluriel = ascPuces.length > 1;
       const texte = pluriel

--- a/envergo/templates/nitrates/fragments/_drawer_conditions.html
+++ b/envergo/templates/nitrates/fragments/_drawer_conditions.html
@@ -47,11 +47,15 @@ dates (fond orange, cohérent calendrier), en tête du contenu.
 </div>
 
 {% comment %}
-Prescription(s) conditionnée(s) : contenu riche PC (#136). Même logique que
-l'ancien rendu inline du panneau résultat, désormais dans le drawer.
+Prescription(s) conditionnée(s) : contenu riche PC (#136), dans le drawer.
+On EXCLUT les PC « plafond sur couvert » (PC12-15 & fusions/overrides) : elles
+s'appliquent sur tout le 2nd semestre, pas seulement sur la période ASC, donc
+elles restent INLINE sous le calendrier (cf. _panneau_resultat.html). Ici on ne
+garde que les PC hors-plafond, vraiment spécifiques à la période sous condition.
 {% endcomment %}
-{% if ev.regle.codes_prescription %}
-  {% for cp in ev.regle.codes_prescription %}
+{% codes_prescription_hors_plafond ev.regle as pc_drawer %}
+{% if pc_drawer %}
+  {% for cp in pc_drawer %}
     {% with pc=codes_prescription|get_item:cp %}
       {% if pc.blocs %}
         <div class="fr-accordions-group fr-mt-3w">{% compile_blocs pc.blocs id_prefix=cp %}</div>

--- a/envergo/templates/nitrates/fragments/_panneau_resultat.html
+++ b/envergo/templates/nitrates/fragments/_panneau_resultat.html
@@ -112,6 +112,25 @@ Structure inspiree de la maquette site-nitrates-maquette/index.html :
           {% endif %}
 
           {% comment %}
+          CR 2026-08 : les PC « plafond sur couvert » (PC12-15 & fusions/overrides)
+          s'appliquent sur tout le 2nd semestre (automne + hiver), pas seulement
+          sur la période d'autorisation sous condition. Elles restent donc
+          affichées INLINE sous le calendrier (et NON dans le drawer conditions).
+          Les autres PC (spécifiques à la période ASC) vont dans le drawer.
+          {% endcomment %}
+          {% codes_prescription_plafond_couvert ev.regle as pc_plafond %}
+          {% for cp in pc_plafond %}
+            {% with pc=codes_prescription|get_item:cp %}
+              {% if pc.blocs %}
+                <div class="fr-accordions-group fr-mt-3w">{% compile_blocs pc.blocs id_prefix=cp %}</div>
+              {% elif pc %}
+                <h4 class="fr-h6 fr-mt-3w">{{ pc.mots_cles|default:cp }}</h4>
+                {% if pc.texte_court %}<p>{{ pc.texte_court|linebreaksbr }}</p>{% endif %}
+              {% endif %}
+            {% endwith %}
+          {% endfor %}
+
+          {% comment %}
           Ancien callout "Condition d'autorisation" (texte_condition, #28)
           retire : redondant avec les prescriptions conditionnees riches qui
           portent desormais tout le detail. Le texte_condition reste exploite
@@ -131,6 +150,9 @@ Structure inspiree de la maquette site-nitrates-maquette/index.html :
           {% if ev.regle.type != "calculatrice" %}
             {% periodes_par_section ev.regle as sections_periodes %}
             {% nb_periodes_sous_condition ev.regle as nb_asc %}
+            {# Lien drawer affiché seulement s'il reste des PC HORS plafond (les #}
+            {# PC plafond sont inline sous le calendrier) ou une note. #}
+            {% drawer_conditions_a_du_contenu ev.regle as drawer_a_du_contenu %}
             {% for section in sections_periodes %}
               <p class="periodes-section-titre">{{ section.titre }} :</p>
               {% comment %}
@@ -146,7 +168,7 @@ Structure inspiree de la maquette site-nitrates-maquette/index.html :
               puce sinon (au singulier). L'item n'a pas de marqueur (liseré vide).
               {% endcomment %}
               <ul class="fr-mb-0 periodes-liste">
-                {% if section.titre == "Période d’autorisation sous condition" and nb_asc > 1 and ev.regle.codes_prescription %}
+                {% if section.titre == "Période d’autorisation sous condition" and nb_asc > 1 and drawer_a_du_contenu %}
                   <li class="periodes-lien-conditions">
                     <a href="#drawer-conditions"
                        class="fr-link periodes-lien-conditions__link"
@@ -177,7 +199,7 @@ Structure inspiree de la maquette site-nitrates-maquette/index.html :
                     {% endif %}
                   </li>
                 {% endfor %}
-                {% if section.titre == "Période d’autorisation sous condition" and nb_asc == 1 and ev.regle.codes_prescription %}
+                {% if section.titre == "Période d’autorisation sous condition" and nb_asc == 1 and drawer_a_du_contenu %}
                   <li class="periodes-lien-conditions">
                     <a href="#drawer-conditions"
                        class="fr-link periodes-lien-conditions__link"
@@ -241,9 +263,11 @@ Structure inspiree de la maquette site-nitrates-maquette/index.html :
           condition » (cf. plus haut pour les règles non calculatrice ; pour les
           calculatrice/couverts, le lien est injecté par le calendrier dynamique
           près de son recap ASC). Le drawer n'est rendu que s'il y a du contenu
-          conditionné (codes_prescription ou note).
+          conditionné HORS plafond couvert (PC non-plafond ou note) : une règle
+          qui n'a que des PC plafond les affiche inline, sans drawer.
           {% endcomment %}
-          {% if ev.regle.codes_prescription or ev.regle.note %}
+          {% drawer_conditions_a_du_contenu ev.regle as drawer_a_du_contenu %}
+          {% if drawer_a_du_contenu %}
             {% comment %}
             Drawer latéral (#271 chantier 3) : slide depuis la droite (2/3
             desktop, plein écran mobile). Contenu = prescriptions conditionnées


### PR DESCRIPTION
## Contexte (CR retour utilisateur 2026-08)

Les PC « plafond sur couvert » (PC12 à 15) s'appliquent sur tout le 2nd semestre (automne + hiver), pas seulement sur la période d'autorisation sous condition. Elles ne doivent donc **pas** être dans le drawer « conditions » introduit par #271, mais rester **inline sous le calendrier** comme avant.

## Contenu

- `nitrates_tags.py` : regexp large `_PC_PLAFOND_COUVERT_RE` (`pc1[2-5]` comme token), forward-compatible avec les futurs override/fusion de PC (`pc15_fusion`, `pc12_pc15_fusion`, `pc13_ge_override`…). Filtres `codes_prescription_plafond_couvert` / `_hors_plafond` + `drawer_conditions_a_du_contenu`.
- `_panneau_resultat.html` : PC plafond rendues **inline** sous le calendrier ; le lien/drawer ne s'affiche que s'il reste des PC hors-plafond ou une note.
- `_drawer_conditions.html` : le drawer n'itère plus que sur les PC hors-plafond.
- `calculatrice-calendrier.js` (couverts) : miroir JS de la regexp ; le lien du recap ASC n'apparaît que s'il reste des PC hors-plafond ou une note.

Vérifié sur le cas couvert CINE (`codes_prescription = [pc1, pc13]`) : `pc13` plafond inline (pas dans le drawer, pas de doublon), `pc1` dans le drawer. Regexp validée Python + JS. Tests JS 36/36.

Pur front + templatetags. Aucun changement d'arbre ni de référentiels.

À merger sur develop puis propager vers main (déploiement dev) quand le build Scalingo est réparé (cf. handover : build cassé par `optipng ENOENT`, indépendant de ce fix).