### PR TITLE
Deploy dev : fix build optipng + CSP enforce + fix PC couvert + auto-merge dependabot

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,49 @@
+# Auto-merge des PR Dependabot sûres.
+#
+# Politique (validée 2026-07-31) :
+#   - patch + minor : merge automatique en squash DÈS QUE la CI est verte.
+#     L'auto-merge GitHub attend les status checks requis sur `main`
+#     (pytest + linter, cf. protection de branche) avant de fusionner.
+#     Un test qui casse => la PR reste ouverte, rien n'est mergé.
+#   - major : PAS d'auto-merge. On laisse la PR ouverte pour revue manuelle
+#     (un bump majeur peut introduire un breaking non couvert par les tests).
+#
+# La CI (ci.yml) tourne déjà sur ces PR (pull_request -> main) ; ce workflow
+# ne fait qu'ARMER l'auto-merge, il ne court-circuite aucun test.
+name: Dependabot auto-merge
+
+on:
+  pull_request:
+    branches: ["main"]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    # Uniquement les PR ouvertes par Dependabot.
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Récupère les métadonnées Dependabot
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+
+      - name: Arme l'auto-merge (patch + minor uniquement)
+        if: >-
+          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+          steps.meta.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Signale les majors (revue manuelle requise)
+        if: steps.meta.outputs.update-type == 'version-update:semver-major'
+        run: |
+          gh pr comment "$PR_URL" --body \
+            "Bump **majeur** (\`${{ steps.meta.outputs.dependency-names }}\` -> ${{ steps.meta.outputs.new-version }}). Pas d'auto-merge : à revoir et merger manuellement une fois la CI verte."
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -328,54 +328,56 @@ FROM_EMAIL = {
 
 SERVER_EMAIL = env("DJANGO_SERVER_EMAIL", default=FROM_EMAIL["amenagement"]["admin"])
 
-# Whenever we are confident the csp policy is ok, move the rules from the "report only"
-# settings to this setting.
-SECURE_CSP = {}
+# Politique CSP resserrée au périmètre réel de nitrates (#261).
+#
+# On N'hérite PAS des origines Envergo (crisp.chat, sentry-cdn,
+# demarches-simplifiees...) : le fork nitrates n'utilise aucun de ces services.
+# On n'autorise que ce que le simulateur appelle réellement, pour ne pas
+# élargir la surface d'attaque par défaut.
+#
+# Surface réseau externe réelle (audit des templates + JS du simulateur) :
+#   - data.geopf.fr        : tuiles carto IGN/Géoplateforme (WMTS) + géocodage
+#   - api-adresse.data.gouv.fr, geo.api.gouv.fr : autocomplétion / commune (BAN)
+#   - Cellar S3            : médias (captures de validation)
+#   - sentry.incubateur.net : monitoring erreurs
+#   - Matomo beta.gouv     : stats (à implémenter prochainement, autorisé en amont)
+# Tout le reste (scripts, styles, fonts) est servi en propre ('self').
+# 'unsafe-inline' reste nécessaire tant que des <script>/style inline existent
+# dans les templates (migration vers nonce = chantier séparé).
+#
+# L'admin (éditeur YAML CodeMirror via cdnjs/unpkg) élargit cette politique
+# au cas par cas via csp_update, pas ici — cf. views_admin_yaml.
+_GEOPF = "https://data.geopf.fr"  # IGN / Géoplateforme (carto + géocodage)
+_BAN = "https://api-adresse.data.gouv.fr"  # Base Adresse Nationale
+_GEO_API = "https://geo.api.gouv.fr"  # Reverse commune
+_CELLAR_S3 = "https://*.cellar-c2.services.clever-cloud.com"  # Médias validation
+_SENTRY = "https://sentry.incubateur.net"  # Monitoring erreurs (loader JS + envoi)
+_MATOMO = "https://*.beta.gouv.fr"  # Stats Matomo (à venir)
 
-SECURE_CSP_REPORT_ONLY = {
+_CSP_POLICY = {
     "default-src": [CSP.SELF],
-    "script-src": [
-        CSP.SELF,
-        CSP.UNSAFE_INLINE,
-        "https://*.crisp.chat",
-        "https://sentry.incubateur.net",
-        "https://browser.sentry-cdn.com",
-        "https://*.data.gouv.fr",
-        "https://*.beta.gouv.fr",
-    ],
-    "connect-src": [
-        CSP.SELF,
-        "https://data.geopf.fr",  # New address autocomplete api
-        "https://*.data.gouv.fr",  # Address autocomplete api
-        "https://geo.api.gouv.fr",  # Reverse geocode commune (nitrates simulateur)
-        "https://*.beta.gouv.fr",  # Stats
-        "https://sentry.incubateur.net",
-        "https://*.crisp.chat",
-        "wss://*.crisp.chat",
-    ],
-    "style-src": [CSP.SELF, CSP.UNSAFE_INLINE, "https://*.crisp.chat"],
-    "img-src": [
-        CSP.SELF,
-        "https://data.geopf.fr",  # Leaflet geoportail images
-        "https://*.s3.fr-par.scw.cloud",
-        "data:",
-        "https://*.crisp.chat",
-        "https://static.demarches-simplifiees.fr",
-    ],
-    "font-src": [CSP.SELF, "https://*.crisp.chat"],
-    "media-src": [CSP.SELF, "https://*.s3.fr-par.scw.cloud", "https://*.crisp.chat"],
-    "frame-src": [
-        CSP.SELF,
-        "https://*.crisp.chat",
-        "https://*.data.gouv.fr",  # Matomo iframe opt-out
-        "https://*.beta.gouv.fr",
-    ],
-    "worker-src": [CSP.SELF, "blob:", "https://*.crisp.chat"],
+    "script-src": [CSP.SELF, CSP.UNSAFE_INLINE, _SENTRY, _MATOMO],
+    "connect-src": [CSP.SELF, _GEOPF, _BAN, _GEO_API, _SENTRY, _MATOMO],
+    "style-src": [CSP.SELF, CSP.UNSAFE_INLINE],
+    "img-src": [CSP.SELF, _GEOPF, _CELLAR_S3, "data:", _MATOMO],
+    "font-src": [CSP.SELF],
+    "media-src": [CSP.SELF, _CELLAR_S3],
+    "frame-src": [CSP.SELF, _MATOMO],  # iframe opt-out CNIL Matomo
+    "worker-src": [CSP.SELF, "blob:"],
     "object-src": [CSP.NONE],
     "base-uri": [CSP.SELF],
     "form-action": [CSP.SELF],
     "report-uri": "/csp/reports/",
 }
+
+# Enforce la politique (header Content-Security-Policy). Peut être basculé en
+# report-only seul via DJANGO_SECURE_CSP_ENFORCE=false en cas de régression.
+if env.bool("DJANGO_SECURE_CSP_ENFORCE", default=True):
+    SECURE_CSP = _CSP_POLICY
+else:
+    SECURE_CSP = {}
+
+SECURE_CSP_REPORT_ONLY = _CSP_POLICY
 
 RATELIMIT_IP_META_KEY = "HTTP_X_REAL_IP"
 

--- a/envergo/nitrates/templatetags/nitrates_tags.py
+++ b/envergo/nitrates/templatetags/nitrates_tags.py
@@ -416,6 +416,56 @@ _SECTION_TITRE = {
 }
 
 
+# PC « plafond sur couvert » (PC12 à PC15 et leurs futures fusions/overrides).
+# Ces prescriptions s'appliquent sur tout le 2nd semestre (automne + hiver), PAS
+# seulement sur la periode d'autorisation sous condition : elles restent donc
+# affichees INLINE sous le calendrier (et NON dans le drawer conditions, #271).
+#
+# Regexp volontairement LARGE (forward-compatible avec les dev d'override et de
+# fusion de PC a venir) : matche pc12/pc13/pc14/pc15 apparaissant comme un token
+# dans l'identifiant, quelle que soit la decoration autour. Couvre ainsi :
+#   pc12, pc13, pc14, pc15, pc15_fusion, pc12_pc15_fusion, pc13_ge_override, ...
+_PC_PLAFOND_COUVERT_RE = re.compile(r"pc1[2-5](?:\b|_)", re.IGNORECASE)
+
+
+@register.filter
+def est_pc_plafond_couvert(cp) -> bool:
+    """True si l'identifiant de PC `cp` designe un plafond sur couvert (PC12-15
+    et fusions/overrides). Cf. _PC_PLAFOND_COUVERT_RE (matching large)."""
+    if not cp:
+        return False
+    return bool(_PC_PLAFOND_COUVERT_RE.search(str(cp)))
+
+
+@register.simple_tag
+def codes_prescription_plafond_couvert(regle) -> list:
+    """Sous-liste des codes_prescription de `regle` qui sont des plafonds sur
+    couvert (a rendre INLINE sous le calendrier)."""
+    codes = getattr(regle, "codes_prescription", None) or []
+    return [cp for cp in codes if est_pc_plafond_couvert(cp)]
+
+
+@register.simple_tag
+def codes_prescription_hors_plafond(regle) -> list:
+    """Sous-liste des codes_prescription de `regle` qui NE sont PAS des plafonds
+    sur couvert (a rendre dans le drawer conditions, #271)."""
+    codes = getattr(regle, "codes_prescription", None) or []
+    return [cp for cp in codes if not est_pc_plafond_couvert(cp)]
+
+
+@register.simple_tag
+def drawer_conditions_a_du_contenu(regle) -> bool:
+    """True si le drawer « conditions » a quelque chose a montrer : au moins une
+    PC HORS plafond couvert, ou une note. Les PC plafond couvert etant rendues
+    inline sous le calendrier, une regle qui n'a QUE des PC plafond ne doit PAS
+    afficher le lien / drawer (#271, CR 2026-08)."""
+    if regle is None:
+        return False
+    if getattr(regle, "note", None):
+        return True
+    return len(codes_prescription_hors_plafond(regle)) > 0
+
+
 @register.simple_tag
 def nb_periodes_sous_condition(regle) -> int:
     """Nombre de periodes « autorisation sous condition » d'une regle (#271).

--- a/envergo/nitrates/tests/test_csp_header.py
+++ b/envergo/nitrates/tests/test_csp_header.py
@@ -1,0 +1,101 @@
+"""CSP nitrates : header enforce + périmètre resserré + exception admin (#261).
+
+Le staging tourne sous config.settings.production, où SECURE_CSP est désormais
+peuplé (promu depuis le report-only), resserré au périmètre réel de nitrates.
+"""
+
+from django.http import HttpResponse
+from django.test import override_settings
+
+from envergo.decorators.csp import csp_update
+from envergo.middleware.csp import ContentSecurityPolicyMiddleware
+
+CSP_ENFORCE = "Content-Security-Policy"
+CSP_REPORT_ONLY = "Content-Security-Policy-Report-Only"
+
+POLICY = {
+    "default-src": ["'self'"],
+    "script-src": ["'self'", "'unsafe-inline'"],
+    "img-src": ["'self'", "https://data.geopf.fr"],
+    "object-src": ["'none'"],
+    "report-uri": "/csp/reports/",
+}
+
+
+def _run_middleware(rf, response=None):
+    request = rf.get("/")
+    middleware = ContentSecurityPolicyMiddleware(lambda req: HttpResponse("ok"))
+    middleware.process_request(request)
+    return middleware.process_response(request, response or HttpResponse("ok"))
+
+
+@override_settings(SECURE_CSP=POLICY, SECURE_CSP_REPORT_ONLY=POLICY)
+def test_enforce_header_present_when_policy_set(rf):
+    """SECURE_CSP peuplé -> header enforce présent."""
+    response = _run_middleware(rf)
+    assert CSP_ENFORCE in response
+    assert "default-src 'self'" in response[CSP_ENFORCE]
+    assert "object-src 'none'" in response[CSP_ENFORCE]
+
+
+@override_settings(SECURE_CSP={}, SECURE_CSP_REPORT_ONLY=POLICY)
+def test_enforce_header_absent_when_policy_empty(rf):
+    """SECURE_CSP vide -> pas de header enforce, report-only seul (pré-#261)."""
+    response = _run_middleware(rf)
+    assert CSP_ENFORCE not in response
+    assert CSP_REPORT_ONLY in response
+
+
+class TestProductionPolicyScope:
+    """La politique de production ne doit PAS hériter des origines Envergo.
+
+    On lit le bloc _CSP_POLICY dans le source (le module production.py entier
+    n'est pas importable en test : il dépend de sentry_sdk / secrets absents).
+    """
+
+    def _policy_source(self):
+        from pathlib import Path
+
+        import config
+
+        # config/__init__.py -> config/settings/production.py, sans importer
+        # le module (qui tirerait sentry_sdk et les secrets prod). On borne au
+        # bloc CSP (définitions _GEOPF/_BAN... + dict _CSP_POLICY).
+        prod = Path(config.__file__).parent / "settings" / "production.py"
+        src = prod.read_text()
+        start = src.index("_GEOPF = ")
+        end = src.index("SECURE_CSP_REPORT_ONLY", start)
+        return src[start:end]
+
+    def test_ign_and_ban_present(self):
+        pol = self._policy_source()
+        assert "data.geopf.fr" in pol  # IGN / Géoplateforme
+        assert "api-adresse.data.gouv.fr" in pol  # BAN
+        assert "geo.api.gouv.fr" in pol  # commune
+
+    def test_no_envergo_third_parties(self):
+        # Gardés volontairement : sentry.incubateur.net (monitoring) et
+        # *.beta.gouv.fr (Matomo, à implémenter). Ce ne sont pas des dépendances
+        # tierces Envergo. On vérifie l'absence des services Envergo non utilisés.
+        pol = self._policy_source()
+        for banned in (
+            "crisp.chat",
+            "demarches-simplifiees",
+            "scw.cloud",
+            "sentry-cdn",
+        ):
+            assert banned not in pol, f"{banned} ne devrait pas être dans la CSP"
+
+
+@override_settings(SECURE_CSP=POLICY)
+def test_admin_yaml_view_extends_policy_with_cdns(rf):
+    """csp_update sur la vue admin ajoute cdnjs/unpkg sans toucher au global."""
+
+    @csp_update(config={"script-src": ["https://cdnjs.cloudflare.com"]})
+    def _view(request):
+        return HttpResponse("ok")
+
+    response = _run_middleware(rf, response=_view(rf.get("/")))
+    script = response[CSP_ENFORCE]
+    assert "cdnjs.cloudflare.com" in script  # exception admin
+    assert "'self'" in script  # base préservée

--- a/envergo/nitrates/views_admin_yaml.py
+++ b/envergo/nitrates/views_admin_yaml.py
@@ -19,6 +19,7 @@ from pygments import highlight
 from pygments.formatters import HtmlFormatter
 from pygments.lexers import YamlLexer
 
+from envergo.decorators.csp import csp_update
 from envergo.nitrates.models import DecisionTree
 from envergo.nitrates.permissions import can_activate_tree, can_edit_active
 from envergo.nitrates.yaml_admin.flatten import iter_entries
@@ -34,8 +35,21 @@ from envergo.nitrates.yaml_tree import load_tree_admin, load_tree_raw
 _VUES = {"arbre", "brut", "split"}
 _MODES = {"lecture", "edition"}
 
+# L'admin nitrates charge deux CDN : htmx depuis unpkg (layout base.html) et
+# CodeMirror depuis cdnjs (éditeur YAML, CSS + JS). La CSP globale nitrates est
+# volontairement stricte ('self' pour scripts/styles) pour le simulateur
+# public ; on élargit uniquement pour cette vue admin (derrière login) au lieu
+# d'ouvrir ces CDN à tout le public.
+_CDNJS = "https://cdnjs.cloudflare.com"  # CodeMirror (éditeur YAML)
+_UNPKG = "https://unpkg.com"  # htmx (layout admin)
+_CSP_ADMIN_YAML = {
+    "script-src": [_CDNJS, _UNPKG],
+    "style-src": [_CDNJS],
+}
+
 
 @method_decorator(staff_member_required, name="dispatch")
+@method_decorator(csp_update(_CSP_ADMIN_YAML), name="dispatch")
 class YamlTreeView(TemplateView):
     template_name = "nitrates_admin/yaml_tree/tree.html"
 

--- a/envergo/static/nitrates/calculatrice-calendrier.js
+++ b/envergo/static/nitrates/calculatrice-calendrier.js
@@ -88,6 +88,12 @@
     non_applicable: "ne s'applique pas",
   };
 
+  // PC « plafond sur couvert » (PC12-15 & fusions/overrides). Miroir de la
+  // regexp Python _PC_PLAFOND_COUVERT_RE (nitrates_tags.py) : matching LARGE,
+  // forward-compatible avec les futurs override/fusion de PC. Ces PC sont
+  // rendues inline sous le calendrier (pas dans le drawer, CR 2026-08).
+  const EST_PC_PLAFOND_COUVERT = /pc1[2-5](?:$|_|\b)/i;
+
   // Titre de section du récap (#159, maquette : regroupement par régime, une
   // liste à puces par section). Ordre = du moins au plus restrictif, pour
   // s'aligner sur le récap des cultures principales (autorisation d'abord,
@@ -1479,9 +1485,17 @@
     // période(s) ASC. Ainsi il reste rattaché à la bonne période (avant, un <p>
     // hors calendrier pouvait suggérer un rattachement à une autre section).
     // Rendu uniquement si la règle porte des prescriptions/note à montrer.
+    //
+    // CR 2026-08 : on EXCLUT les PC « plafond sur couvert » (PC12-15 & fusions/
+    // overrides) : elles s'appliquent sur tout le 2nd semestre, pas seulement sur
+    // la période ASC -> rendues inline sous le calendrier (côté template), pas
+    // dans le drawer. Le lien n'apparaît donc que s'il reste des PC HORS plafond
+    // ou une note.
     const ascPuces = pucesParRegime.autorisation_sous_condition || [];
-    const aDuContenu =
-      (data.codes_prescription && data.codes_prescription.length) || data.note;
+    const pcHorsPlafond = (data.codes_prescription || []).filter(
+      (cp) => !EST_PC_PLAFOND_COUVERT.test(String(cp))
+    );
+    const aDuContenu = pcHorsPlafond.length > 0 || data.note;
     if (ascPuces.length && aDuContenu) {
       const pluriel = ascPuces.length > 1;
       const texte = pluriel

--- a/envergo/templates/nitrates/fragments/_drawer_conditions.html
+++ b/envergo/templates/nitrates/fragments/_drawer_conditions.html
@@ -47,11 +47,15 @@ dates (fond orange, cohérent calendrier), en tête du contenu.
 </div>
 
 {% comment %}
-Prescription(s) conditionnée(s) : contenu riche PC (#136). Même logique que
-l'ancien rendu inline du panneau résultat, désormais dans le drawer.
+Prescription(s) conditionnée(s) : contenu riche PC (#136), dans le drawer.
+On EXCLUT les PC « plafond sur couvert » (PC12-15 & fusions/overrides) : elles
+s'appliquent sur tout le 2nd semestre, pas seulement sur la période ASC, donc
+elles restent INLINE sous le calendrier (cf. _panneau_resultat.html). Ici on ne
+garde que les PC hors-plafond, vraiment spécifiques à la période sous condition.
 {% endcomment %}
-{% if ev.regle.codes_prescription %}
-  {% for cp in ev.regle.codes_prescription %}
+{% codes_prescription_hors_plafond ev.regle as pc_drawer %}
+{% if pc_drawer %}
+  {% for cp in pc_drawer %}
     {% with pc=codes_prescription|get_item:cp %}
       {% if pc.blocs %}
         <div class="fr-accordions-group fr-mt-3w">{% compile_blocs pc.blocs id_prefix=cp %}</div>

--- a/envergo/templates/nitrates/fragments/_panneau_resultat.html
+++ b/envergo/templates/nitrates/fragments/_panneau_resultat.html
@@ -112,6 +112,25 @@ Structure inspiree de la maquette site-nitrates-maquette/index.html :
           {% endif %}
 
           {% comment %}
+          CR 2026-08 : les PC « plafond sur couvert » (PC12-15 & fusions/overrides)
+          s'appliquent sur tout le 2nd semestre (automne + hiver), pas seulement
+          sur la période d'autorisation sous condition. Elles restent donc
+          affichées INLINE sous le calendrier (et NON dans le drawer conditions).
+          Les autres PC (spécifiques à la période ASC) vont dans le drawer.
+          {% endcomment %}
+          {% codes_prescription_plafond_couvert ev.regle as pc_plafond %}
+          {% for cp in pc_plafond %}
+            {% with pc=codes_prescription|get_item:cp %}
+              {% if pc.blocs %}
+                <div class="fr-accordions-group fr-mt-3w">{% compile_blocs pc.blocs id_prefix=cp %}</div>
+              {% elif pc %}
+                <h4 class="fr-h6 fr-mt-3w">{{ pc.mots_cles|default:cp }}</h4>
+                {% if pc.texte_court %}<p>{{ pc.texte_court|linebreaksbr }}</p>{% endif %}
+              {% endif %}
+            {% endwith %}
+          {% endfor %}
+
+          {% comment %}
           Ancien callout "Condition d'autorisation" (texte_condition, #28)
           retire : redondant avec les prescriptions conditionnees riches qui
           portent desormais tout le detail. Le texte_condition reste exploite
@@ -131,6 +150,9 @@ Structure inspiree de la maquette site-nitrates-maquette/index.html :
           {% if ev.regle.type != "calculatrice" %}
             {% periodes_par_section ev.regle as sections_periodes %}
             {% nb_periodes_sous_condition ev.regle as nb_asc %}
+            {# Lien drawer affiché seulement s'il reste des PC HORS plafond (les #}
+            {# PC plafond sont inline sous le calendrier) ou une note. #}
+            {% drawer_conditions_a_du_contenu ev.regle as drawer_a_du_contenu %}
             {% for section in sections_periodes %}
               <p class="periodes-section-titre">{{ section.titre }} :</p>
               {% comment %}
@@ -146,7 +168,7 @@ Structure inspiree de la maquette site-nitrates-maquette/index.html :
               puce sinon (au singulier). L'item n'a pas de marqueur (liseré vide).
               {% endcomment %}
               <ul class="fr-mb-0 periodes-liste">
-                {% if section.titre == "Période d’autorisation sous condition" and nb_asc > 1 and ev.regle.codes_prescription %}
+                {% if section.titre == "Période d’autorisation sous condition" and nb_asc > 1 and drawer_a_du_contenu %}
                   <li class="periodes-lien-conditions">
                     <a href="#drawer-conditions"
                        class="fr-link periodes-lien-conditions__link"
@@ -177,7 +199,7 @@ Structure inspiree de la maquette site-nitrates-maquette/index.html :
                     {% endif %}
                   </li>
                 {% endfor %}
-                {% if section.titre == "Période d’autorisation sous condition" and nb_asc == 1 and ev.regle.codes_prescription %}
+                {% if section.titre == "Période d’autorisation sous condition" and nb_asc == 1 and drawer_a_du_contenu %}
                   <li class="periodes-lien-conditions">
                     <a href="#drawer-conditions"
                        class="fr-link periodes-lien-conditions__link"
@@ -241,9 +263,11 @@ Structure inspiree de la maquette site-nitrates-maquette/index.html :
           condition » (cf. plus haut pour les règles non calculatrice ; pour les
           calculatrice/couverts, le lien est injecté par le calendrier dynamique
           près de son recap ASC). Le drawer n'est rendu que s'il y a du contenu
-          conditionné (codes_prescription ou note).
+          conditionné HORS plafond couvert (PC non-plafond ou note) : une règle
+          qui n'a que des PC plafond les affiche inline, sans drawer.
           {% endcomment %}
-          {% if ev.regle.codes_prescription or ev.regle.note %}
+          {% drawer_conditions_a_du_contenu ev.regle as drawer_a_du_contenu %}
+          {% if drawer_a_du_contenu %}
             {% comment %}
             Drawer latéral (#271 chantier 3) : slide depuis la droite (2/3
             desktop, plein écran mobile). Contenu = prescriptions conditionnées

--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -95,10 +95,16 @@ function vendorScripts() {
     .pipe(dest(paths.js, { sourcemaps: '.' }));
 }
 
-// Image compression
+// Image compression (optimisation ponctuelle des sources, PAS dans le build de
+// déploiement). gulp-imagemin -> optipng-bin télécharge un binaire précompilé au
+// build ; ce binaire est régulièrement indisponible/incompatible et fait planter
+// `gulp build` sur Scalingo (spawn optipng ENOENT). On sort donc cette tâche du
+// build : elle recompresse des SOURCES en place, ce n'est pas un livrable. À
+// lancer manuellement au besoin : `npx gulp imgCompression`.
 async function imgCompression() {
   const imagemin = (await import("gulp-imagemin")).default;
   return src(`${paths.images}/*.{png,svg,jpg}`, { encoding: false })
+    .pipe(plumber()) // ne crashe pas le process si un optimiseur échoue
     .pipe(imagemin()) // Compresses PNG, JPEG, SVG images.
     .pipe(dest(paths.images));
 }
@@ -145,11 +151,16 @@ function watchPaths() {
   );
 }
 
-// Generate all assets
-const build = parallel(styles, scripts, imgCompression);
+// Generate all assets déployés (CSS + JS). La compression d'images est
+// volontairement HORS build (cf. imgCompression) car elle dépend d'un binaire
+// externe fragile (optipng) qui casse le build Scalingo.
+const build = parallel(styles, scripts);
 
 // Set up dev environment
 const dev = parallel(initBrowserSync, watchPaths);
+
+// Tâche manuelle d'optimisation d'images (hors build de déploiement).
+task('imgCompression', imgCompression);
 
 task('default', series(build, dev));
 task('build', build);


### PR DESCRIPTION
Intégration groupée (un seul déploiement dev) :

- **#309** — fix build : sort la compression d'images (optipng) du build de déploiement, qui cassait le CD dev.
- **#266** — sécurité : header CSP en enforce, resserré au périmètre nitrates.
- **#312** — fix : PC plafond couvert (PC12-15) hors drawer, inline sous calendrier (retour utilisateur).
- **#311** — CI : workflow d'auto-merge des dependabot patch/minor.

Le fix build (#309) est inclus, donc le déploiement dev doit repasser (build success).