### PR TITLE
ci: auto-merge de tous les dependabot (major inclus) si CI verte

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,15 +1,18 @@
-# Auto-merge des PR Dependabot sûres.
+# Auto-merge de TOUTES les PR Dependabot dès que la CI est verte.
 #
-# Politique (validée 2026-07-31) :
-#   - patch + minor : merge automatique en squash DÈS QUE la CI est verte.
-#     L'auto-merge GitHub attend les status checks requis sur `main`
-#     (pytest + linter, cf. protection de branche) avant de fusionner.
-#     Un test qui casse => la PR reste ouverte, rien n'est mergé.
-#   - major : PAS d'auto-merge. On laisse la PR ouverte pour revue manuelle
-#     (un bump majeur peut introduire un breaking non couvert par les tests).
+# Politique (validée 2026-08-03) :
+#   - patch + minor + MAJOR : merge automatique en squash dès que les status
+#     checks requis sur `main` (pytest + linter) passent. L'auto-merge GitHub
+#     attend ces checks avant de fusionner ; un test qui casse => la PR reste
+#     ouverte, rien n'est mergé.
+#   - Le CD ne déploie que `dev` : une régression non couverte par les tests se
+#     voit sur dev, pas chez les utilisateurs.
 #
-# La CI (ci.yml) tourne déjà sur ces PR (pull_request -> main) ; ce workflow
-# ne fait qu'ARMER l'auto-merge, il ne court-circuite aucun test.
+# Renfort prévu (TODO) : ajouter les e2e Playwright nitrates + les tests JS à la
+# CI et les rendre requis, pour élargir le filet avant d'ouvrir sur staging/prod.
+#
+# La CI (ci.yml) tourne déjà sur ces PR (pull_request -> main) ; ce workflow ne
+# fait qu'ARMER l'auto-merge, il ne court-circuite aucun test.
 name: Dependabot auto-merge
 
 on:
@@ -26,24 +29,8 @@ jobs:
     if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
-      - name: Récupère les métadonnées Dependabot
-        id: meta
-        uses: dependabot/fetch-metadata@v2
-
-      - name: Arme l'auto-merge (patch + minor uniquement)
-        if: >-
-          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
-          steps.meta.outputs.update-type == 'version-update:semver-minor'
+      - name: Arme l'auto-merge (tous les bumps, CI verte requise)
         run: gh pr merge --auto --squash "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Signale les majors (revue manuelle requise)
-        if: steps.meta.outputs.update-type == 'version-update:semver-major'
-        run: |
-          gh pr comment "$PR_URL" --body \
-            "Bump **majeur** (\`${{ steps.meta.outputs.dependency-names }}\` -> ${{ steps.meta.outputs.new-version }}). Pas d'auto-merge : à revoir et merger manuellement une fois la CI verte."
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Étend l'auto-merge Dependabot à TOUS les bumps (major inclus), plus seulement patch/minor.

Tout bump s'auto-merge en squash dès que les checks requis sur main (pytest + linter) passent. Un test qui casse => la PR reste ouverte.

Le CD ne déploie que dev : une régression non couverte se voit sur dev avant staging/prod. Renfort prévu (TODO) : ajouter les e2e Playwright nitrates + tests JS à la CI et les rendre requis, pour élargir le filet avant staging/prod.