### PR TITLE
nitrates(data): réaligne les arbres et référentiels sur l'état validé

### DIFF
--- a/envergo/nitrates/fixtures/initial_referentiels.json
+++ b/envergo/nitrates/fixtures/initial_referentiels.json
@@ -1619,7 +1619,7 @@
         },
         {
           "data": {
-            "texte": "L'épandage de certains fertilisants azotés issus d'activités agroalimentaires peut être autorisé, le cas échéant, en période d'interdiction d'épandage."
+            "texte": "L'épandage de certains effluents d'élevage peut être autorisé, le cas échéant, en période d'interdiction d'épandage."
           },
           "type": "paragraphe"
         },

--- a/envergo/nitrates/specs/arbres_actifs/national.yaml
+++ b/envergo/nitrates/specs/arbres_actifs/national.yaml
@@ -2586,7 +2586,6 @@ arbre:
                       placeholder: 15/08
                     texte_condition: Apports possibles selon les conditions fixées par le PAR ou entre le semis et les 15 jours suivants.
                     code_prescription: pc15
-                    plafonnement_associe: r_plafond_cie_courte
                   valeur: type_III
                 type_noeud: formulaire
               valeur: cie_courte
@@ -2628,35 +2627,15 @@ metadata:
   statut: brouillon - migré depuis SVG Miro 28/04 (grammaire v2 inchangée)
   version: 0.4.0-draft
   derniere_maj: '2026-04-28'
-plafonnements:
-- regle:
-    id: r_plafond_cine_avant_3112
-    type: plafonnement
-    texte: "Apports totaux (toutes formes et origines confondues) de 70 kg N/ha\navant l'implantation du couvert d'interculture, dont 50 kg N/ha\nd'azote efficace.\n"
-    code_prescription: pc13
-    plafond_azote_kg_n_ha: 70
-- regle:
-    id: r_plafond_cie_courte
-    type: plafonnement
-    code_prescription: pc15
-    plafond_azote_kg_n_ha: 70
-- regle:
-    id: r_plafond_prairies
-    type: plafonnement
-    texte: "Pour les prairies permanentes, apports à compter de la reprise de\nvégétation (fin février à début mars) plafonnés à 70 kg N/ha par\nsaison.\n"
-    code_prescription: pc16
-    plafond_azote_kg_n_ha: 70
 regles_partagees:
 - regle:
     id: r_cine_courte_types_0_I_II
     type: autorisation_sous_condition
     message: Couvert d'interculture courte non exporté, types 0, I (Ia ou Ib) ou II.
     texte_condition: Apport autorisé.
-    plafonnement_associe: r_plafond_cine_avant_3112
 - regle:
     id: r_cie_courte_types_0_I_II
     type: autorisation_sous_condition
     message: Couvert d'interculture courte exporté (dérobée, CIVE), types 0, I (Ia ou Ib) ou II.
     code_prescription: pc15
     texte_condition: Apport autorisé selon les conditions du PAR.
-    plafonnement_associe: r_plafond_cie_courte

--- a/envergo/nitrates/specs/arbres_actifs/national.yaml
+++ b/envergo/nitrates/specs/arbres_actifs/national.yaml
@@ -307,9 +307,8 @@ arbre:
                 branches:
                 - noeud:
                     id: q_prairie_plus6_type_0_icpe
-                    aide: ''
                     champ: plan_epandage
-                    texte: Votre plan d'épandage est-il soumis à autorisation?
+                    texte: S'agit-il d'un épandage prévu dans le cadre d'un plan d'épandage ICPE soumis à autorisation ?
                     niveau: complement
                     branches:
                     - regle:
@@ -318,7 +317,7 @@ arbre:
                         periodes:
                         - au: 15/01
                           du: 15/12
-                        inputs_requis: []
+                        texte_condition: Autorisé sous condition entre le 15/12 et le 15/01 (ICPE A).
                         code_prescription: pc1
                       valeur: icpe_a
                       libelle: Oui
@@ -336,9 +335,10 @@ arbre:
                     id: r_prairie_plus_6_type_I
                     type: interdiction
                     periodes:
-                    - au: 15/01
-                      du: 15/12
-                    code_prescription: pc4
+                    - du: 15/12
+                      au: 15/01
+                    code_prescription: pc16
+                    inputs_requis: []
                   valeur: type_I
                   libelle: Type I (Ia ou Ib)
                 - noeud:
@@ -414,9 +414,8 @@ arbre:
                   renvoi_vers: q_prairie_plus6_type_0_icpe
                 - noeud:
                     id: q_luzerne_I_icpe
-                    aide: ''
                     champ: plan_epandage
-                    texte: Votre plan d'épandage est-il soumis à autorisation?
+                    texte: S'agit-il d'un épandage prévu dans le cadre d'un plan d'épandage ICPE soumis à autorisation ?
                     niveau: complement
                     branches:
                     - noeud:
@@ -473,9 +472,8 @@ arbre:
                   valeur: type_I
                 - noeud:
                     id: q_luzerne_II_icpe
-                    aide: ''
                     champ: plan_epandage
-                    texte: Votre plan d'épandage est-il soumis à autorisation?
+                    texte: S'agit-il d'un épandage prévu dans le cadre d'un plan d'épandage ICPE soumis à autorisation ?
                     niveau: complement
                     branches:
                     - noeud:
@@ -521,9 +519,8 @@ arbre:
                   valeur: type_II
                 - noeud:
                     id: q_luzerne_III_icpe
-                    aide: ''
                     champ: plan_epandage
-                    texte: Votre plan d'épandage est-il soumis à autorisation?
+                    texte: S'agit-il d'un épandage prévu dans le cadre d'un plan d'épandage ICPE soumis à autorisation ?
                     niveau: complement
                     branches:
                     - noeud:
@@ -788,9 +785,23 @@ arbre:
                         - au: 15/01
                           du: 15/12
                           regime: interdiction
+                        composant: calendrier_dynamique_couvert
+                        inputs_requis:
+                        - id: date_semis_couvert
+                          type: date
+                          label: Date de semis du couvert
+                          label_court: semis
+                          placeholder: 15/08
+                        - id: date_destruction_couvert
+                          max: 31/12
+                          type: date
+                          label: Date de destruction prévue du couvert
+                          label_court: destruction
+                          placeholder: 01/11
+                        texte_condition: Autorisation dans les conditions de la note 1. Sinon interdiction du 15/12 au 15/01.
                         code_prescription: pc13
                       valeur: icpe_a
-                      libelle: Oui, plan d'épandage soumis à autorisation et à étude d'impact ou d'incidence
+                      libelle: Oui, plan d'épandage ICPE soumis à autorisation
                     - noeud:
                         id: q_icpe_ed
                         champ: fertilisant_iaa
@@ -804,6 +815,19 @@ arbre:
                             - au: 15/01
                               du: 15/12
                               regime: interdiction
+                            composant: calendrier_dynamique_couvert
+                            inputs_requis:
+                            - id: date_semis_couvert
+                              type: date
+                              label: Date de semis du couvert
+                              label_court: semis
+                              placeholder: 15/08
+                            - id: date_destruction_couvert
+                              max: 31/12
+                              type: date
+                              label: Date de destruction prévue du couvert
+                              label_court: destruction
+                              placeholder: 01/11
                             code_prescription: pc13
                           valeur: true
                           libelle: Oui
@@ -820,7 +844,7 @@ arbre:
                           libelle: Non
                         type_noeud: formulaire
                       valeur: icpe_ed
-                      libelle: Oui, plan d'épandage soumis à enregistrement ou à déclaration.
+                      libelle: Oui, plan d'épandage ICPE soumis à enregistrement ou à déclaration.
                     - regle:
                         id: r_cine_avant_3112_fertilisant_cine_avant_3112_type_0_icpe_false
                         type: interdiction
@@ -874,7 +898,7 @@ arbre:
                         - pc1
                         - pc13
                       valeur: icpe_a
-                      libelle: Oui, plan d'épandage soumis à autorisation et à étude d'impact ou d'incidence
+                      libelle: Oui, plan d'épandage ICPE soumis à autorisation
                     - noeud:
                         id: q_cine_avant_3112_type_Ia_icpe_ed_q6
                         champ: icpe_ed
@@ -942,7 +966,7 @@ arbre:
                           libelle: Non
                         type_noeud: formulaire
                       valeur: icpe_ed
-                      libelle: Oui, plan d'épandage soumis à enregistrement ou à déclaration.
+                      libelle: Oui, plan d'épandage ICPE soumis à enregistrement ou à déclaration.
                     - regle:
                         id: r_cine_avant_3112_type_Ia_autre
                         type: calculatrice
@@ -1066,7 +1090,7 @@ arbre:
                           libelle: Non
                         type_noeud: formulaire
                       valeur: icpe_a
-                      libelle: Oui, plan d'épandage soumis à autorisation et à étude d'impact ou d'incidence
+                      libelle: Oui, plan d'épandage ICPE soumis à autorisation
                     - noeud:
                         id: q_cine_avant_3112_type_Ib_icpe_ed_q6
                         champ: fertilisant_iaa
@@ -1147,7 +1171,7 @@ arbre:
                           libelle: Non
                         type_noeud: formulaire
                       valeur: icpe_ed
-                      libelle: Oui, plan d'épandage soumis à enregistrement ou à déclaration.
+                      libelle: Oui, plan d'épandage ICPE soumis à enregistrement ou à déclaration.
                     - regle:
                         id: r_cine_avant_3112_type_Ib_non_concerne
                         type: calculatrice
@@ -1325,7 +1349,7 @@ arbre:
                           expression: sous_fertilisant not in ('effluents_peu_charges_elevage', 'effluents_peu_charges_non_elevage')
                         type_noeud: catalogue_parametre
                       valeur: icpe_a
-                      libelle: Oui, plan d'épandage soumis à autorisation et à étude d'impact ou d'incidence
+                      libelle: Oui, plan d'épandage ICPE soumis à autorisation
                     - noeud:
                         id: q_cine_avant_3112_type_II_icpe_ed_effluent
                         champ: effluent_peu_charge_elevage
@@ -1450,7 +1474,7 @@ arbre:
                           expression: sous_fertilisant != 'effluents_peu_charges_elevage'
                         type_noeud: catalogue_parametre
                       valeur: icpe_ed
-                      libelle: Oui, plan d'épandage soumis à enregistrement ou à déclaration.
+                      libelle: Oui, plan d'épandage ICPE soumis à enregistrement ou à déclaration.
                     - noeud:
                         id: q_cine_avant_3112_type_II_non_concerne_effluent
                         champ: effluent_peu_charge_elevage
@@ -1588,7 +1612,7 @@ arbre:
                         - pc1
                         - pc12
                       valeur: icpe_a
-                      libelle: Oui, plan d'épandage soumis à autorisation et à étude d'impact ou d'incidence
+                      libelle: Oui, plan d'épandage ICPE soumis à autorisation
                     - noeud:
                         id: q_ICPE_ED_q6
                         champ: fertilisant_q6
@@ -1642,7 +1666,7 @@ arbre:
                           libelle: Non
                         type_noeud: formulaire
                       valeur: icpe_ed
-                      libelle: Oui, plan d'épandage soumis à enregistrement ou à déclaration.
+                      libelle: Oui, plan d'épandage ICPE soumis à enregistrement ou à déclaration.
                     - regle:
                         id: r_cine_apres_0101_type_0_autre
                         type: interdiction
@@ -1691,11 +1715,12 @@ arbre:
                           label: Date de destruction du couvert
                           label_court: destruction
                           placeholder: 15/01
+                        texte_condition: Autorisé sous condition entre le 15/11 et le 15/01.
                         code_prescription:
                         - pc1
                         - pc12
                       valeur: icpe_a
-                      libelle: Oui, plan d'épandage soumis à autorisation et à étude d'impact ou d'incidence
+                      libelle: Oui, plan d'épandage ICPE soumis à autorisation
                     - noeud:
                         id: q_q
                         champ: q_typeIa_ICPE_ED_q6
@@ -1772,7 +1797,7 @@ arbre:
                           libelle: Non
                         type_noeud: formulaire
                       valeur: icpe_ed
-                      libelle: Oui, plan d'épandage soumis à enregistrement ou à déclaration.
+                      libelle: Oui, plan d'épandage ICPE soumis à enregistrement ou à déclaration.
                     - regle:
                         id: r_cine_apres_0101_type_Ia_autre
                         type: calculatrice
@@ -1810,8 +1835,9 @@ arbre:
                   valeur: type_Ia
                 - noeud:
                     id: q_cine_apres_0101_type_Ib_icpe
+                    aide: ''
                     champ: plan_epandage
-                    texte: Plan d'épandage ?
+                    texte: S'agit-il d'un épandage prévu dans le cadre d'un plan d'épandage ICPE ?
                     niveau: complement
                     branches:
                     - noeud:
@@ -1850,6 +1876,7 @@ arbre:
                               label: Date de destruction du couvert
                               label_court: destruction
                               placeholder: 15/01
+                            texte_condition: Autorisé sous condition entre le 15/11 et le 15/01.
                             code_prescription:
                             - pc2
                             - pc12
@@ -1867,7 +1894,7 @@ arbre:
                           libelle: Non
                         type_noeud: formulaire
                       valeur: icpe_a
-                      libelle: Oui, plan d'épandage soumis à autorisation et à étude d'impact ou d'incidence
+                      libelle: Oui, plan d'épandage ICPE soumis à autorisation
                     - noeud:
                         id: q_cine_apres_0101_type_Ib_icpe_ed_q6
                         champ: fertilisant_iaa
@@ -1946,7 +1973,7 @@ arbre:
                           libelle: Non
                         type_noeud: formulaire
                       valeur: icpe_ed
-                      libelle: Oui, plan d'épandage soumis à enregistrement ou à déclaration.
+                      libelle: Oui, plan d'épandage ICPE soumis à enregistrement ou à déclaration.
                     - regle:
                         id: r_cine_apres_0101_type_Ib_non_concerne
                         type: calculatrice
@@ -2028,6 +2055,7 @@ arbre:
                                   label: Date de destruction du couvert
                                   label_court: destruction
                                   placeholder: 15/01
+                                texte_condition: Autorisé sous condition entre le 15/10 et le 15/01.
                                 code_prescription:
                                 - pc1
                                 - pc12
@@ -2170,6 +2198,7 @@ arbre:
                                       label: Date de destruction du couvert
                                       label_court: destruction
                                       placeholder: 15/01
+                                    texte_condition: Autorisé sous condition entre le 15/10 et le 31/01.
                                     code_prescription:
                                     - pc2
                                     - pc12
@@ -2195,7 +2224,7 @@ arbre:
                         reference: zone_note_5
                         type_noeud: catalogue
                       valeur: icpe_a
-                      libelle: Oui, plan d'épandage soumis à autorisation et à étude d'impact ou d'incidence
+                      libelle: Oui, plan d'épandage ICPE soumis à autorisation
                     - noeud:
                         id: n_cine_apres_0101_type_II_icpe_ed_zone_note_5
                         champ: zone_note_5
@@ -2258,6 +2287,7 @@ arbre:
                                       label: Date de destruction du couvert
                                       label_court: destruction
                                       placeholder: 15/01
+                                    texte_condition: Autorisé sous condition entre le 15/10 et le 15/01.
                                     code_prescription:
                                     - pc3
                                     - pc12
@@ -2284,6 +2314,7 @@ arbre:
                                       label: Date de destruction du couvert
                                       label_court: destruction
                                       placeholder: 15/01
+                                    texte_condition: Interdit du 15/10 au 15/01.
                                     code_prescription:
                                     - pc4
                                     - pc12
@@ -2379,6 +2410,7 @@ arbre:
                                       label: Date de destruction du couvert
                                       label_court: destruction
                                       placeholder: 15/01
+                                    texte_condition: Interdit du 15/10 au 31/01.
                                     code_prescription:
                                     - pc4
                                     - pc12
@@ -2394,7 +2426,7 @@ arbre:
                         reference: zone_note_5
                         type_noeud: catalogue
                       valeur: icpe_ed
-                      libelle: Oui, plan d'épandage soumis à enregistrement ou à déclaration.
+                      libelle: Oui, plan d'épandage ICPE soumis à enregistrement ou à déclaration.
                     - noeud:
                         id: n_cine_apres_0101_type_II_non_concerne_zone_note_5
                         champ: zone_note_5
@@ -2442,6 +2474,7 @@ arbre:
                                   label: Date de destruction du couvert
                                   label_court: destruction
                                   placeholder: 15/01
+                                texte_condition: Interdit du 15/10 au 15/01.
                                 code_prescription:
                                 - pc4
                                 - pc12
@@ -2494,6 +2527,7 @@ arbre:
                                   label: Date de destruction du couvert
                                   label_court: destruction
                                   placeholder: 15/01
+                                texte_condition: Interdit du 15/10 au 31/01.
                                 code_prescription:
                                 - pc4
                                 - pc12
@@ -2564,12 +2598,12 @@ arbre:
                 niveau: type_fertilisant
                 branches:
                 - valeur: type_0
-                  renvoi_vers: r_cie_courte_types_0_I_II
+                  renvoi_vers: r_cine_courte_types_0_I_II
                 - valeur: type_I
                   libelle: Type I (Ia ou Ib)
-                  renvoi_vers: r_cie_courte_types_0_I_II
+                  renvoi_vers: r_cine_courte_types_0_I_II
                 - valeur: type_II
-                  renvoi_vers: r_cie_courte_types_0_I_II
+                  renvoi_vers: r_cine_courte_types_0_I_II
                 - regle:
                     id: r_cine_courte_type_III
                     type: interdiction
@@ -2614,10 +2648,15 @@ plafonnements:
     plafond_azote_kg_n_ha: 70
 regles_partagees:
 - regle:
+    id: r_cine_courte_types_0_I_II
+    type: autorisation_sous_condition
+    message: Couvert d'interculture courte non exporté, types 0, I (Ia ou Ib) ou II.
+    texte_condition: Apport autorisé.
+    plafonnement_associe: r_plafond_cine_avant_3112
+- regle:
     id: r_cie_courte_types_0_I_II
     type: autorisation_sous_condition
-    message: Couvert d'interculture courte, types 0, I (Ia ou Ib) ou II.
-    periodes:
-    - au: 30/06
-      du: 01/07
+    message: Couvert d'interculture courte exporté (dérobée, CIVE), types 0, I (Ia ou Ib) ou II.
     code_prescription: pc15
+    texte_condition: Apport autorisé selon les conditions du PAR.
+    plafonnement_associe: r_plafond_cie_courte

--- a/envergo/nitrates/specs/arbres_actifs/region_32.yaml
+++ b/envergo/nitrates/specs/arbres_actifs/region_32.yaml
@@ -166,10 +166,33 @@ arbre:
                           libelle: Type_II — renvoi PAN culture de printemps type II (légumes implantés avant le 1er juin, non régis par le PAR)
                           noeud_cible: q_printemps_II_fertirrigation
                           renvoi_arbre: national
-                        - valeur: type_III
-                          libelle: Type_III — renvoi PAN culture de printemps type III
-                          noeud_cible: q_printemps_III_irriguee
-                          renvoi_arbre: national
+                        - noeud:
+                            id: q_type_iii
+                            champ: type_iii
+                            texte: Est-ce que votre culture est irriguée?
+                            niveau: complement
+                            branches:
+                            - regle:
+                                id: r_avant_le_1er_juin_type_iii_true
+                                type: interdiction
+                                periodes:
+                                - au: 15/02
+                                  du: 15/07
+                                inputs_requis: []
+                              valeur: true
+                              libelle: Oui
+                            - regle:
+                                id: r_avant_le_1er_juin_type_iii_false
+                                type: interdiction
+                                periodes:
+                                - au: 15/02
+                                  du: 01/07
+                                inputs_requis: []
+                              valeur: false
+                              libelle: Non
+                            type_noeud: formulaire
+                          valeur: type_III
+                          libelle: Type_III
                         type_noeud: formulaire
                       valeur: Avant le 1er juin
                       libelle: Avant le 1er juin
@@ -271,10 +294,10 @@ arbre:
               valeur: cine_apres_0101
               libelle: CINE détruit après le 01/01
             - valeur: cine_courte
-              libelle: Cie_courte
+              libelle: Cine_courte
               renvoi_vers: q_cine_apres_0101
-            - valeur: cie_avant_3112
-              libelle: Cie_avant_3112
+            - valeur: cine_avant_3112
+              libelle: Cine_avant_3112
               renvoi_vers: q_cine_apres_0101
             type_noeud: formulaire
           valeur: couvert_intercultures

--- a/envergo/nitrates/specs/arbres_actifs/region_44.yaml
+++ b/envergo/nitrates/specs/arbres_actifs/region_44.yaml
@@ -81,6 +81,7 @@ arbre:
                                   du: 01/07
                                   regime: autorisation_sous_condition
                                 inputs_requis: []
+                                texte_condition: Autorisé sous condition entre le 01/07 et le 31/08.
                                 code_prescription: pc6
                               valeur: true
                               libelle: Oui
@@ -267,9 +268,8 @@ arbre:
                     branches:
                     - noeud:
                         id: q_luzerne_en_zone_grand_est_1_type_II
-                        aide: ''
                         champ: plan_epandage
-                        texte: Votre plan d'épandage est-il soumis à autorisation ?
+                        texte: S'agit-il d'un épandage prévu dans le cadre d'un plan d'épandage ICPE soumis à autorisation ?
                         niveau: complement
                         branches:
                         - noeud:
@@ -316,9 +316,8 @@ arbre:
                       libelle: Type II
                     - noeud:
                         id: q_luzerne_en_zone_grand_est_1_type_III
-                        aide: ''
                         champ: plan_epandage
-                        texte: Votre plan d'épandage est-il soumis à autorisation ?
+                        texte: S'agit-il d'un épandage prévu dans le cadre d'un plan d'épandage ICPE soumis à autorisation ?
                         niveau: complement
                         branches:
                         - noeud:
@@ -471,9 +470,12 @@ arbre:
                 - noeud:
                     id: q_cine_apres_0101_type_Ib
                     champ: plan_epandage
-                    texte: S'agit-il d'un épandage prévu dans le cadre d'un plan d'épandage soumis à autorisation et à étude d'impact ou d'incidence ?
+                    texte: S'agit-il d'un épandage prévu dans le cadre d'un plan d'épandage ICPE ?
                     niveau: complement
                     branches:
+                    - valeur: icpe_a
+                      libelle: Oui, plan d'épandage ICPE soumis à autorisation
+                      feuille_vide: true
                     - noeud:
                         id: q_cine_apres_0101_type_Ib_icpe_ed
                         champ: fertilisant_iaa
@@ -513,7 +515,7 @@ arbre:
                           feuille_vide: true
                         type_noeud: formulaire
                       valeur: icpe_ed
-                      libelle: Oui, plan d'épandage soumis à enregistrement ou à déclaration.
+                      libelle: Oui, plan d'épandage ICPE soumis à enregistrement ou à déclaration.
                     - regle:
                         id: r_cine_apres_0101_type_Ib_icpe_autre
                         type: calculatrice
@@ -553,7 +555,7 @@ arbre:
                     - noeud:
                         id: q_cine_apres_0101_type_II_hors_note5
                         champ: plan_epandage
-                        texte: S'agit-il d'un épandage prévu dans le cadre d'un plan d'épandage soumis à autorisation et à étude d'impact ou d'incidence ?
+                        texte: S'agit-il d'un épandage prévu dans le cadre d'un plan d'épandage ICPE ?
                         niveau: complement
                         branches:
                         - noeud:
@@ -584,7 +586,7 @@ arbre:
                               expression: categorie_fertilisant == 'digestats'
                             type_noeud: catalogue_parametre
                           valeur: icpe_a
-                          libelle: Oui, plan d'épandage soumis à autorisation et à étude d'impact ou d'incidence
+                          libelle: Oui, plan d'épandage ICPE soumis à autorisation
                         - noeud:
                             id: n_cine_apres_0101_type_II_hors_note5_icpe_ed
                             champ: effluent_peu_charge_elevage
@@ -636,6 +638,7 @@ arbre:
                                         - au: 31/01
                                           du: 16/11
                                           regime: interdiction
+                                        composant: calendrier_dynamique_couvert
                                         inputs_requis: []
                                         code_prescription:
                                         - pc4
@@ -655,7 +658,7 @@ arbre:
                               expression: sous_fertilisant !='effluents_peu_charges_elevage'
                             type_noeud: catalogue_parametre
                           valeur: icpe_ed
-                          libelle: Oui, plan d'épandage soumis à enregistrement ou à déclaration.
+                          libelle: Oui, plan d'épandage ICPE soumis à enregistrement ou à déclaration.
                         - noeud:
                             id: n_cine_apres_0101_type_II_hors_note5_icpe_autre
                             champ: effluent_peu_charge_elevage
@@ -701,6 +704,19 @@ arbre:
                                     - au: 31/01
                                       du: 16/11
                                       regime: interdiction
+                                    composant: calendrier_dynamique_couvert
+                                    inputs_requis:
+                                    - id: date_semis_couvert
+                                      type: date
+                                      label: Date de semis du couvert
+                                      label_court: semis
+                                      placeholder: 15/08
+                                    - id: date_destruction_couvert
+                                      max: 31/12
+                                      type: date
+                                      label: Date de destruction du couvert
+                                      label_court: destruction
+                                      placeholder: 15/03
                                     code_prescription:
                                     - pc12
                                     - pc4
@@ -735,11 +751,13 @@ arbre:
                 branches:
                 - noeud:
                     id: q_cine_avant_3112_type_Ib
-                    aide: ''
                     champ: plan_epandage
-                    texte: S'agit-il d'un épandage prévu dans le cadre d'un plan d'épandage soumis enregistrement ou déclaration?
+                    texte: S'agit-il d'un épandage prévu dans le cadre d'un plan d'épandage ICPE ?
                     niveau: complement
                     branches:
+                    - valeur: icpe_a
+                      libelle: Oui, plan d'épandage ICPE soumis à autorisation
+                      feuille_vide: true
                     - noeud:
                         id: q_cine_avant_3112_type_Ib_icpe_ed
                         champ: fertilisant_iaa
@@ -786,7 +804,7 @@ arbre:
                           feuille_vide: true
                         type_noeud: formulaire
                       valeur: icpe_ed
-                      libelle: Oui, plan d'épandage soumis à enregistrement ou à déclaration.
+                      libelle: Oui, plan d'épandage ICPE soumis à enregistrement ou à déclaration.
                     - regle:
                         id: r_cine_avant_3112_type_Ib_pas_digestats
                         type: calculatrice
@@ -829,7 +847,7 @@ arbre:
                 - noeud:
                     id: q_cine_avant_3112_type_II
                     champ: plan_epandage
-                    texte: S'agit-il d'un épandage prévu dans le cadre d'un plan d'épandage soumis à autorisation et à étude d'impact ou d'incidence ?
+                    texte: S'agit-il d'un épandage prévu dans le cadre d'un plan d'épandage ICPE ?
                     niveau: complement
                     branches:
                     - noeud:
@@ -869,7 +887,7 @@ arbre:
                           expression: categorie_fertilisant == 'digestats'
                         type_noeud: catalogue_parametre
                       valeur: icpe_a
-                      libelle: Oui, plan d'épandage soumis à autorisation et à étude d'impact ou d'incidence
+                      libelle: Oui, plan d'épandage ICPE soumis à autorisation
                     - noeud:
                         id: n_cine_avant_3112_type_II_icpe_ed
                         champ: effluent_peu_charge_elevage
@@ -896,6 +914,7 @@ arbre:
                                 - au: 30/06
                                   du: 16/11
                                   regime: interdiction
+                                  condition: date_destruction_couvert-20jours > 16/11
                                 composant: calendrier_dynamique_couvert
                                 inputs_requis:
                                 - id: date_semis_couvert
@@ -970,7 +989,7 @@ arbre:
                           expression: sous_fertilisant != 'effluents_peu_charges_elevage'
                         type_noeud: catalogue_parametre
                       valeur: icpe_ed
-                      libelle: Oui, plan d'épandage soumis à enregistrement ou à déclaration.
+                      libelle: Oui, plan d'épandage ICPE soumis à enregistrement ou à déclaration.
                     - noeud:
                         id: n_cine_avant_3112_type_II_icpe_autre
                         champ: effluent_peu_charge_elevage

--- a/envergo/nitrates/specs/arbres_actifs/zar_44.yaml
+++ b/envergo/nitrates/specs/arbres_actifs/zar_44.yaml
@@ -121,6 +121,9 @@ arbre:
                     texte: S'agit-il d'un épandage prévu dans le cadre d'un plan d'épandage ICPE ?
                     niveau: complement
                     branches:
+                    - valeur: icpe_a
+                      libelle: Oui, plan d'épandage ICPE soumis à autorisation
+                      feuille_vide: true
                     - noeud:
                         id: q_couvert_interculture_cine_apres_0101_type_Ia_icpe_ed
                         champ: fertilisant_iaa
@@ -147,7 +150,7 @@ arbre:
                           libelle: Non
                         type_noeud: formulaire
                       valeur: icpe_ed
-                      libelle: Oui, plan d'épandage soumis à enregistrement ou à déclaration.
+                      libelle: Oui, plan d'épandage ICPE soumis à enregistrement ou à déclaration.
                     - regle:
                         id: r_couvert_interculture_cine_apres_0101_type_Ia_icpe_autre
                         type: interdiction
@@ -155,17 +158,21 @@ arbre:
                         - au: 15/01
                           du: 15/11
                         code_prescription: pc12
-                      valeur: non_concerne
+                      valeur: icpe_autre
                       libelle: Non concerné
                     type_noeud: formulaire
                   valeur: type_Ia
                   libelle: Type Ia
                 - noeud:
                     id: q_couvert_interculture_cine_apres_0101_type_Ib
+                    aide: ''
                     champ: plan_epandage
-                    texte: S'agit-il d'un épandage prévu dans le cadre d'un plan d'épandage soumis à autorisation et à étude d'impact ou d'incidence ?
+                    texte: S'agit-il d'un épandage prévu dans le cadre d'un plan d'épandage ICPE ?
                     niveau: complement
                     branches:
+                    - valeur: icpe_a
+                      libelle: Oui, plan d'épandage ICPE soumis à autorisation
+                      feuille_vide: true
                     - noeud:
                         id: q_couvert_interculture_cine_apres_0101_type_Ib_icpe_ed
                         champ: fertilisant_iaa
@@ -186,7 +193,7 @@ arbre:
                           feuille_vide: true
                         type_noeud: formulaire
                       valeur: icpe_ed
-                      libelle: Oui, plan d'épandage soumis à enregistrement ou à déclaration.
+                      libelle: Oui, plan d'épandage ICPE soumis à enregistrement ou à déclaration.
                     - regle:
                         id: r_couvert_interculture_cine_apres_0101_type_Ib_icpe_autre
                         type: interdiction
@@ -194,17 +201,21 @@ arbre:
                         - au: 15/01
                           du: 15/11
                         code_prescription: pc12
-                      valeur: non_concerne
+                      valeur: icpe_autre
                       libelle: Non concerné
                     type_noeud: formulaire
                   valeur: type_Ib
                   libelle: Type Ib
                 - noeud:
                     id: q_couvert_interculture_cine_apres_0101_type_II
+                    aide: ''
                     champ: plan_epandage
-                    texte: S'agit-il d'un épandage prévu dans le cadre d'un plan d'épandage soumis à autorisation et à étude d'impact ou d'incidence ?
+                    texte: S'agit-il d'un épandage prévu dans le cadre d'un plan d'épandage ICPE ?
                     niveau: complement
                     branches:
+                    - valeur: icpe_a
+                      libelle: Oui, plan d'épandage ICPE soumis à autorisation
+                      feuille_vide: true
                     - noeud:
                         id: n_couvert_interculture_cine_apres_0101_type_II_icpe_ed
                         champ: zone_note_5
@@ -273,7 +284,7 @@ arbre:
                         reference: zone_note_5
                         type_noeud: catalogue
                       valeur: icpe_ed
-                      libelle: Oui, plan d'épandage soumis à enregistrement ou à déclaration.
+                      libelle: Oui, plan d'épandage ICPE soumis à enregistrement ou à déclaration.
                     - noeud:
                         id: n_couvert_interculture_cine_apres_0101_type_II_icpe_autre
                         champ: zone_note_5
@@ -329,7 +340,7 @@ arbre:
                           libelle: Pas concerné par la note 5
                         reference: zone_note_5
                         type_noeud: catalogue
-                      valeur: non_concerne
+                      valeur: icpe_autre
                       libelle: Non concerné
                     type_noeud: formulaire
                   valeur: type_II
@@ -348,10 +359,14 @@ arbre:
                 branches:
                 - noeud:
                     id: q_couvert_interculture_cine_avant_3112_type_Ia
+                    aide: ''
                     champ: plan_epandage
                     texte: S'agit-il d'un épandage prévu dans le cadre d'un plan d'épandage ICPE ?
                     niveau: complement
                     branches:
+                    - valeur: icpe_a
+                      libelle: Oui, plan d'épandage ICPE soumis à autorisation
+                      feuille_vide: true
                     - noeud:
                         id: q_couvert_interculture_cine_avant_3112_type_Ia_icpe_ed
                         champ: fertilisant_iaa
@@ -363,15 +378,15 @@ arbre:
                             type: calculatrice
                             periodes:
                             - au: 15/01
-                              du: date_destruction_couvert-20jours
+                              du: date_destruction_prevue-20jours
                               regime: interdiction
-                              condition: date_destruction_couvert-20jours < 15/01
+                              condition: date_destruction_prevue-20jours < 15/01
                             - au: 15/01
                               du: 15/11
                               regime: interdiction
                             composant: calendrier_dynamique_couvert
                             inputs_requis:
-                            - id: date_destruction_couvert
+                            - id: date_destruction_prevue
                               max: 31/12
                               type: date
                               label: Date de destruction prévue
@@ -385,38 +400,42 @@ arbre:
                           feuille_vide: true
                         type_noeud: formulaire
                       valeur: icpe_ed
-                      libelle: Oui, plan d'épandage soumis à enregistrement ou à déclaration.
+                      libelle: Oui, plan d'épandage ICPE soumis à enregistrement ou à déclaration.
                     - regle:
                         id: r_couvert_interculture_cine_avant_3112_type_Ia_icpe_autre
                         type: calculatrice
                         periodes:
                         - au: 15/01
-                          du: date_destruction_couvert-20jours
+                          du: date_destruction_prevue-20jours
                           regime: interdiction
-                          condition: date_destruction_couvert-20jours < 15/01
+                          condition: date_destruction_prevue-20jours < 15/01
                         - au: 15/01
                           du: 15/11
                           regime: interdiction
                         composant: calendrier_dynamique_couvert
                         inputs_requis:
-                        - id: date_destruction_couvert
+                        - id: date_destruction_prevue
                           max: 31/12
                           type: date
                           label: Date de destruction prévue
                           label_court: destruction
                           placeholder: 15/03
                         code_prescription: pc13
-                      valeur: non_concerne
+                      valeur: icpe_autre
                       libelle: Non concerné
                     type_noeud: formulaire
                   valeur: type_Ia
                   libelle: Type Ia
                 - noeud:
                     id: q_couvert_interculture_cine_avant_3112_type_Ib
+                    aide: ''
                     champ: plan_epandage
-                    texte: S'agit-il d'un épandage prévu dans le cadre d'un plan d'épandage soumis à autorisation et à étude d'impact ou d'incidence ?
+                    texte: S'agit-il d'un épandage prévu dans le cadre d'un plan d'épandage ICPE ?
                     niveau: complement
                     branches:
+                    - valeur: icpe_a
+                      libelle: Oui, plan d'épandage ICPE soumis à autorisation
+                      feuille_vide: true
                     - noeud:
                         id: q_couvert_interculture_cine_avant_3112_type_Ib_icpe_ed
                         champ: fertilisant_iaa
@@ -458,7 +477,7 @@ arbre:
                           feuille_vide: true
                         type_noeud: formulaire
                       valeur: icpe_ed
-                      libelle: Oui, plan d'épandage soumis à enregistrement ou à déclaration.
+                      libelle: Oui, plan d'épandage ICPE soumis à enregistrement ou à déclaration.
                     - regle:
                         id: r_couvert_interculture_cine_avant_3112_type_Ib_icpe_autre
                         type: calculatrice
@@ -487,17 +506,21 @@ arbre:
                           label_court: destruction
                           placeholder: 01/11
                         code_prescription: pc13
-                      valeur: non_concerne
+                      valeur: icpe_autre
                       libelle: Non concerné
                     type_noeud: formulaire
                   valeur: type_Ib
                   libelle: Type Ib
                 - noeud:
                     id: q_couvert_interculture_cine_avant_3112_type_II
+                    aide: ''
                     champ: plan_epandage
-                    texte: S'agit-il d'un épandage prévu dans le cadre d'un plan d'épandage soumis à autorisation et à étude d'impact ou d'incidence ?
+                    texte: S'agit-il d'un épandage prévu dans le cadre d'un plan d'épandage ICPE ?
                     niveau: complement
                     branches:
+                    - valeur: icpe_a
+                      libelle: Oui, plan d'épandage ICPE soumis à autorisation
+                      feuille_vide: true
                     - noeud:
                         id: n_couvert_interculture_cine_avant_3112_type_II_icpe_ed
                         champ: n_cine_avant3112_type_ii_icpe_ed
@@ -586,7 +609,7 @@ arbre:
                           expression: sous_fertilisant !='effluents_peu_charges_elevage'
                         type_noeud: catalogue_parametre
                       valeur: icpe_ed
-                      libelle: Oui, plan d'épandage soumis à enregistrement ou à déclaration.
+                      libelle: Oui, plan d'épandage ICPE soumis à enregistrement ou à déclaration.
                     - noeud:
                         id: n_couvert_interculture_cine_avant_3112_type_II_icpe_autre
                         champ: effluent_peu_charge_elevage
@@ -604,14 +627,14 @@ arbre:
                                   regime: interdiction
                                   condition: 01/07 < date_semis_couvert-15jours
                                 - au: 30/06
-                                  du: date_destruction_couvert-20jours
+                                  du: date_destruction_prevue-20jours
                                   regime: interdiction
                                 - au: 30/06
                                   du: 15/10
                                   regime: interdiction
                                 composant: calendrier_dynamique_couvert
                                 inputs_requis:
-                                - id: date_destruction_couvert
+                                - id: date_destruction_prevue
                                   max: 31/12
                                   type: date
                                   label: Date de destruction prévue
@@ -635,14 +658,14 @@ arbre:
                                   regime: interdiction
                                   condition: 01/07 < date_semis_couvert-15jours
                                 - au: 31/01
-                                  du: date_destruction_couvert-20jours
+                                  du: date_destruction_prevue-20jours
                                   regime: interdiction
                                 - au: 31/01
                                   du: 15/10
                                   regime: interdiction
                                 composant: calendrier_dynamique_couvert
                                 inputs_requis:
-                                - id: date_destruction_couvert
+                                - id: date_destruction_prevue
                                   max: 31/12
                                   type: date
                                   label: Date de destruction prévue
@@ -661,7 +684,7 @@ arbre:
                           valeur: 'False'
                           expression: sous_fertilisant !='effluents_peu_charges_elevage'
                         type_noeud: catalogue_parametre
-                      valeur: non_concerne
+                      valeur: icpe_autre
                       libelle: Non concerné
                     type_noeud: formulaire
                   valeur: type_II


### PR DESCRIPTION
Réalignement des données métier entre staging, dev et le repo, après audit systématique (arbres, codes de prescription, référentiels, feuilles de validation).

**Arbres** — les 4 arbres versionnés sont redumpés depuis l'état validé : question complémentaire "culture irriguée" du PAR Hauts-de-France, correction des libellés CIE/CINE, travail ICPE du 27/07. Sans ce redump, chaque déploiement rechargeait une version antérieure et écrasait les corrections faites en base.

**Plafonds d'azote** — la section `plafonnements` et les 3 `plafonnement_associe` sont retirés de l'arbre national : ils affichaient un encart "Plafond d'azote 70 kg N/ha" non voulu sur les parcours couvert. L'information passe par le code de prescription associé. Les 3 autres arbres n'en contenaient pas.

**PC4** — le principe est reformulé sur les effluents d'élevage (note 3 du PAN) au lieu des fertilisants issus d'activités agroalimentaires, en conservant les sous-items (durée/période du couvert, plafonnement).

Vérifié : les 4 arbres se rechargent sans erreur de validation, aucune référence orpheline, et la comparaison structurelle avec les versions archivées confirme qu'aucun nœud ni règle métier n'est perdu.