### PR TITLE
nitrates(front): #335 — sol non cultivé en 1ère question + nouvel intitulé Q1

### DIFF
--- a/e2e/nitrates/refactor_272_flow_couvert.spec.ts
+++ b/e2e/nitrates/refactor_272_flow_couvert.spec.ts
@@ -134,16 +134,28 @@ test('#272 date-picker : le calendrier s ouvre et un jour est cliquable (fix cli
   expect(await hidden(page, 'id_date_semis_couvert')).toBe(v);
 });
 
-test('#272 label sol_non_cultivé porte la parenthèse explicative', async ({ page }) => {
+test('#335 label sol_non_cultivé (option Q1) porte la parenthèse explicative', async ({ page }) => {
   await page.goto(`/simulateur/?lng=${REIMS_LNG}&lat=${REIMS_LAT}`);
   await page.waitForLoadState('networkidle');
-  await pickFlow(page, 'cflow_destination', 2); // culture principale
-  const dernier = page.locator('#q_type_couvert label').last();
+  // #335 : sol non cultivé est une réponse de Q1 (dernière option), plus de Q2.
+  const dernier = page.locator('#q_destination_epandage label').last();
   await expect(dernier).toContainText('Sol non cultivé');
   await expect(dernier).toContainText('surface non utilisée en vue d');
 });
 
-test('#272 culture principale : Q2 5 catégories, sol_non_cultivé en bas, Q3 précision', async ({ page }) => {
+test('#335 Q1 a 5 réponses (dont sol non cultivé en dernier)', async ({ page }) => {
+  await page.goto(`/simulateur/?lng=${REIMS_LNG}&lat=${REIMS_LAT}`);
+  await page.waitForLoadState('networkidle');
+  // Intitulé Q1 mis à jour par la carte #335.
+  await expect(page.locator('#q_destination_epandage-wrapper')).toContainText(
+    "Sur quelle culture ou couvert prévoyez-vous d'épandre",
+  );
+  const labels = await page.locator('#q_destination_epandage label').allTextContents();
+  expect(labels.length).toBe(5);
+  expect(labels[labels.length - 1].toLowerCase()).toContain('sol non cultiv');
+});
+
+test('#335 culture principale : Q2 4 catégories (sans sol non cultivé), Q3 précision', async ({ page }) => {
   await page.goto(`/simulateur/?lng=${REIMS_LNG}&lat=${REIMS_LAT}`);
   await page.waitForLoadState('networkidle');
 
@@ -155,10 +167,10 @@ test('#272 culture principale : Q2 5 catégories, sol_non_cultivé en bas, Q3 pr
     'Quelle catégorie de culture principale',
   );
 
-  // Q2 culture : 5 options, dernière = sol_non_cultivé.
+  // #335 : Q2 culture = 4 options, sol non cultivé n'y est PLUS (remonté en Q1).
   const labels = await page.locator('#q_type_couvert label').allTextContents();
-  expect(labels.length).toBe(5);
-  expect(labels[labels.length - 1].toLowerCase()).toContain('sol non cultiv');
+  expect(labels.length).toBe(4);
+  expect(labels.join(' ').toLowerCase()).not.toContain('sol non cultiv');
 
   // On choisit culture d'hiver (index 0) -> Q3 précision (colza / autre).
   await pickFlow(page, 'cflow_type_couvert', 0);
@@ -200,14 +212,15 @@ test('#272 page résultat : dates dégagées du form gauche, bandeau + titre + l
   expect(labels).toContain('Date de destruction du couvert');
 });
 
-test('#272 sol non cultivé : pas de Q3 précision, occupation_sol résolu direct', async ({ page }) => {
+test('#335 sol non cultivé : réponse Q1 directe, pas de Q2 ni Q3, occupation_sol résolu', async ({ page }) => {
   await page.goto(`/simulateur/?lng=${REIMS_LNG}&lat=${REIMS_LAT}`);
   await page.waitForLoadState('networkidle');
 
-  await pickFlow(page, 'cflow_destination', 2); // culture principale
-  await pickFlow(page, 'cflow_type_couvert', 4); // sol_non_cultivé (dernier)
-  // Pas de question précision.
+  await pickFlow(page, 'cflow_destination', 4); // sol non cultivé (dernière option Q1)
+  // Aucune 2ᵉ question ne s'affiche (ni type couvert/catégorie, ni précision).
+  expect(await estVisible(page, '#q_type_couvert-wrapper')).toBeFalsy();
   expect(await estVisible(page, '#q_sous_culture-wrapper')).toBeFalsy();
+  // Le champ occupation_sol est résolu directement par la cascade.
   expect(await hidden(page, 'id_occupation_sol')).toBe('sol_non_cultive');
 });
 

--- a/envergo/static/nitrates/question_couvert_flow.js
+++ b/envergo/static/nitrates/question_couvert_flow.js
@@ -56,7 +56,6 @@
     "culture_printemps",
     "prairies_ou_luzerne",
     "autres_cultures_principales",
-    "sol_non_cultive",
   ];
 
   // Libellés surchargés côté flow (#272) sans toucher aux référentiels : la
@@ -75,6 +74,10 @@
       val: "culture_principale",
       label: "Juste avant l'implantation d'une culture principale",
     },
+    // #335 : « sol_non_cultive » remonté de Q2 vers Q1. Court-circuite Q2 (pas
+    // de sous-question), on pilote directement categorie_culture (cf.
+    // onChangeDestination). Libellé surchargé (parenthèse explicative).
+    { val: "sol_non_cultive", label: LABELS_CULTURE_OVERRIDE.sol_non_cultive },
   ];
 
   // Q3 — axe récolté (détermine CIE vs CINE).
@@ -291,8 +294,14 @@
     cacher("q_type_couvert");
     cacher("q_couvert_recolte");
     cacher("q_dates_couvert");
+    cacher("q_sous_culture");
 
-    if (val === "couvert") {
+    if (val === "sol_non_cultive") {
+      // #335 : sol non cultivé n'a pas de 2ᵉ question. On pilote directement le
+      // champ cascade categorie_culture -> cascade.js résout occupation_sol=
+      // sol_non_cultive et court-circuite vers le fertilisant. Q2 reste cachée.
+      pilotherCascade("categorie_culture", "sol_non_cultive");
+    } else if (val === "couvert") {
       rendreQ2Couvert();
       montrer("q_type_couvert");
     } else {
@@ -849,6 +858,17 @@
       .forEach(function (r) {
         r.checked = false;
       });
+    // #335 : si la destination précédente était « sol non cultivé », le vrai
+    // champ cascade categorie_culture porte encore sol_non_cultive (pas de Q2
+    // pour le décocher). On le décoche ici pour repartir propre au changement
+    // de Q1 ; cascade.js réagit au change et remet la suite à zéro.
+    var solRadio = document.querySelector(
+      'input[type="radio"][name="categorie_culture"][value="sol_non_cultive"]'
+    );
+    if (solRadio && solRadio.checked) {
+      solRadio.checked = false;
+      solRadio.dispatchEvent(new Event("change", { bubbles: true }));
+    }
     resetApresType();
   }
 
@@ -916,6 +936,12 @@
     var initial = window.NITRATES_INITIAL_DATA || {};
     var cat = initial.categorie_culture;
     if (!cat) return;
+    // #335 : sol non cultivé est désormais une réponse de Q1 (pas de Q2). On
+    // recoche l'option Q1 correspondante et on s'arrête là.
+    if (cat === "sol_non_cultive") {
+      cocherFlow("cflow_destination", "sol_non_cultive");
+      return;
+    }
     var estCouvert =
       cat === "couvert_intercultures_longue" ||
       cat === "couvert_intercultures_courte";

--- a/envergo/templates/nitrates/fragments/_panneau_form.html
+++ b/envergo/templates/nitrates/fragments/_panneau_form.html
@@ -227,7 +227,7 @@ questions/résultat. djLint (H025) croit à tort le <form> orphelin à cause des
 
           {# Q1 — destination de l'épandage (regroupement UI front, 4 réponses -> 2 familles) #}
           <div class="form-question-group" id="q_destination_epandage-wrapper">
-            <p class="form-question-text">Vous avez prévu d'épandre&nbsp;? *</p>
+            <p class="form-question-text">Sur quelle culture ou couvert prévoyez-vous d'épandre&nbsp;? *</p>
             <div id="q_destination_epandage" class="couvert-flow__group"></div>
           </div>
 


### PR DESCRIPTION
Carte #335 : réagencement de la 1ère question du parcours culture/couvert.

### Changements
- **Intitulé de la 1ère question** : « Vous avez prévu d'épandre ? » → **« Sur quelle culture ou couvert prévoyez-vous d'épandre ? »**. Le titre de section reste « Culture ou couvert ».
- **« Sol non cultivé » remonté en 1ère question** : c'est désormais la dernière réponse de Q1 (avec sa parenthèse explicative), au lieu d'être une catégorie de la 2ème question. Il court-circuite la Q2 : on résout directement `occupation_sol=sol_non_cultive` et on enchaîne sur le fertilisant.
- La 2ème question « catégorie de culture principale » ne liste plus que 4 catégories.

### Nature
100 % front (flow JS `question_couvert_flow.js` + template). **Aucun changement d'arbre ni de référentiels.**

### Tests
Tests e2e du flow couvert mis à jour (#335) et repassés : 12/12 verts (4 nouveaux #335 + 8 existants #272).

Note : un test préexistant du même fichier (`#272 result page : changer une question du flow invalide le résultat`) échoue déjà sur `main`, indépendamment de cette PR (à investiguer séparément).
