### PR TITLE
nitrates: tracking Matomo du simulateur + 4 compteurs métier

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -393,6 +393,12 @@ ANALYTICS = {
         "SITE_ID": env("DJANGO_HAIE_SITE_ID", default=""),
         "SECURITY_TOKEN": env("DJANGO_HAIE_MATOMO_SECURITY_TOKEN", default=""),
     },
+    "NITRATES": {
+        "TRACKER_ENABLED": env("DJANGO_NITRATES_TRACKER_ENABLED", default=False),
+        "TRACKER_URL": env("DJANGO_NITRATES_TRACKER_URL", default=""),
+        "SITE_ID": env("DJANGO_NITRATES_SITE_ID", default=""),
+        "SECURITY_TOKEN": env("DJANGO_NITRATES_MATOMO_SECURITY_TOKEN", default=""),
+    },
 }
 
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"

--- a/envergo/static/nitrates/nitrates_analytics.js
+++ b/envergo/static/nitrates/nitrates_analytics.js
@@ -1,0 +1,77 @@
+// Tracking metier nitrates -> Matomo (events trackEvent).
+//
+// Le tag Matomo lui-meme (visites, rebond, devices, navigateurs) est injecte
+// par _analytics.html des que ANALYTICS["NITRATES"].TRACKER_ENABLED est vrai ;
+// ce module n'ajoute QUE les 4 compteurs metier demandes, en events Matomo :
+//
+//   Categorie "Simulateur"
+//     - RechercheCommune     : l'utilisateur a choisi une commune via la
+//                              recherche (autocomplete BAN).
+//     - SelectionPointCarte  : l'utilisateur a clique DIRECTEMENT sur la carte
+//                              (hors selection via la recherche de commune).
+//     - SimulationLancee     : l'utilisateur a soumis le formulaire (clic
+//                              "Lancer la simulation").
+//     - Simulation2Plus      : l'utilisateur a lance AU MOINS 2 simulations
+//                              (compteur persistant par navigateur).
+//
+// Les events sont emis par simulator.js via des CustomEvent (couplage faible :
+// pas de dependance a Matomo dans la logique carte/form). Ici on ecoute ces
+// events et on relaie vers _paq. sendBeacon garantit que l'event part meme
+// juste avant le full-reload GET de la soumission.
+(function () {
+  "use strict";
+
+  var _paq = (window._paq = window._paq || []);
+
+  // Fiabilise l'envoi juste avant une navigation (submit = GET full-reload) :
+  // Matomo bascule sur navigator.sendBeacon au lieu d'une image bloquante.
+  _paq.push(["alwaysUseSendBeacon"]);
+
+  function track(action, name) {
+    // name optionnel (ex: departement). Categorie fixe "Simulateur".
+    if (name === undefined) {
+      _paq.push(["trackEvent", "Simulateur", action]);
+    } else {
+      _paq.push(["trackEvent", "Simulateur", action, name]);
+    }
+  }
+
+  document.addEventListener("nitrates:recherche-commune", function () {
+    track("RechercheCommune");
+  });
+
+  document.addEventListener("nitrates:point-carte", function () {
+    track("SelectionPointCarte");
+  });
+
+  // "Lancer la simulation" : compteur persistant pour derouler le "2+".
+  // localStorage survit aux full-reload GET du parcours et aux sessions ; c'est
+  // ce qui permet de compter un utilisateur qui revient lancer une 2e simu.
+  var STORAGE_KEY = "nitrates_nb_simulations";
+
+  document.addEventListener("nitrates:simulation-lancee", function (e) {
+    var dept = (e && e.detail && e.detail.department) || undefined;
+    track("SimulationLancee", dept);
+
+    var n = 0;
+    try {
+      n = parseInt(window.localStorage.getItem(STORAGE_KEY) || "0", 10) || 0;
+    } catch (err) {
+      // localStorage indisponible (navigation privee stricte) : on degrade
+      // sans casser, on ne pourra juste pas deriver le "2+" pour ce visiteur.
+      n = 0;
+    }
+    n += 1;
+    try {
+      window.localStorage.setItem(STORAGE_KEY, String(n));
+    } catch (err) {
+      /* no-op */
+    }
+    // On emet Simulation2Plus UNE SEULE fois, au passage a la 2e simulation,
+    // pour un compteur "au moins 2 simulations" propre (pas incremente a
+    // chaque simu au-dela de 2).
+    if (n === 2) {
+      track("Simulation2Plus");
+    }
+  });
+})();

--- a/envergo/static/nitrates/simulator.js
+++ b/envergo/static/nitrates/simulator.js
@@ -571,6 +571,13 @@
   map.on("click", function (e) {
     const { lat, lng } = e.latlng;
 
+    // Analytics (#Matomo) : ne compter que les clics carte REELS. selectCommune
+    // rejoue ce handler via map.fire(...) sans originalEvent -> on l'exclut ici
+    // (il est deja compte comme "RechercheCommune").
+    if (e.originalEvent) {
+      document.dispatchEvent(new CustomEvent("nitrates:point-carte"));
+    }
+
     // Pre-remplit le form -- c'est l'objectif principal de cette page.
     lngInput.value = lng.toFixed(6);
     latInput.value = lat.toFixed(6);
@@ -766,6 +773,8 @@
       // exactement quelle commune (parmi les homonymes) a ete retenue.
       searchInput.value = libelleSuggestion(feature.properties || {});
       closeSearch();
+      // Analytics (#Matomo) : l'utilisateur a utilise la recherche de commune.
+      document.dispatchEvent(new CustomEvent("nitrates:recherche-commune"));
       // Une fois le form revele (apres le reverse-geocode async), on deplace le
       // focus sur le 1er radio de la 1re question (Carte #154, a11y) : Max veut
       // qu'apres selection d'une ville, Tab/Entree operent directement sur le
@@ -863,6 +872,25 @@
       }
     });
   }
+
+  // Analytics (#Matomo) : "Lancer la simulation" = submit du formulaire (le
+  // parcours est un GET full-reload). On emet l'event AVANT la navigation ;
+  // sendBeacon (cf. nitrates_analytics.js) garantit qu'il parte. On enrichit
+  // avec le departement (2 premiers chiffres du code INSEE) quand il est connu.
+  (function trackSimulationSubmit() {
+    const form = document.getElementById("form-simulateur");
+    if (!form) return;
+    form.addEventListener("submit", function () {
+      const insee =
+        (document.getElementById("id_code_insee") || {}).value || "";
+      const department = insee ? insee.slice(0, 2) : undefined;
+      document.dispatchEvent(
+        new CustomEvent("nitrates:simulation-lancee", {
+          detail: { department: department },
+        })
+      );
+    });
+  })();
 
   // #271 : au chargement d'une PAGE RÉSULTAT, on établit le scope de RÉFÉRENCE
   // en interrogeant DebugView pour le point du résultat (lat/lng des hidden).

--- a/envergo/templates/nitrates/simulateur.html
+++ b/envergo/templates/nitrates/simulateur.html
@@ -53,6 +53,9 @@
   </script>
   {# static_v : ?v=<mtime> en DEBUG pour casser le cache navigateur du JS (sinon #}
   {# dev server + cache servent une version perimee malgre hard-refresh). #}
+  {# Tracking metier -> Matomo (recherche commune, point carte, simulation, 2+). #}
+  {# Charge avant simulator.js pour que ses listeners d'events soient prets. #}
+  <script defer src="{% static_v 'nitrates/nitrates_analytics.js' %}"></script>
   <script defer src="{% static_v 'nitrates/simulator.js' %}"></script>
   <script defer src="{% static_v 'nitrates/cascade.js' %}"></script>
   {# Barre de progression du parcours, fixee top (#154). #}

--- a/envergo/utils/context_processors.py
+++ b/envergo/utils/context_processors.py
@@ -26,11 +26,12 @@ def settings_context(_request):
             else settings.CRISP["AMENAGEMENT"]["CHATBOX_ENABLED"]
         )
 
-    analytics = (
-        settings.ANALYTICS["HAIE"]
-        if _request.site.domain == settings.ENVERGO_HAIE_DOMAIN
-        else settings.ANALYTICS["AMENAGEMENT"]
-    )
+    if _request.site.domain == settings.ENVERGO_HAIE_DOMAIN:
+        analytics = settings.ANALYTICS["HAIE"]
+    elif _request.site.domain == settings.ENVERGO_NITRATES_DOMAIN:
+        analytics = settings.ANALYTICS["NITRATES"]
+    else:
+        analytics = settings.ANALYTICS["AMENAGEMENT"]
 
     crisp_website_id = (
         settings.CRISP["HAIE"]["WEBSITE_ID"]


### PR DESCRIPTION
Active l'analytics Matomo pour le produit nitrates et ajoute 4 compteurs métier demandés pour le suivi d'usage du simulateur.

## Ce que ça fait

- Configuration `ANALYTICS["NITRATES"]` dédiée + résolution du bon site Matomo selon le domaine (branche NITRATES dans le context processor, qui tombait avant sur la config Aménagement).
- Le tag Matomo standard couvre visites, taux de rebond, devices et navigateurs (rien à configurer côté serveur).
- 4 compteurs métier en events Matomo (catégorie `Simulateur`), via un module dédié `nitrates_analytics.js` relayé par des CustomEvent émis dans `simulator.js` :
  - `RechercheCommune` : recherche / sélection d'une commune (autocomplete BAN)
  - `SelectionPointCarte` : clic direct sur la carte (exclut les clics issus de la recherche)
  - `SimulationLancee` : soumission du formulaire (+ département)
  - `Simulation2Plus` : au moins 2 simulations lancées (compteur localStorage)

## Notes

- Les events ne nécessitent aucune configuration serveur Matomo (créés à la volée). `sendBeacon` garantit l'envoi avant le full-reload GET de la soumission.
- Activation par le flag `DJANGO_NITRATES_TRACKER_ENABLED` (env var, géré dans l'IaC pour staging et prod).
- Déjà déployé sur staging et prod en amont de cette PR pour répondre au besoin de mesure immédiat ; cette PR le remet dans le flux normal de montée de code.