### PR TITLE
ops: CD staging/prod par release GitHub + e2e en gate + rollback 1 clic

### DIFF
--- a/.github/scripts/deploy_release_code.sh
+++ b/.github/scripts/deploy_release_code.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# DEPLOY CODE (staging / prod) : deploie une REF GIT donnee par archive.
+#
+# Variante "release" de deploy_dev_code.sh. Deux differences :
+#   - on deploie une ref arbitraire (le tag de la release), pas forcement HEAD ;
+#   - AUCUN reload de donnees derriere (pas d'arbres, pas de referentiels) :
+#     sur staging/prod le contenu metier est pilote a la main. Le seul effet
+#     de bord DB est le `migrate` joue par bin/post_deploy.sh cote Scalingo.
+#
+# Env requis : SCALINGO_REGION, SCALINGO_APP, SCALINGO_API_TOKEN.
+# Arg 1 : la ref git a deployer (tag, ex "v0.5.0"). Defaut : HEAD.
+
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+REF="${1:-HEAD}"
+SHA="$(git rev-parse "$REF")"
+ARCHIVE="/tmp/nitrates-${SHA}.tar.gz"
+
+echo "== Deploiement de ${REF} (${SHA}) sur ${SCALINGO_APP} (${SCALINGO_REGION}) =="
+
+# --prefix : Scalingo exige un tar avec un repertoire wrapper unique a la
+# racine. Sans prefixe, le deployeur echoue ("fail to handle tgz ... is a
+# directory"). Cf. deploy_dev_code.sh.
+git archive --format=tar.gz --prefix=nitrates/ -o "$ARCHIVE" "$SHA"
+ls -la "$ARCHIVE"
+
+# On etiquette le deploiement avec la ref lisible (tag) plutot que le sha nu,
+# pour que `scalingo deployments` soit lisible au moment d'un rollback.
+echo "== scalingo deploy (--no-follow : on suit l'issue via l'API) =="
+scalingo --region "$SCALINGO_REGION" --app "$SCALINGO_APP" \
+  deploy --no-follow "$ARCHIVE" "$REF"
+
+echo "== Attente de l'issue du deploiement =="
+# Le post_deploy (migrate) tourne dans la phase 'starting'. On poll le status
+# du deploiement jusqu'a success / erreur. 90 x 10s = 15 min de marge.
+final=""
+for i in $(seq 1 90); do
+  sleep 10
+  line=$(scalingo --region "$SCALINGO_REGION" --app "$SCALINGO_APP" \
+         deployments 2>/dev/null | grep "$REF" | grep -v "build-error" | head -1 || true)
+  status=$(echo "$line" | grep -oE 'success|crashed|build-error|deploy-error|aborted' | head -1 || true)
+  if [ -n "$status" ]; then final="$status"; break; fi
+done
+
+echo "Status final du deploiement : ${final:-timeout}"
+if [ "$final" != "success" ]; then
+  echo "ECHEC : deploiement non abouti (${final:-timeout})" >&2
+  scalingo --region "$SCALINGO_REGION" --app "$SCALINGO_APP" deployments 2>/dev/null | head -4
+  exit 1
+fi
+echo "Deploiement code OK."

--- a/.github/scripts/deploy_release_smoke.sh
+++ b/.github/scripts/deploy_release_smoke.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# SMOKE (staging / prod) : verifie que l'app repond apres deploiement.
+#
+# Volontairement MINIMAL et non destructif : on ne touche a aucune donnee.
+#   1. HTTP : la racine repond (200, ou 302 si l'env est encore derriere le
+#      lockdown login).
+#   2. Migrations : aucune migration non appliquee (le post_deploy a bien
+#      joue `migrate`). C'est le seul effet DB attendu d'un deploiement
+#      release, donc le seul qu'on verifie.
+#
+# On ne verifie PAS les arbres / referentiels : sur staging et prod, ces
+# contenus sont pilotes a la main et ne font pas partie du deploiement.
+#
+# Env requis : SCALINGO_REGION, SCALINGO_APP, SCALINGO_API_TOKEN.
+# Env optionnel : APP_URL (sinon deduite du nom d'app et de la region).
+
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+source .github/scripts/_scalingo_oneoff.sh
+
+APP_URL="${APP_URL:-https://${SCALINGO_APP}.${SCALINGO_REGION}.scalingo.io/}"
+
+echo "== Smoke HTTP : ${APP_URL} =="
+code=$(curl -s -o /dev/null -w '%{http_code}' -L --max-time 30 "$APP_URL" || echo "000")
+echo "HTTP ${code}"
+case "$code" in
+  200|301|302) echo "OK (l'app repond)";;
+  *) echo "ECHEC smoke HTTP (code ${code})" >&2; exit 1;;
+esac
+
+echo "== Smoke migrations : aucune migration en attente =="
+# `migrate --check` sort en code != 0 s'il reste des migrations non appliquees.
+# On se fie au CODE RETOUR du one-off (capture fiable via le marqueur du
+# helper), pas au texte des logs (arrivee desordonnee cote Scalingo).
+set +e
+out=$(run_oneoff "python manage.py migrate --check")
+rc=$?
+set -e
+echo "$out"
+if [ "$rc" -ne 0 ]; then
+  echo "ECHEC smoke : des migrations restent non appliquees (rc=$rc)" >&2
+  echo "Le post_deploy a probablement echoue -- verifier les logs Scalingo." >&2
+  exit 1
+fi
+
+echo "Smoke OK."

--- a/.github/scripts/gate_ci_green.sh
+++ b/.github/scripts/gate_ci_green.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# GATE : refuse de deployer un SHA dont la CI n'est pas verte.
+#
+# Pourquoi : rien n'empeche de tagger un commit arbitraire (y compris un commit
+# jamais passe en PR, ou pousse en direct sur main par un admin -- la protection
+# de branche a enforce_admins=false). Sans ce garde-fou, creer une release
+# suffirait a envoyer du code non teste en prod.
+#
+# On interroge l'API "check-runs" du SHA et on exige que les checks REQUIS
+# soient en success. Un check absent est un ECHEC (il n'a jamais tourne), pas
+# un succes implicite.
+#
+# Env requis : GH_TOKEN (fourni par le workflow), GITHUB_REPOSITORY.
+# Arg 1 : le SHA a verifier.
+# Arg 2+ : noms des checks requis (defaut : linter pytest).
+
+set -euo pipefail
+
+SHA="${1:?usage: gate_ci_green.sh <sha> [check...]}"
+shift || true
+REQUIS=("$@")
+if [ "${#REQUIS[@]}" -eq 0 ]; then
+  REQUIS=("linter" "pytest")
+fi
+
+echo "== Gate CI : verification des checks de ${SHA} =="
+
+# --paginate : un SHA peut porter beaucoup de check-runs (CodeQL, Dependabot,
+# GitGuardian...). Sans pagination on risque de rater le check cherche et de
+# conclure a tort qu'il est absent.
+runs=$(gh api --paginate \
+  "repos/${GITHUB_REPOSITORY}/commits/${SHA}/check-runs" \
+  --jq '.check_runs[] | "\(.name)\t\(.status)\t\(.conclusion)"' 2>/dev/null || true)
+
+if [ -z "$runs" ]; then
+  echo "ECHEC : aucun check-run trouve pour ${SHA}." >&2
+  echo "Le commit n'a jamais ete teste par la CI -- deploiement refuse." >&2
+  exit 1
+fi
+
+echo "Checks trouves :"
+echo "$runs" | sed 's/^/  /'
+
+echec=0
+for check in "${REQUIS[@]}"; do
+  # Un meme check peut avoir plusieurs runs (re-run). On prend la MEILLEURE
+  # conclusion : si un re-run a repare un echec, le SHA est vert.
+  ligne=$(echo "$runs" | awk -F'\t' -v c="$check" '$1 == c' || true)
+  if [ -z "$ligne" ]; then
+    echo "ECHEC : le check requis '${check}' n'a pas tourne sur ce SHA." >&2
+    echec=1
+    continue
+  fi
+  if echo "$ligne" | awk -F'\t' '$2 == "completed" && $3 == "success"' | grep -q .; then
+    echo "OK : ${check} est vert."
+  else
+    echo "ECHEC : le check requis '${check}' n'est pas vert :" >&2
+    echo "$ligne" | sed 's/^/    /' >&2
+    echec=1
+  fi
+done
+
+if [ "$echec" -ne 0 ]; then
+  echo "" >&2
+  echo "Deploiement refuse : la CI de ${SHA} n'est pas verte." >&2
+  exit 1
+fi
+
+echo "Gate CI OK : tous les checks requis sont verts."

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,140 @@
+name: Deploy prod
+
+# CD production, declenche par la publication d'une release GitHub NORMALE
+# (non pre-release). Une pre-release part sur staging (deploy-staging.yml).
+#
+# Memes garde-fous que staging, plus :
+#   - l'environment `production` exige une APPROBATION MANUELLE (required
+#     reviewer) : le job se met en pause avant d'ecrire quoi que ce soit ;
+#   - un backup Postgres est declenche AVANT le deploiement.
+#
+# La prod vit sur SecNumCloud (osc-secnum-fr1), region distincte de
+# dev/staging : le token peut devoir etre different de celui d'osc-fr1.
+#
+# PREREQUIS avant la premiere execution :
+#   - `tofu apply` de envs/prod (l'app nitrates-prod doit exister) ;
+#   - secret SCALINGO_API_TOKEN pose dans l'environment `production` ;
+#   - device TOTP enrole pour chaque compte admin (DJANGO_ADMIN_OTP_REQUIRED
+#     est a True en prod : sans device, login impossible).
+
+permissions:
+  contents: read
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Tag ou SHA a deployer en production"
+        required: true
+        type: string
+
+jobs:
+  gate-ci:
+    # Sur `release`, ne tourne QUE pour une release NON pre-release.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.release.prerelease == false
+    runs-on: ubuntu-latest
+    outputs:
+      ref: ${{ steps.resolve.outputs.ref }}
+      sha: ${{ steps.resolve.outputs.sha }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Resoudre la ref a deployer
+        id: resolve
+        env:
+          EVENT: ${{ github.event_name }}
+          INPUT_REF: ${{ inputs.ref }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          if [ "$EVENT" = "workflow_dispatch" ]; then
+            REF="$INPUT_REF"
+          else
+            REF="$TAG"
+          fi
+          git fetch --tags --force
+          SHA=$(git rev-parse "$REF")
+          echo "ref=$REF" >> "$GITHUB_OUTPUT"
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+          echo "Deploiement cible : $REF ($SHA)"
+
+      - name: Gate — la CI du SHA est verte
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash .github/scripts/gate_ci_green.sh "${{ steps.resolve.outputs.sha }}"
+
+  gate-e2e:
+    needs: gate-ci
+    uses: ./.github/workflows/e2e.yml
+
+  deploy-prod:
+    needs: [gate-ci, gate-e2e]
+    runs-on: ubuntu-latest
+    # C'est ICI que se joue la protection : l'environment `production` est
+    # configure avec un required reviewer -> le run attend l'approbation.
+    environment:
+      name: production
+      url: https://nitrates-prod.osc-secnum-fr1.scalingo.io/
+    env:
+      SCALINGO_REGION: osc-secnum-fr1
+      SCALINGO_APP: nitrates-prod
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.gate-ci.outputs.sha }}
+
+      - name: Installer la CLI Scalingo
+        run: |
+          curl -s -O https://cli-dl.scalingo.com/install && bash install
+          scalingo --version
+
+      # --- Backup DB AVANT tout ecrit -------------------------------------
+      # L'addon Postgres fait ses propres backups, mais on veut un point de
+      # restauration DATE SUR CE DEPLOIEMENT. Non bloquant : c'est un filet,
+      # et un backup indisponible ne doit pas empecher un correctif urgent
+      # de partir. L'echec est visible dans les logs.
+      - name: Backup Postgres (filet de securite)
+        env:
+          SCALINGO_API_TOKEN: ${{ secrets.SCALINGO_API_TOKEN }}
+        continue-on-error: true
+        run: |
+          addon=$(scalingo --region "$SCALINGO_REGION" --app "$SCALINGO_APP" \
+                  addons 2>/dev/null | grep -i postgres | awk '{print $2}' | head -1)
+          if [ -z "$addon" ]; then
+            echo "Addon Postgres introuvable -- backup saute." >&2
+            exit 1
+          fi
+          echo "Declenchement d'un backup sur l'addon ${addon}"
+          scalingo --region "$SCALINGO_REGION" --app "$SCALINGO_APP" \
+            --addon "$addon" backups-create
+
+      - name: Deploy code
+        env:
+          SCALINGO_API_TOKEN: ${{ secrets.SCALINGO_API_TOKEN }}
+        run: bash .github/scripts/deploy_release_code.sh "${{ needs.gate-ci.outputs.sha }}"
+
+      - name: Smoke test
+        env:
+          SCALINGO_API_TOKEN: ${{ secrets.SCALINGO_API_TOKEN }}
+        run: bash .github/scripts/deploy_release_smoke.sh
+
+      - name: Recapitulatif
+        if: always()
+        run: |
+          {
+            echo "## Deploiement production"
+            echo ""
+            echo "- Ref deployee : \`${{ needs.gate-ci.outputs.ref }}\`"
+            echo "- SHA : \`${{ needs.gate-ci.outputs.sha }}\`"
+            echo "- App : \`nitrates-prod\` (osc-secnum-fr1)"
+            echo ""
+            echo "Rollback : workflow **Rollback** -> environnement \`production\` -> tag precedent."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,125 @@
+name: Deploy staging
+
+# CD staging, declenche par la publication d'une PRE-RELEASE GitHub.
+#
+#   Release marquee "pre-release"  -> staging  (ce workflow)
+#   Release normale                -> prod     (deploy-prod.yml)
+#
+# Sequence, volontairement SANS reload de donnees (les arbres, referentiels et
+# jeux SIG de staging sont pilotes a la main) :
+#   1. gate CI  : le SHA du tag a ses checks verts
+#   2. gate e2e : suite Playwright complete sur base ephemere
+#   3. deploy   : git archive -> scalingo deploy (post_deploy joue migrate)
+#   4. smoke    : HTTP + aucune migration en attente
+#
+# Secret requis : SCALINGO_API_TOKEN, dans l'environment `staging`.
+
+permissions:
+  contents: read
+
+on:
+  release:
+    types: [published]
+  # Rejeu manuel (et deploiement d'un tag arbitraire sur staging).
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Tag ou SHA a deployer sur staging"
+        required: true
+        type: string
+
+jobs:
+  # --- 1. Gate CI --------------------------------------------------------
+  # Job separe et prealable : inutile de payer 10 min d'e2e si le SHA est
+  # deja rouge.
+  gate-ci:
+    # Sur `release`, ne tourne QUE pour une pre-release (une release normale
+    # part en prod). Sur workflow_dispatch, toujours.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.release.prerelease == true
+    runs-on: ubuntu-latest
+    outputs:
+      ref: ${{ steps.resolve.outputs.ref }}
+      sha: ${{ steps.resolve.outputs.sha }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Resoudre la ref a deployer
+        id: resolve
+        env:
+          EVENT: ${{ github.event_name }}
+          INPUT_REF: ${{ inputs.ref }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          if [ "$EVENT" = "workflow_dispatch" ]; then
+            REF="$INPUT_REF"
+          else
+            REF="$TAG"
+          fi
+          git fetch --tags --force
+          SHA=$(git rev-parse "$REF")
+          echo "ref=$REF" >> "$GITHUB_OUTPUT"
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+          echo "Deploiement cible : $REF ($SHA)"
+
+      - name: Gate — la CI du SHA est verte
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash .github/scripts/gate_ci_green.sh "${{ steps.resolve.outputs.sha }}"
+
+  # --- 2. Gate e2e -------------------------------------------------------
+  # Reutilise le workflow e2e (meme definition que le run nocturne).
+  gate-e2e:
+    needs: gate-ci
+    uses: ./.github/workflows/e2e.yml
+
+  # --- 3+4. Deploy + smoke -----------------------------------------------
+  deploy-staging:
+    needs: [gate-ci, gate-e2e]
+    runs-on: ubuntu-latest
+    # L'environment porte le secret et restreint qui peut le lire.
+    environment:
+      name: staging
+      url: https://nitrates-staging.osc-fr1.scalingo.io/
+    env:
+      SCALINGO_REGION: osc-fr1
+      SCALINGO_APP: nitrates-staging
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.gate-ci.outputs.sha }}
+
+      - name: Installer la CLI Scalingo
+        run: |
+          curl -s -O https://cli-dl.scalingo.com/install && bash install
+          scalingo --version
+
+      - name: Deploy code
+        env:
+          SCALINGO_API_TOKEN: ${{ secrets.SCALINGO_API_TOKEN }}
+        run: bash .github/scripts/deploy_release_code.sh "${{ needs.gate-ci.outputs.sha }}"
+
+      - name: Smoke test
+        env:
+          SCALINGO_API_TOKEN: ${{ secrets.SCALINGO_API_TOKEN }}
+        run: bash .github/scripts/deploy_release_smoke.sh
+
+      - name: Recapitulatif
+        if: always()
+        run: |
+          {
+            echo "## Deploiement staging"
+            echo ""
+            echo "- Ref deployee : \`${{ needs.gate-ci.outputs.ref }}\`"
+            echo "- SHA : \`${{ needs.gate-ci.outputs.sha }}\`"
+            echo "- App : \`nitrates-staging\` (osc-fr1)"
+            echo "- URL : https://nitrates-staging.osc-fr1.scalingo.io/"
+            echo ""
+            echo "Rollback : workflow **Rollback** -> environnement \`staging\` -> tag precedent."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,165 @@
+name: E2E nitrates
+
+# Suite Playwright nitrates, montee sur une base ephemere.
+#
+# Workflow REUTILISABLE (workflow_call) : appele en GATE par deploy-staging et
+# deploy-prod. Il n'est VOLONTAIREMENT pas branche sur les PR : le lot e2e dure
+# plusieurs minutes et ralentirait la boucle de dev. Le contrat est : une
+# version TAGGEE ne part sur staging/prod que si l'e2e est verte.
+#
+# Aussi appelable a la main (workflow_dispatch) et en nocturne (schedule) sur
+# main, pour ne pas decouvrir une regression e2e le jour de la release.
+#
+# Les specs `capture_*` sont EXCLUES : ce sont des outils de production de
+# captures d'ecran pour la validation juriste (elles ecrivent des manifestes),
+# pas des tests de non-regression.
+
+permissions:
+  contents: read
+
+on:
+  workflow_call: {}
+  workflow_dispatch: {}
+  schedule:
+    # Tous les jours a 03:17 UTC. Heure decalee (pas pile) pour eviter le pic
+    # de charge des runners GitHub a l'heure ronde.
+    - cron: "17 3 * * *"
+
+env:
+  DATABASE_URL: "postgis://envergo:envergo@localhost:5432/envergo"
+  USE_DOCKER: "False"
+  LANG: "fr_FR.UTF-8"
+  LC_ALL: "fr_FR.UTF-8"
+  DJANGO_SETTINGS_MODULE: "config.settings.ci"
+
+jobs:
+  e2e-nitrates:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    services:
+      database:
+        image: postgis/postgis:14-master
+        env:
+          POSTGRES_USER: envergo
+          POSTGRES_PASSWORD: envergo
+          POSTGRES_DB: envergo
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Checkout Code Repository
+        uses: actions/checkout@v7
+
+      # --- Locale FR : les specs assertent des libelles francais (dates,
+      # intitules de cultures). Sans la locale, les tests echouent sur du
+      # texte anglais.
+      - name: Installer la locale francaise
+        run: |
+          sudo apt update
+          sudo apt install -y language-pack-fr
+          sudo locale-gen
+          sudo update-locale LANG="fr_FR.UTF-8" LC_ALL="fr_FR.UTF-8"
+
+      - name: Dependances geo (GDAL/PROJ)
+        run: sudo apt install -y binutils libproj-dev gdal-bin gettext
+
+      - name: Extensions postgis sur template1
+        run: |
+          psql -d postgresql://envergo:envergo@localhost/template1 -c 'CREATE EXTENSION IF NOT EXISTS postgis;'
+          psql -d postgresql://envergo:envergo@localhost/template1 -c 'CREATE EXTENSION IF NOT EXISTS postgis_raster;'
+        env:
+          PGPASSWORD: envergo
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6.3.0
+        with:
+          python-version: 3.12.8
+
+      - name: Install python dependencies
+        run: pip install -r requirements/local.txt
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install js dependencies
+        run: npm ci
+
+      # Les specs testent le JS compile (cascade, flow couvert, carte Leaflet).
+      # Sans build, le serveur sert des assets absents -> tout casse.
+      - name: Build assets
+        run: bash bin/build_assets.sh
+
+      # --- Base : migrations + referentiels + arbres canoniques ------------
+      # Les specs interrogent /api/referentiels/ et /api/arbre/ (qui doit
+      # renvoyer l'arbre PAN, noeud racine n_zvn) : il faut donc les
+      # referentiels seedes ET au moins l'arbre PAN actif en DB.
+      - name: Preparer la base (migrate + referentiels + arbres)
+        run: |
+          python manage.py migrate --noinput
+          python manage.py seed_referentiels
+          python manage.py load_arbres_actifs
+
+      # --- Serveur de test -------------------------------------------------
+      # Le middleware SetUrlConfBasedOnSite force l'urlconf nitrates quel que
+      # soit le Host, donc pas besoin de bricoler une Site id=3 ici. On ajoute
+      # quand meme 127.0.0.1 aux ALLOWED_HOSTS (ci.py ne liste que localhost)
+      # car playwright.config.nitrates.ts cible 127.0.0.1.
+      #
+      # LOCKDOWN_BEHIND_LOGIN doit rester desactive : sinon toute requete
+      # anonyme est redirigee vers le login admin et les specs ne voient que
+      # la page de connexion.
+      - name: Lancer le serveur Django
+        env:
+          DJANGO_ALLOWED_HOSTS: "127.0.0.1,localhost"
+          DJANGO_LOCKDOWN_BEHIND_LOGIN: "False"
+          DJANGO_NITRATES_ROOT_OUVERT: "True"
+        run: |
+          python manage.py runserver 127.0.0.1:8042 --noreload &
+          echo "Attente du serveur sur 127.0.0.1:8042..."
+          for i in $(seq 1 60); do
+            code=$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:8042/ || echo "000")
+            if [ "$code" != "000" ]; then
+              echo "Serveur up (HTTP $code)"; exit 0
+            fi
+            sleep 2
+          done
+          echo "ECHEC : le serveur n'a pas demarre en 120s" >&2
+          exit 1
+
+      - name: Installer les navigateurs Playwright
+        run: npx playwright install --with-deps chromium
+
+      # --- Run --------------------------------------------------------------
+      # `capture_*` exclu (outils de capture, pas de la non-reg) ainsi que les
+      # specs prefixees `_` (scratchpads de mesure : _zoomj, _meas107, _iter107).
+      - name: Run Playwright (hors specs de capture)
+        env:
+          NITRATES_BASE_URL: "http://127.0.0.1:8042"
+          CI: "true"
+        run: |
+          npx playwright test \
+            --config playwright.config.nitrates.ts \
+            $(ls e2e/nitrates/*.spec.ts \
+                | grep -v '/capture_' \
+                | grep -v '/_' \
+                | tr '\n' ' ')
+
+      - name: Upload rapport Playwright
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            playwright-report/
+            test-results/
+          retention-days: 14
+          if-no-files-found: warn

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -1,0 +1,138 @@
+name: Rollback
+
+# ROLLBACK EN 1 CLIC : redeploie une version anterieure sur staging ou prod.
+#
+# Usage : onglet Actions -> "Rollback" -> "Run workflow" -> choisir
+# l'environnement et le tag a restaurer -> Run.
+#
+# Principe : Scalingo n'offre pas de rollback atomique fiable en CLI. Le
+# mecanisme le plus previsible est de REDEPLOYER l'archive d'un tag anterieur,
+# c'est-a-dire exactement le meme chemin que le deploiement nominal. Ce qui a
+# ete teste au deploiement l'est donc aussi au rollback.
+#
+# ATTENTION -- LIMITE ASSUMEE : ceci restaure le CODE, pas le SCHEMA DB.
+# Django ne joue pas de migration inverse. Si la version qu'on quitte a
+# introduit une migration DESTRUCTIVE (RemoveField, DeleteModel), redeployer
+# l'ancien code laisse la base dans le nouvel etat -> l'ancien code peut
+# planter. D'ou la regle : entre deux releases, migrations ADDITIVE-ONLY.
+# En cas de migration destructive, le rollback passe par la restauration du
+# backup Postgres (cf. runbook), pas par ce workflow.
+#
+# Le gate e2e est VOLONTAIREMENT absent : un rollback est une mesure
+# d'urgence, vers une version qui a deja ete testee et deployee. Rajouter
+# 10 minutes d'e2e pendant un incident serait contre-productif.
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+    inputs:
+      environnement:
+        description: "Environnement a restaurer"
+        required: true
+        type: choice
+        options:
+          - staging
+          - production
+      version:
+        description: "Tag (ou SHA) a restaurer, ex. v0.4.0"
+        required: true
+        type: string
+      motif:
+        description: "Motif du rollback (trace dans le recapitulatif)"
+        required: false
+        type: string
+        default: "non precise"
+
+jobs:
+  rollback:
+    runs-on: ubuntu-latest
+    environment:
+      name: ${{ inputs.environnement }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      # La cible (app + region) depend de l'environnement choisi. On la
+      # resout ici plutot que de dupliquer deux jobs quasi identiques.
+      - name: Resoudre la cible et la version
+        id: cible
+        env:
+          ENVIRONNEMENT: ${{ inputs.environnement }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          case "$ENVIRONNEMENT" in
+            staging)
+              echo "region=osc-fr1" >> "$GITHUB_OUTPUT"
+              echo "app=nitrates-staging" >> "$GITHUB_OUTPUT"
+              ;;
+            production)
+              echo "region=osc-secnum-fr1" >> "$GITHUB_OUTPUT"
+              echo "app=nitrates-prod" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "Environnement inconnu : $ENVIRONNEMENT" >&2; exit 1;;
+          esac
+          git fetch --tags --force
+          # Echoue proprement si le tag n'existe pas, AVANT de toucher a
+          # l'app (message clair plutot qu'un git archive cryptique).
+          if ! SHA=$(git rev-parse --verify "${VERSION}^{commit}" 2>/dev/null); then
+            echo "ECHEC : la version '${VERSION}' n'existe pas dans le repo." >&2
+            echo "Tags disponibles (10 derniers) :" >&2
+            git tag --sort=-creatordate | head -10 >&2
+            exit 1
+          fi
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+          echo "Rollback de $ENVIRONNEMENT vers $VERSION ($SHA)"
+
+      - name: Installer la CLI Scalingo
+        run: |
+          curl -s -O https://cli-dl.scalingo.com/install && bash install
+          scalingo --version
+
+      # Trace de l'etat qu'on quitte : indispensable pour le post-mortem, et
+      # pour savoir vers quoi "re-avancer" une fois le correctif pret.
+      - name: Tracer la version actuellement deployee
+        env:
+          SCALINGO_API_TOKEN: ${{ secrets.SCALINGO_API_TOKEN }}
+          SCALINGO_REGION: ${{ steps.cible.outputs.region }}
+          SCALINGO_APP: ${{ steps.cible.outputs.app }}
+        continue-on-error: true
+        run: |
+          echo "== Derniers deploiements AVANT rollback =="
+          scalingo --region "$SCALINGO_REGION" --app "$SCALINGO_APP" \
+            deployments 2>/dev/null | head -5
+
+      - name: Redeployer la version cible
+        env:
+          SCALINGO_API_TOKEN: ${{ secrets.SCALINGO_API_TOKEN }}
+          SCALINGO_REGION: ${{ steps.cible.outputs.region }}
+          SCALINGO_APP: ${{ steps.cible.outputs.app }}
+        run: bash .github/scripts/deploy_release_code.sh "${{ steps.cible.outputs.sha }}"
+
+      - name: Smoke test
+        env:
+          SCALINGO_API_TOKEN: ${{ secrets.SCALINGO_API_TOKEN }}
+          SCALINGO_REGION: ${{ steps.cible.outputs.region }}
+          SCALINGO_APP: ${{ steps.cible.outputs.app }}
+        run: bash .github/scripts/deploy_release_smoke.sh
+
+      - name: Recapitulatif
+        if: always()
+        run: |
+          {
+            echo "## Rollback ${{ inputs.environnement }}"
+            echo ""
+            echo "- Version restauree : \`${{ inputs.version }}\`"
+            echo "- SHA : \`${{ steps.cible.outputs.sha }}\`"
+            echo "- App : \`${{ steps.cible.outputs.app }}\` (${{ steps.cible.outputs.region }})"
+            echo "- Motif : ${{ inputs.motif }}"
+            echo "- Declenche par : @${{ github.actor }}"
+            echo ""
+            echo "> Rappel : ce rollback restaure le CODE. Si la version quittee"
+            echo "> a introduit une migration destructive, restaurer aussi le"
+            echo "> backup Postgres (cf. runbook)."
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Pose le pipeline de livraison vers staging et prod, et branche l'e2e
Playwright en gate. Couvre le point 1 de #246 (e2e dans la CI).

## Modèle de déploiement

| Env | Déclencheur | App | Approbation |
|---|---|---|---|
| dev | push sur `main` (inchangé) | nitrates-dev | non |
| staging | release GitHub **pre-release** | nitrates-staging | non |
| prod | release GitHub **normale** | nitrates-prod | oui |

Séquence staging/prod : gate CI (le SHA taggé est vert) → gate e2e →
deploy (archive) → smoke. La prod ajoute un backup Postgres préalable
et une approbation manuelle via l'environment `production`.

**Le pipeline ne déploie que du code** : ni arbres, ni référentiels, ni
jeux SIG, qui restent pilotés à la main sur staging/prod. Seul effet en
base : le `migrate` du `post_deploy`.

## e2e Playwright

Nouveau workflow réutilisable `e2e.yml` (base éphémère, migrate + seed +
arbres, serveur Django, chromium). 12 specs retenues sur 19 : les
`capture_*` sont exclues (outils de production de captures juriste, pas
de la non-régression) ainsi que les scratchpads `_*`.

**Volontairement pas branché sur les PR ni sur dev** : plusieurs minutes
de run ralentiraient la boucle de dev. Il gate les versions taggées, plus
un run nocturne sur `main` pour ne pas découvrir une régression le jour
de la release.

## Rollback

Workflow `rollback.yml` en `workflow_dispatch` : environnement + version
+ motif. Redéploie l'archive d'un tag antérieur, même chemin que le
déploiement nominal.

Limite assumée : restaure le **code**, pas le schéma DB (Django ne joue
pas de migration inverse) → règle migrations additive-only entre deux
releases, documentée dans le runbook.

## Nettoyage cron.json

Les 5 tâches planifiées héritées d'Envergo amont opéraient sur des
modèles hors périmètre et échouaient chaque nuit en silence :
`obsolete_moulinette_template_admin_alert` plantait sur
`Site.DoesNotExist` (cherche la Site du domaine Aménagement, absente en
base). Crash en one-off uniquement, jamais sur une requête web.
Deux d'entre elles envoyaient en plus des emails à des utilisateurs
Aménagement.

`cron.json` est vidé, explication et jobs d'origine dans `cron.README.md`
(marqueur REVERT_AT_MERGE_TIME_FOR_UPSTREAM_ENVERGO).

## Non testé

Aucun de ces workflows n'a encore tourné. Premier test conseillé : une
pre-release sur staging, puis un rollback volontaire sur staging pour
valider le chemin de secours avant d'en avoir besoin.

## À faire à la main avant le premier run

Les environments et leurs secrets ne peuvent pas être créés depuis la PR :

```bash
gh api -X PUT repos/betagouv/nitrates/environments/staging
gh secret set SCALINGO_API_TOKEN --env staging

gh api -X PUT repos/betagouv/nitrates/environments/production \
  -F "reviewers[][type]=User" -F "reviewers[][id]=23218626"
gh secret set SCALINGO_API_TOKEN --env production
```

La prod ne peut pas tourner tant que `nitrates-prod` n'existe pas
(`tofu apply` de `envs/prod` + prérequis listés dans le runbook).

Runbook : `nitrates-iac/docs/runbook_cicd_release.md`.

Refs #246, #50
