### PR TITLE
develop → main : pipeline CD + analytics Matomo

### DIFF
--- a/.github/scripts/deploy_release_code.sh
+++ b/.github/scripts/deploy_release_code.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# DEPLOY CODE (staging / prod) : deploie une REF GIT donnee par archive.
+#
+# Variante "release" de deploy_dev_code.sh. Deux differences :
+#   - on deploie une ref arbitraire (le tag de la release), pas forcement HEAD ;
+#   - AUCUN reload de donnees derriere (pas d'arbres, pas de referentiels) :
+#     sur staging/prod le contenu metier est pilote a la main. Le seul effet
+#     de bord DB est le `migrate` joue par bin/post_deploy.sh cote Scalingo.
+#
+# Env requis : SCALINGO_REGION, SCALINGO_APP, SCALINGO_API_TOKEN.
+# Arg 1 : la ref git a deployer (tag, ex "v0.5.0"). Defaut : HEAD.
+
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+REF="${1:-HEAD}"
+SHA="$(git rev-parse "$REF")"
+ARCHIVE="/tmp/nitrates-${SHA}.tar.gz"
+
+echo "== Deploiement de ${REF} (${SHA}) sur ${SCALINGO_APP} (${SCALINGO_REGION}) =="
+
+# --prefix : Scalingo exige un tar avec un repertoire wrapper unique a la
+# racine. Sans prefixe, le deployeur echoue ("fail to handle tgz ... is a
+# directory"). Cf. deploy_dev_code.sh.
+git archive --format=tar.gz --prefix=nitrates/ -o "$ARCHIVE" "$SHA"
+ls -la "$ARCHIVE"
+
+# On etiquette le deploiement avec la ref lisible (tag) plutot que le sha nu,
+# pour que `scalingo deployments` soit lisible au moment d'un rollback.
+echo "== scalingo deploy (--no-follow : on suit l'issue via l'API) =="
+scalingo --region "$SCALINGO_REGION" --app "$SCALINGO_APP" \
+  deploy --no-follow "$ARCHIVE" "$REF"
+
+echo "== Attente de l'issue du deploiement =="
+# Le post_deploy (migrate) tourne dans la phase 'starting'. On poll le status
+# du deploiement jusqu'a success / erreur. 90 x 10s = 15 min de marge.
+final=""
+for i in $(seq 1 90); do
+  sleep 10
+  line=$(scalingo --region "$SCALINGO_REGION" --app "$SCALINGO_APP" \
+         deployments 2>/dev/null | grep "$REF" | grep -v "build-error" | head -1 || true)
+  status=$(echo "$line" | grep -oE 'success|crashed|build-error|deploy-error|aborted' | head -1 || true)
+  if [ -n "$status" ]; then final="$status"; break; fi
+done
+
+echo "Status final du deploiement : ${final:-timeout}"
+if [ "$final" != "success" ]; then
+  echo "ECHEC : deploiement non abouti (${final:-timeout})" >&2
+  scalingo --region "$SCALINGO_REGION" --app "$SCALINGO_APP" deployments 2>/dev/null | head -4
+  exit 1
+fi
+echo "Deploiement code OK."

--- a/.github/scripts/deploy_release_smoke.sh
+++ b/.github/scripts/deploy_release_smoke.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# SMOKE (staging / prod) : verifie que l'app repond apres deploiement.
+#
+# Volontairement MINIMAL et non destructif : on ne touche a aucune donnee.
+#   1. HTTP : la racine repond (200, ou 302 si l'env est encore derriere le
+#      lockdown login).
+#   2. Migrations : aucune migration non appliquee (le post_deploy a bien
+#      joue `migrate`). C'est le seul effet DB attendu d'un deploiement
+#      release, donc le seul qu'on verifie.
+#
+# On ne verifie PAS les arbres / referentiels : sur staging et prod, ces
+# contenus sont pilotes a la main et ne font pas partie du deploiement.
+#
+# Env requis : SCALINGO_REGION, SCALINGO_APP, SCALINGO_API_TOKEN.
+# Env optionnel : APP_URL (sinon deduite du nom d'app et de la region).
+
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+source .github/scripts/_scalingo_oneoff.sh
+
+APP_URL="${APP_URL:-https://${SCALINGO_APP}.${SCALINGO_REGION}.scalingo.io/}"
+
+echo "== Smoke HTTP : ${APP_URL} =="
+code=$(curl -s -o /dev/null -w '%{http_code}' -L --max-time 30 "$APP_URL" || echo "000")
+echo "HTTP ${code}"
+case "$code" in
+  200|301|302) echo "OK (l'app repond)";;
+  *) echo "ECHEC smoke HTTP (code ${code})" >&2; exit 1;;
+esac
+
+echo "== Smoke migrations : aucune migration en attente =="
+# `migrate --check` sort en code != 0 s'il reste des migrations non appliquees.
+# On se fie au CODE RETOUR du one-off (capture fiable via le marqueur du
+# helper), pas au texte des logs (arrivee desordonnee cote Scalingo).
+set +e
+out=$(run_oneoff "python manage.py migrate --check")
+rc=$?
+set -e
+echo "$out"
+if [ "$rc" -ne 0 ]; then
+  echo "ECHEC smoke : des migrations restent non appliquees (rc=$rc)" >&2
+  echo "Le post_deploy a probablement echoue -- verifier les logs Scalingo." >&2
+  exit 1
+fi
+
+echo "Smoke OK."

--- a/.github/scripts/gate_ci_green.sh
+++ b/.github/scripts/gate_ci_green.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# GATE : refuse de deployer un SHA dont la CI n'est pas verte.
+#
+# Pourquoi : rien n'empeche de tagger un commit arbitraire (y compris un commit
+# jamais passe en PR, ou pousse en direct sur main par un admin -- la protection
+# de branche a enforce_admins=false). Sans ce garde-fou, creer une release
+# suffirait a envoyer du code non teste en prod.
+#
+# On interroge l'API "check-runs" du SHA et on exige que les checks REQUIS
+# soient en success. Un check absent est un ECHEC (il n'a jamais tourne), pas
+# un succes implicite.
+#
+# Env requis : GH_TOKEN (fourni par le workflow), GITHUB_REPOSITORY.
+# Arg 1 : le SHA a verifier.
+# Arg 2+ : noms des checks requis (defaut : linter pytest).
+
+set -euo pipefail
+
+SHA="${1:?usage: gate_ci_green.sh <sha> [check...]}"
+shift || true
+REQUIS=("$@")
+if [ "${#REQUIS[@]}" -eq 0 ]; then
+  REQUIS=("linter" "pytest")
+fi
+
+echo "== Gate CI : verification des checks de ${SHA} =="
+
+# --paginate : un SHA peut porter beaucoup de check-runs (CodeQL, Dependabot,
+# GitGuardian...). Sans pagination on risque de rater le check cherche et de
+# conclure a tort qu'il est absent.
+runs=$(gh api --paginate \
+  "repos/${GITHUB_REPOSITORY}/commits/${SHA}/check-runs" \
+  --jq '.check_runs[] | "\(.name)\t\(.status)\t\(.conclusion)"' 2>/dev/null || true)
+
+if [ -z "$runs" ]; then
+  echo "ECHEC : aucun check-run trouve pour ${SHA}." >&2
+  echo "Le commit n'a jamais ete teste par la CI -- deploiement refuse." >&2
+  exit 1
+fi
+
+echo "Checks trouves :"
+echo "$runs" | sed 's/^/  /'
+
+echec=0
+for check in "${REQUIS[@]}"; do
+  # Un meme check peut avoir plusieurs runs (re-run). On prend la MEILLEURE
+  # conclusion : si un re-run a repare un echec, le SHA est vert.
+  ligne=$(echo "$runs" | awk -F'\t' -v c="$check" '$1 == c' || true)
+  if [ -z "$ligne" ]; then
+    echo "ECHEC : le check requis '${check}' n'a pas tourne sur ce SHA." >&2
+    echec=1
+    continue
+  fi
+  if echo "$ligne" | awk -F'\t' '$2 == "completed" && $3 == "success"' | grep -q .; then
+    echo "OK : ${check} est vert."
+  else
+    echo "ECHEC : le check requis '${check}' n'est pas vert :" >&2
+    echo "$ligne" | sed 's/^/    /' >&2
+    echec=1
+  fi
+done
+
+if [ "$echec" -ne 0 ]; then
+  echo "" >&2
+  echo "Deploiement refuse : la CI de ${SHA} n'est pas verte." >&2
+  exit 1
+fi
+
+echo "Gate CI OK : tous les checks requis sont verts."

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,140 @@
+name: Deploy prod
+
+# CD production, declenche par la publication d'une release GitHub NORMALE
+# (non pre-release). Une pre-release part sur staging (deploy-staging.yml).
+#
+# Memes garde-fous que staging, plus :
+#   - l'environment `production` exige une APPROBATION MANUELLE (required
+#     reviewer) : le job se met en pause avant d'ecrire quoi que ce soit ;
+#   - un backup Postgres est declenche AVANT le deploiement.
+#
+# La prod vit sur SecNumCloud (osc-secnum-fr1), region distincte de
+# dev/staging : le token peut devoir etre different de celui d'osc-fr1.
+#
+# PREREQUIS avant la premiere execution :
+#   - `tofu apply` de envs/prod (l'app nitrates-prod doit exister) ;
+#   - secret SCALINGO_API_TOKEN pose dans l'environment `production` ;
+#   - device TOTP enrole pour chaque compte admin (DJANGO_ADMIN_OTP_REQUIRED
+#     est a True en prod : sans device, login impossible).
+
+permissions:
+  contents: read
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Tag ou SHA a deployer en production"
+        required: true
+        type: string
+
+jobs:
+  gate-ci:
+    # Sur `release`, ne tourne QUE pour une release NON pre-release.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.release.prerelease == false
+    runs-on: ubuntu-latest
+    outputs:
+      ref: ${{ steps.resolve.outputs.ref }}
+      sha: ${{ steps.resolve.outputs.sha }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Resoudre la ref a deployer
+        id: resolve
+        env:
+          EVENT: ${{ github.event_name }}
+          INPUT_REF: ${{ inputs.ref }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          if [ "$EVENT" = "workflow_dispatch" ]; then
+            REF="$INPUT_REF"
+          else
+            REF="$TAG"
+          fi
+          git fetch --tags --force
+          SHA=$(git rev-parse "$REF")
+          echo "ref=$REF" >> "$GITHUB_OUTPUT"
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+          echo "Deploiement cible : $REF ($SHA)"
+
+      - name: Gate — la CI du SHA est verte
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash .github/scripts/gate_ci_green.sh "${{ steps.resolve.outputs.sha }}"
+
+  gate-e2e:
+    needs: gate-ci
+    uses: ./.github/workflows/e2e.yml
+
+  deploy-prod:
+    needs: [gate-ci, gate-e2e]
+    runs-on: ubuntu-latest
+    # C'est ICI que se joue la protection : l'environment `production` est
+    # configure avec un required reviewer -> le run attend l'approbation.
+    environment:
+      name: production
+      url: https://nitrates-prod.osc-secnum-fr1.scalingo.io/
+    env:
+      SCALINGO_REGION: osc-secnum-fr1
+      SCALINGO_APP: nitrates-prod
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.gate-ci.outputs.sha }}
+
+      - name: Installer la CLI Scalingo
+        run: |
+          curl -s -O https://cli-dl.scalingo.com/install && bash install
+          scalingo --version
+
+      # --- Backup DB AVANT tout ecrit -------------------------------------
+      # L'addon Postgres fait ses propres backups, mais on veut un point de
+      # restauration DATE SUR CE DEPLOIEMENT. Non bloquant : c'est un filet,
+      # et un backup indisponible ne doit pas empecher un correctif urgent
+      # de partir. L'echec est visible dans les logs.
+      - name: Backup Postgres (filet de securite)
+        env:
+          SCALINGO_API_TOKEN: ${{ secrets.SCALINGO_API_TOKEN }}
+        continue-on-error: true
+        run: |
+          addon=$(scalingo --region "$SCALINGO_REGION" --app "$SCALINGO_APP" \
+                  addons 2>/dev/null | grep -i postgres | awk '{print $2}' | head -1)
+          if [ -z "$addon" ]; then
+            echo "Addon Postgres introuvable -- backup saute." >&2
+            exit 1
+          fi
+          echo "Declenchement d'un backup sur l'addon ${addon}"
+          scalingo --region "$SCALINGO_REGION" --app "$SCALINGO_APP" \
+            --addon "$addon" backups-create
+
+      - name: Deploy code
+        env:
+          SCALINGO_API_TOKEN: ${{ secrets.SCALINGO_API_TOKEN }}
+        run: bash .github/scripts/deploy_release_code.sh "${{ needs.gate-ci.outputs.sha }}"
+
+      - name: Smoke test
+        env:
+          SCALINGO_API_TOKEN: ${{ secrets.SCALINGO_API_TOKEN }}
+        run: bash .github/scripts/deploy_release_smoke.sh
+
+      - name: Recapitulatif
+        if: always()
+        run: |
+          {
+            echo "## Deploiement production"
+            echo ""
+            echo "- Ref deployee : \`${{ needs.gate-ci.outputs.ref }}\`"
+            echo "- SHA : \`${{ needs.gate-ci.outputs.sha }}\`"
+            echo "- App : \`nitrates-prod\` (osc-secnum-fr1)"
+            echo ""
+            echo "Rollback : workflow **Rollback** -> environnement \`production\` -> tag precedent."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,125 @@
+name: Deploy staging
+
+# CD staging, declenche par la publication d'une PRE-RELEASE GitHub.
+#
+#   Release marquee "pre-release"  -> staging  (ce workflow)
+#   Release normale                -> prod     (deploy-prod.yml)
+#
+# Sequence, volontairement SANS reload de donnees (les arbres, referentiels et
+# jeux SIG de staging sont pilotes a la main) :
+#   1. gate CI  : le SHA du tag a ses checks verts
+#   2. gate e2e : suite Playwright complete sur base ephemere
+#   3. deploy   : git archive -> scalingo deploy (post_deploy joue migrate)
+#   4. smoke    : HTTP + aucune migration en attente
+#
+# Secret requis : SCALINGO_API_TOKEN, dans l'environment `staging`.
+
+permissions:
+  contents: read
+
+on:
+  release:
+    types: [published]
+  # Rejeu manuel (et deploiement d'un tag arbitraire sur staging).
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Tag ou SHA a deployer sur staging"
+        required: true
+        type: string
+
+jobs:
+  # --- 1. Gate CI --------------------------------------------------------
+  # Job separe et prealable : inutile de payer 10 min d'e2e si le SHA est
+  # deja rouge.
+  gate-ci:
+    # Sur `release`, ne tourne QUE pour une pre-release (une release normale
+    # part en prod). Sur workflow_dispatch, toujours.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.release.prerelease == true
+    runs-on: ubuntu-latest
+    outputs:
+      ref: ${{ steps.resolve.outputs.ref }}
+      sha: ${{ steps.resolve.outputs.sha }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Resoudre la ref a deployer
+        id: resolve
+        env:
+          EVENT: ${{ github.event_name }}
+          INPUT_REF: ${{ inputs.ref }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          if [ "$EVENT" = "workflow_dispatch" ]; then
+            REF="$INPUT_REF"
+          else
+            REF="$TAG"
+          fi
+          git fetch --tags --force
+          SHA=$(git rev-parse "$REF")
+          echo "ref=$REF" >> "$GITHUB_OUTPUT"
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+          echo "Deploiement cible : $REF ($SHA)"
+
+      - name: Gate — la CI du SHA est verte
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash .github/scripts/gate_ci_green.sh "${{ steps.resolve.outputs.sha }}"
+
+  # --- 2. Gate e2e -------------------------------------------------------
+  # Reutilise le workflow e2e (meme definition que le run nocturne).
+  gate-e2e:
+    needs: gate-ci
+    uses: ./.github/workflows/e2e.yml
+
+  # --- 3+4. Deploy + smoke -----------------------------------------------
+  deploy-staging:
+    needs: [gate-ci, gate-e2e]
+    runs-on: ubuntu-latest
+    # L'environment porte le secret et restreint qui peut le lire.
+    environment:
+      name: staging
+      url: https://nitrates-staging.osc-fr1.scalingo.io/
+    env:
+      SCALINGO_REGION: osc-fr1
+      SCALINGO_APP: nitrates-staging
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.gate-ci.outputs.sha }}
+
+      - name: Installer la CLI Scalingo
+        run: |
+          curl -s -O https://cli-dl.scalingo.com/install && bash install
+          scalingo --version
+
+      - name: Deploy code
+        env:
+          SCALINGO_API_TOKEN: ${{ secrets.SCALINGO_API_TOKEN }}
+        run: bash .github/scripts/deploy_release_code.sh "${{ needs.gate-ci.outputs.sha }}"
+
+      - name: Smoke test
+        env:
+          SCALINGO_API_TOKEN: ${{ secrets.SCALINGO_API_TOKEN }}
+        run: bash .github/scripts/deploy_release_smoke.sh
+
+      - name: Recapitulatif
+        if: always()
+        run: |
+          {
+            echo "## Deploiement staging"
+            echo ""
+            echo "- Ref deployee : \`${{ needs.gate-ci.outputs.ref }}\`"
+            echo "- SHA : \`${{ needs.gate-ci.outputs.sha }}\`"
+            echo "- App : \`nitrates-staging\` (osc-fr1)"
+            echo "- URL : https://nitrates-staging.osc-fr1.scalingo.io/"
+            echo ""
+            echo "Rollback : workflow **Rollback** -> environnement \`staging\` -> tag precedent."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,165 @@
+name: E2E nitrates
+
+# Suite Playwright nitrates, montee sur une base ephemere.
+#
+# Workflow REUTILISABLE (workflow_call) : appele en GATE par deploy-staging et
+# deploy-prod. Il n'est VOLONTAIREMENT pas branche sur les PR : le lot e2e dure
+# plusieurs minutes et ralentirait la boucle de dev. Le contrat est : une
+# version TAGGEE ne part sur staging/prod que si l'e2e est verte.
+#
+# Aussi appelable a la main (workflow_dispatch) et en nocturne (schedule) sur
+# main, pour ne pas decouvrir une regression e2e le jour de la release.
+#
+# Les specs `capture_*` sont EXCLUES : ce sont des outils de production de
+# captures d'ecran pour la validation juriste (elles ecrivent des manifestes),
+# pas des tests de non-regression.
+
+permissions:
+  contents: read
+
+on:
+  workflow_call: {}
+  workflow_dispatch: {}
+  schedule:
+    # Tous les jours a 03:17 UTC. Heure decalee (pas pile) pour eviter le pic
+    # de charge des runners GitHub a l'heure ronde.
+    - cron: "17 3 * * *"
+
+env:
+  DATABASE_URL: "postgis://envergo:envergo@localhost:5432/envergo"
+  USE_DOCKER: "False"
+  LANG: "fr_FR.UTF-8"
+  LC_ALL: "fr_FR.UTF-8"
+  DJANGO_SETTINGS_MODULE: "config.settings.ci"
+
+jobs:
+  e2e-nitrates:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    services:
+      database:
+        image: postgis/postgis:14-master
+        env:
+          POSTGRES_USER: envergo
+          POSTGRES_PASSWORD: envergo
+          POSTGRES_DB: envergo
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Checkout Code Repository
+        uses: actions/checkout@v7
+
+      # --- Locale FR : les specs assertent des libelles francais (dates,
+      # intitules de cultures). Sans la locale, les tests echouent sur du
+      # texte anglais.
+      - name: Installer la locale francaise
+        run: |
+          sudo apt update
+          sudo apt install -y language-pack-fr
+          sudo locale-gen
+          sudo update-locale LANG="fr_FR.UTF-8" LC_ALL="fr_FR.UTF-8"
+
+      - name: Dependances geo (GDAL/PROJ)
+        run: sudo apt install -y binutils libproj-dev gdal-bin gettext
+
+      - name: Extensions postgis sur template1
+        run: |
+          psql -d postgresql://envergo:envergo@localhost/template1 -c 'CREATE EXTENSION IF NOT EXISTS postgis;'
+          psql -d postgresql://envergo:envergo@localhost/template1 -c 'CREATE EXTENSION IF NOT EXISTS postgis_raster;'
+        env:
+          PGPASSWORD: envergo
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6.3.0
+        with:
+          python-version: 3.12.8
+
+      - name: Install python dependencies
+        run: pip install -r requirements/local.txt
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install js dependencies
+        run: npm ci
+
+      # Les specs testent le JS compile (cascade, flow couvert, carte Leaflet).
+      # Sans build, le serveur sert des assets absents -> tout casse.
+      - name: Build assets
+        run: bash bin/build_assets.sh
+
+      # --- Base : migrations + referentiels + arbres canoniques ------------
+      # Les specs interrogent /api/referentiels/ et /api/arbre/ (qui doit
+      # renvoyer l'arbre PAN, noeud racine n_zvn) : il faut donc les
+      # referentiels seedes ET au moins l'arbre PAN actif en DB.
+      - name: Preparer la base (migrate + referentiels + arbres)
+        run: |
+          python manage.py migrate --noinput
+          python manage.py seed_referentiels
+          python manage.py load_arbres_actifs
+
+      # --- Serveur de test -------------------------------------------------
+      # Le middleware SetUrlConfBasedOnSite force l'urlconf nitrates quel que
+      # soit le Host, donc pas besoin de bricoler une Site id=3 ici. On ajoute
+      # quand meme 127.0.0.1 aux ALLOWED_HOSTS (ci.py ne liste que localhost)
+      # car playwright.config.nitrates.ts cible 127.0.0.1.
+      #
+      # LOCKDOWN_BEHIND_LOGIN doit rester desactive : sinon toute requete
+      # anonyme est redirigee vers le login admin et les specs ne voient que
+      # la page de connexion.
+      - name: Lancer le serveur Django
+        env:
+          DJANGO_ALLOWED_HOSTS: "127.0.0.1,localhost"
+          DJANGO_LOCKDOWN_BEHIND_LOGIN: "False"
+          DJANGO_NITRATES_ROOT_OUVERT: "True"
+        run: |
+          python manage.py runserver 127.0.0.1:8042 --noreload &
+          echo "Attente du serveur sur 127.0.0.1:8042..."
+          for i in $(seq 1 60); do
+            code=$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:8042/ || echo "000")
+            if [ "$code" != "000" ]; then
+              echo "Serveur up (HTTP $code)"; exit 0
+            fi
+            sleep 2
+          done
+          echo "ECHEC : le serveur n'a pas demarre en 120s" >&2
+          exit 1
+
+      - name: Installer les navigateurs Playwright
+        run: npx playwright install --with-deps chromium
+
+      # --- Run --------------------------------------------------------------
+      # `capture_*` exclu (outils de capture, pas de la non-reg) ainsi que les
+      # specs prefixees `_` (scratchpads de mesure : _zoomj, _meas107, _iter107).
+      - name: Run Playwright (hors specs de capture)
+        env:
+          NITRATES_BASE_URL: "http://127.0.0.1:8042"
+          CI: "true"
+        run: |
+          npx playwright test \
+            --config playwright.config.nitrates.ts \
+            $(ls e2e/nitrates/*.spec.ts \
+                | grep -v '/capture_' \
+                | grep -v '/_' \
+                | tr '\n' ' ')
+
+      - name: Upload rapport Playwright
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            playwright-report/
+            test-results/
+          retention-days: 14
+          if-no-files-found: warn

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -1,0 +1,138 @@
+name: Rollback
+
+# ROLLBACK EN 1 CLIC : redeploie une version anterieure sur staging ou prod.
+#
+# Usage : onglet Actions -> "Rollback" -> "Run workflow" -> choisir
+# l'environnement et le tag a restaurer -> Run.
+#
+# Principe : Scalingo n'offre pas de rollback atomique fiable en CLI. Le
+# mecanisme le plus previsible est de REDEPLOYER l'archive d'un tag anterieur,
+# c'est-a-dire exactement le meme chemin que le deploiement nominal. Ce qui a
+# ete teste au deploiement l'est donc aussi au rollback.
+#
+# ATTENTION -- LIMITE ASSUMEE : ceci restaure le CODE, pas le SCHEMA DB.
+# Django ne joue pas de migration inverse. Si la version qu'on quitte a
+# introduit une migration DESTRUCTIVE (RemoveField, DeleteModel), redeployer
+# l'ancien code laisse la base dans le nouvel etat -> l'ancien code peut
+# planter. D'ou la regle : entre deux releases, migrations ADDITIVE-ONLY.
+# En cas de migration destructive, le rollback passe par la restauration du
+# backup Postgres (cf. runbook), pas par ce workflow.
+#
+# Le gate e2e est VOLONTAIREMENT absent : un rollback est une mesure
+# d'urgence, vers une version qui a deja ete testee et deployee. Rajouter
+# 10 minutes d'e2e pendant un incident serait contre-productif.
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+    inputs:
+      environnement:
+        description: "Environnement a restaurer"
+        required: true
+        type: choice
+        options:
+          - staging
+          - production
+      version:
+        description: "Tag (ou SHA) a restaurer, ex. v0.4.0"
+        required: true
+        type: string
+      motif:
+        description: "Motif du rollback (trace dans le recapitulatif)"
+        required: false
+        type: string
+        default: "non precise"
+
+jobs:
+  rollback:
+    runs-on: ubuntu-latest
+    environment:
+      name: ${{ inputs.environnement }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      # La cible (app + region) depend de l'environnement choisi. On la
+      # resout ici plutot que de dupliquer deux jobs quasi identiques.
+      - name: Resoudre la cible et la version
+        id: cible
+        env:
+          ENVIRONNEMENT: ${{ inputs.environnement }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          case "$ENVIRONNEMENT" in
+            staging)
+              echo "region=osc-fr1" >> "$GITHUB_OUTPUT"
+              echo "app=nitrates-staging" >> "$GITHUB_OUTPUT"
+              ;;
+            production)
+              echo "region=osc-secnum-fr1" >> "$GITHUB_OUTPUT"
+              echo "app=nitrates-prod" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "Environnement inconnu : $ENVIRONNEMENT" >&2; exit 1;;
+          esac
+          git fetch --tags --force
+          # Echoue proprement si le tag n'existe pas, AVANT de toucher a
+          # l'app (message clair plutot qu'un git archive cryptique).
+          if ! SHA=$(git rev-parse --verify "${VERSION}^{commit}" 2>/dev/null); then
+            echo "ECHEC : la version '${VERSION}' n'existe pas dans le repo." >&2
+            echo "Tags disponibles (10 derniers) :" >&2
+            git tag --sort=-creatordate | head -10 >&2
+            exit 1
+          fi
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+          echo "Rollback de $ENVIRONNEMENT vers $VERSION ($SHA)"
+
+      - name: Installer la CLI Scalingo
+        run: |
+          curl -s -O https://cli-dl.scalingo.com/install && bash install
+          scalingo --version
+
+      # Trace de l'etat qu'on quitte : indispensable pour le post-mortem, et
+      # pour savoir vers quoi "re-avancer" une fois le correctif pret.
+      - name: Tracer la version actuellement deployee
+        env:
+          SCALINGO_API_TOKEN: ${{ secrets.SCALINGO_API_TOKEN }}
+          SCALINGO_REGION: ${{ steps.cible.outputs.region }}
+          SCALINGO_APP: ${{ steps.cible.outputs.app }}
+        continue-on-error: true
+        run: |
+          echo "== Derniers deploiements AVANT rollback =="
+          scalingo --region "$SCALINGO_REGION" --app "$SCALINGO_APP" \
+            deployments 2>/dev/null | head -5
+
+      - name: Redeployer la version cible
+        env:
+          SCALINGO_API_TOKEN: ${{ secrets.SCALINGO_API_TOKEN }}
+          SCALINGO_REGION: ${{ steps.cible.outputs.region }}
+          SCALINGO_APP: ${{ steps.cible.outputs.app }}
+        run: bash .github/scripts/deploy_release_code.sh "${{ steps.cible.outputs.sha }}"
+
+      - name: Smoke test
+        env:
+          SCALINGO_API_TOKEN: ${{ secrets.SCALINGO_API_TOKEN }}
+          SCALINGO_REGION: ${{ steps.cible.outputs.region }}
+          SCALINGO_APP: ${{ steps.cible.outputs.app }}
+        run: bash .github/scripts/deploy_release_smoke.sh
+
+      - name: Recapitulatif
+        if: always()
+        run: |
+          {
+            echo "## Rollback ${{ inputs.environnement }}"
+            echo ""
+            echo "- Version restauree : \`${{ inputs.version }}\`"
+            echo "- SHA : \`${{ steps.cible.outputs.sha }}\`"
+            echo "- App : \`${{ steps.cible.outputs.app }}\` (${{ steps.cible.outputs.region }})"
+            echo "- Motif : ${{ inputs.motif }}"
+            echo "- Declenche par : @${{ github.actor }}"
+            echo ""
+            echo "> Rappel : ce rollback restaure le CODE. Si la version quittee"
+            echo "> a introduit une migration destructive, restaurer aussi le"
+            echo "> backup Postgres (cf. runbook)."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -393,6 +393,12 @@ ANALYTICS = {
         "SITE_ID": env("DJANGO_HAIE_SITE_ID", default=""),
         "SECURITY_TOKEN": env("DJANGO_HAIE_MATOMO_SECURITY_TOKEN", default=""),
     },
+    "NITRATES": {
+        "TRACKER_ENABLED": env("DJANGO_NITRATES_TRACKER_ENABLED", default=False),
+        "TRACKER_URL": env("DJANGO_NITRATES_TRACKER_URL", default=""),
+        "SITE_ID": env("DJANGO_NITRATES_SITE_ID", default=""),
+        "SECURITY_TOKEN": env("DJANGO_NITRATES_MATOMO_SECURITY_TOKEN", default=""),
+    },
 }
 
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"

--- a/envergo/static/nitrates/nitrates_analytics.js
+++ b/envergo/static/nitrates/nitrates_analytics.js
@@ -1,0 +1,77 @@
+// Tracking metier nitrates -> Matomo (events trackEvent).
+//
+// Le tag Matomo lui-meme (visites, rebond, devices, navigateurs) est injecte
+// par _analytics.html des que ANALYTICS["NITRATES"].TRACKER_ENABLED est vrai ;
+// ce module n'ajoute QUE les 4 compteurs metier demandes, en events Matomo :
+//
+//   Categorie "Simulateur"
+//     - RechercheCommune     : l'utilisateur a choisi une commune via la
+//                              recherche (autocomplete BAN).
+//     - SelectionPointCarte  : l'utilisateur a clique DIRECTEMENT sur la carte
+//                              (hors selection via la recherche de commune).
+//     - SimulationLancee     : l'utilisateur a soumis le formulaire (clic
+//                              "Lancer la simulation").
+//     - Simulation2Plus      : l'utilisateur a lance AU MOINS 2 simulations
+//                              (compteur persistant par navigateur).
+//
+// Les events sont emis par simulator.js via des CustomEvent (couplage faible :
+// pas de dependance a Matomo dans la logique carte/form). Ici on ecoute ces
+// events et on relaie vers _paq. sendBeacon garantit que l'event part meme
+// juste avant le full-reload GET de la soumission.
+(function () {
+  "use strict";
+
+  var _paq = (window._paq = window._paq || []);
+
+  // Fiabilise l'envoi juste avant une navigation (submit = GET full-reload) :
+  // Matomo bascule sur navigator.sendBeacon au lieu d'une image bloquante.
+  _paq.push(["alwaysUseSendBeacon"]);
+
+  function track(action, name) {
+    // name optionnel (ex: departement). Categorie fixe "Simulateur".
+    if (name === undefined) {
+      _paq.push(["trackEvent", "Simulateur", action]);
+    } else {
+      _paq.push(["trackEvent", "Simulateur", action, name]);
+    }
+  }
+
+  document.addEventListener("nitrates:recherche-commune", function () {
+    track("RechercheCommune");
+  });
+
+  document.addEventListener("nitrates:point-carte", function () {
+    track("SelectionPointCarte");
+  });
+
+  // "Lancer la simulation" : compteur persistant pour derouler le "2+".
+  // localStorage survit aux full-reload GET du parcours et aux sessions ; c'est
+  // ce qui permet de compter un utilisateur qui revient lancer une 2e simu.
+  var STORAGE_KEY = "nitrates_nb_simulations";
+
+  document.addEventListener("nitrates:simulation-lancee", function (e) {
+    var dept = (e && e.detail && e.detail.department) || undefined;
+    track("SimulationLancee", dept);
+
+    var n = 0;
+    try {
+      n = parseInt(window.localStorage.getItem(STORAGE_KEY) || "0", 10) || 0;
+    } catch (err) {
+      // localStorage indisponible (navigation privee stricte) : on degrade
+      // sans casser, on ne pourra juste pas deriver le "2+" pour ce visiteur.
+      n = 0;
+    }
+    n += 1;
+    try {
+      window.localStorage.setItem(STORAGE_KEY, String(n));
+    } catch (err) {
+      /* no-op */
+    }
+    // On emet Simulation2Plus UNE SEULE fois, au passage a la 2e simulation,
+    // pour un compteur "au moins 2 simulations" propre (pas incremente a
+    // chaque simu au-dela de 2).
+    if (n === 2) {
+      track("Simulation2Plus");
+    }
+  });
+})();

--- a/envergo/static/nitrates/simulator.js
+++ b/envergo/static/nitrates/simulator.js
@@ -571,6 +571,13 @@
   map.on("click", function (e) {
     const { lat, lng } = e.latlng;
 
+    // Analytics (#Matomo) : ne compter que les clics carte REELS. selectCommune
+    // rejoue ce handler via map.fire(...) sans originalEvent -> on l'exclut ici
+    // (il est deja compte comme "RechercheCommune").
+    if (e.originalEvent) {
+      document.dispatchEvent(new CustomEvent("nitrates:point-carte"));
+    }
+
     // Pre-remplit le form -- c'est l'objectif principal de cette page.
     lngInput.value = lng.toFixed(6);
     latInput.value = lat.toFixed(6);
@@ -766,6 +773,8 @@
       // exactement quelle commune (parmi les homonymes) a ete retenue.
       searchInput.value = libelleSuggestion(feature.properties || {});
       closeSearch();
+      // Analytics (#Matomo) : l'utilisateur a utilise la recherche de commune.
+      document.dispatchEvent(new CustomEvent("nitrates:recherche-commune"));
       // Une fois le form revele (apres le reverse-geocode async), on deplace le
       // focus sur le 1er radio de la 1re question (Carte #154, a11y) : Max veut
       // qu'apres selection d'une ville, Tab/Entree operent directement sur le
@@ -863,6 +872,25 @@
       }
     });
   }
+
+  // Analytics (#Matomo) : "Lancer la simulation" = submit du formulaire (le
+  // parcours est un GET full-reload). On emet l'event AVANT la navigation ;
+  // sendBeacon (cf. nitrates_analytics.js) garantit qu'il parte. On enrichit
+  // avec le departement (2 premiers chiffres du code INSEE) quand il est connu.
+  (function trackSimulationSubmit() {
+    const form = document.getElementById("form-simulateur");
+    if (!form) return;
+    form.addEventListener("submit", function () {
+      const insee =
+        (document.getElementById("id_code_insee") || {}).value || "";
+      const department = insee ? insee.slice(0, 2) : undefined;
+      document.dispatchEvent(
+        new CustomEvent("nitrates:simulation-lancee", {
+          detail: { department: department },
+        })
+      );
+    });
+  })();
 
   // #271 : au chargement d'une PAGE RÉSULTAT, on établit le scope de RÉFÉRENCE
   // en interrogeant DebugView pour le point du résultat (lat/lng des hidden).

--- a/envergo/templates/nitrates/simulateur.html
+++ b/envergo/templates/nitrates/simulateur.html
@@ -53,6 +53,9 @@
   </script>
   {# static_v : ?v=<mtime> en DEBUG pour casser le cache navigateur du JS (sinon #}
   {# dev server + cache servent une version perimee malgre hard-refresh). #}
+  {# Tracking metier -> Matomo (recherche commune, point carte, simulation, 2+). #}
+  {# Charge avant simulator.js pour que ses listeners d'events soient prets. #}
+  <script defer src="{% static_v 'nitrates/nitrates_analytics.js' %}"></script>
   <script defer src="{% static_v 'nitrates/simulator.js' %}"></script>
   <script defer src="{% static_v 'nitrates/cascade.js' %}"></script>
   {# Barre de progression du parcours, fixee top (#154). #}

--- a/envergo/utils/context_processors.py
+++ b/envergo/utils/context_processors.py
@@ -26,11 +26,12 @@ def settings_context(_request):
             else settings.CRISP["AMENAGEMENT"]["CHATBOX_ENABLED"]
         )
 
-    analytics = (
-        settings.ANALYTICS["HAIE"]
-        if _request.site.domain == settings.ENVERGO_HAIE_DOMAIN
-        else settings.ANALYTICS["AMENAGEMENT"]
-    )
+    if _request.site.domain == settings.ENVERGO_HAIE_DOMAIN:
+        analytics = settings.ANALYTICS["HAIE"]
+    elif _request.site.domain == settings.ENVERGO_NITRATES_DOMAIN:
+        analytics = settings.ANALYTICS["NITRATES"]
+    else:
+        analytics = settings.ANALYTICS["AMENAGEMENT"]
 
     crisp_website_id = (
         settings.CRISP["HAIE"]["WEBSITE_ID"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,8 +35,8 @@
         "pixrem": "^5.0.0",
         "prettier": "3.9.4",
         "sass": "^1.101.0",
-        "stylelint": "^16.14.1",
-        "stylelint-config-standard-scss": "^14.0.0"
+        "stylelint": "^17.14.1",
+        "stylelint-config-standard-scss": "^17.0.0"
       },
       "engines": {
         "node": "20",
@@ -44,14 +44,15 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.26.2",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
-      "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
-        "picocolors": "^1.0.0"
+        "picocolors": "^1.1.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -103,6 +104,30 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@cacheable/memory": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.2.0.tgz",
+      "integrity": "sha512-CTLKqLItRCEixEAewD3/j9DB3/o96gpTPD4eJ1v+DGOlxZRZncRQkGYqqnAGCscYd6RNeXfGeiuCphsPtqyIfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cacheable/utils": "^2.5.0",
+        "@keyv/bigmap": "^1.3.1",
+        "hookified": "^1.15.1",
+        "keyv": "^5.6.0"
+      }
+    },
+    "node_modules/@cacheable/utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.5.0.tgz",
+      "integrity": "sha512-buipgOVDkkPXNR5+xBpDw7Zk2n1EvU7qBJCNUcL7rhQ//kfpOXPAvQ511Os0vpLYJ1pZnvudNytkQt2hst3wqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hashery": "^1.5.1",
+        "keyv": "^5.6.0"
+      }
+    },
     "node_modules/@colordx/core": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/@colordx/core/-/core-5.5.0.tgz",
@@ -110,10 +135,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@csstools/css-parser-algorithms": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.4.tgz",
-      "integrity": "sha512-Up7rBoV77rv29d3uKHUIVubz1BTcgyUK72IvCQAbfbMv584xHcGKCKbWh7i8hPrRJ7qU4Y8IO3IY9m+iTB7P3A==",
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
       "dev": true,
       "funding": [
         {
@@ -125,17 +150,67 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
+      "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "@csstools/css-tokenizer": "^3.0.3"
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.7.tgz",
+      "integrity": "sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
       }
     },
     "node_modules/@csstools/css-tokenizer": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.3.tgz",
-      "integrity": "sha512-UJnjoFsmxfKUdNYdWgOB0mWUypuLvAfQPH1+pyvRJs6euowbFkFC6P13w1l8mJyi3vxYMxc9kld5jZEGRQs6bw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
       "dev": true,
       "funding": [
         {
@@ -147,14 +222,15 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
+      "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@csstools/media-query-list-parser": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-4.0.2.tgz",
-      "integrity": "sha512-EUos465uvVvMJehckATTlNqGj4UJWkTmdWuDMjqvSUkjGpmOyFZBVwb4knxCm/k2GMTXY+c/5RkdndzFYWeX5A==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-5.0.0.tgz",
+      "integrity": "sha512-T9lXmZOfnam3eMERPsszjY5NK0jX8RmThmmm99FZ8b7z8yMaFZWKwLWGZuTwdO3ddRY5fy13GmmEYZXB4I98Eg==",
       "dev": true,
       "funding": [
         {
@@ -166,18 +242,42 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
+      "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^3.0.4",
-        "@csstools/css-tokenizer": "^3.0.3"
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/selector-resolve-nested": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-resolve-nested/-/selector-resolve-nested-4.0.1.tgz",
+      "integrity": "sha512-j3vdQu0XwLME5qOTWxm8cnmvsf423R2YL6DbKklCHZwkDm7UdKNu6RPlw4REIJhSlKBICY3B70/7QZdicLqZgg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "postcss-selector-parser": "^7.1.1"
       }
     },
     "node_modules/@csstools/selector-specificity": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-5.0.0.tgz",
-      "integrity": "sha512-PCqQV3c4CoVm3kdPhyeZ07VmBRdH2EpMFA/pd9OASpOEC3aXNGoqPDAZ80D0cLpMBxnmk0+yNhGsEx31hq7Gtw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-6.0.0.tgz",
+      "integrity": "sha512-4sSgl78OtOXEX/2d++8A83zHNTgwCJMaR24FvsYL7Uf/VS8HZk9PTwR51elTbGqMuwH3szLvvOXEaVnqn0Z3zA==",
       "dev": true,
       "funding": [
         {
@@ -189,21 +289,12 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
+      "license": "MIT-0",
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "postcss-selector-parser": "^7.0.0"
-      }
-    },
-    "node_modules/@dual-bundle/import-meta-resolve": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@dual-bundle/import-meta-resolve/-/import-meta-resolve-4.1.0.tgz",
-      "integrity": "sha512-+nxncfwHM5SgAtrVzgpzJOI1ol0PkumhVo469KCf9lUi21IGcY90G98VuHm9VRrUypmAzawAHO9bs6hqeADaVg==",
-      "dev": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
+        "postcss-selector-parser": "^7.1.1"
       }
     },
     "node_modules/@gouvfr/dsfr": {
@@ -295,14 +386,29 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@keyv/serialize": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.0.2.tgz",
-      "integrity": "sha512-+E/LyaAeuABniD/RvUezWVXKpeuvwLEA9//nE9952zBaOdBd2mQ3pPoM8cUe2X6IcMByfuSLzmYqnYshG60+HQ==",
+    "node_modules/@keyv/bigmap": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.3.1.tgz",
+      "integrity": "sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "buffer": "^6.0.3"
+        "hashery": "^1.4.0",
+        "hookified": "^1.15.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "keyv": "^5.6.0"
       }
+    },
+    "node_modules/@keyv/serialize": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
+      "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -821,7 +927,8 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "dev": true,
+      "license": "Python-2.0"
     },
     "node_modules/arr-diff": {
       "version": "1.1.0",
@@ -879,15 +986,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/array-union": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/assign-symbols": {
@@ -1657,13 +1755,17 @@
       }
     },
     "node_modules/cacheable": {
-      "version": "1.8.8",
-      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-1.8.8.tgz",
-      "integrity": "sha512-OE1/jlarWxROUIpd0qGBSKFLkNsotY8pt4GeiVErUYh/NUeTNrT+SBksUgllQv4m6a0W/VZsLuiHb88maavqEw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.5.0.tgz",
+      "integrity": "sha512-60cyAOytib/OzBw1JNSoSV/boK1AtHryDIjvVBk7XbN4ugfkM3+Sry7fEjNgPMGgOjuaZPAp8ruZ0Cxafwyq9g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "hookified": "^1.7.0",
-        "keyv": "^5.2.3"
+        "@cacheable/memory": "^2.2.0",
+        "@cacheable/utils": "^2.5.0",
+        "hookified": "^1.15.0",
+        "keyv": "^5.6.0",
+        "qified": "^0.10.1"
       }
     },
     "node_modules/cacheable-request": {
@@ -2036,10 +2138,11 @@
       }
     },
     "node_modules/cosmiconfig": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
-      "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.2.tgz",
+      "integrity": "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -2079,12 +2182,13 @@
       }
     },
     "node_modules/css-functions-list": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.2.3.tgz",
-      "integrity": "sha512-IQOkD3hbR5KrN93MtcYuad6YPuTSUhntLHDuLEbFWE+ff2/XSZNdZG+LcbbIW5AXKg/WFIfYItIzVoHngHXZzA==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.3.3.tgz",
+      "integrity": "sha512-8HFEBPKhOpJPEPu70wJJetjKta86Gw9+CCyCnB3sui2qQfOvRyqBy4IKLKKAwdMpWb2lHXWk9Wb4Z6AmaUT1Pg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=12 || >=16"
+        "node": ">=12"
       }
     },
     "node_modules/css-select": {
@@ -2105,13 +2209,14 @@
       }
     },
     "node_modules/css-tree": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
-      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "mdn-data": "2.12.2",
-        "source-map-js": "^1.0.1"
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
@@ -2534,27 +2639,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/dir-glob": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-      "dev": true,
-      "dependencies": {
-        "path-type": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/dir-glob/node_modules/path-type": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/dom-serializer": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
@@ -2877,6 +2961,7 @@
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
       "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -2894,10 +2979,11 @@
       }
     },
     "node_modules/error-ex": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
       }
@@ -3295,12 +3381,13 @@
       }
     },
     "node_modules/file-entry-cache": {
-      "version": "10.0.6",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-10.0.6.tgz",
-      "integrity": "sha512-0wvv16mVo9nN0Md3k7DMjgAPKG/TY4F/gYMBVb/wMThFRJvzrpaqBFqF6km9wf8QfYTN+mNg5aeaBLfy8k35uA==",
+      "version": "11.1.5",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.5.tgz",
+      "integrity": "sha512-+PFTHITI08JIGhnNpGNI8T8inUpgZfk3GNEqfT9R2zZV2iFXg3CvqzSl/uEhs7TSGujYRELEANyDvS8Fj7+S7Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "flat-cache": "^6.1.6"
+        "flat-cache": "^6.1.23"
       }
     },
     "node_modules/file-type": {
@@ -3437,21 +3524,23 @@
       }
     },
     "node_modules/flat-cache": {
-      "version": "6.1.6",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.6.tgz",
-      "integrity": "sha512-F+CKgSwp0pzLx67u+Zy1aCueVWFAHWbXepvXlZ+bWVTaASbm5SyCnSJ80Fp1ePEmS57wU+Bf6cx6525qtMZ4lQ==",
+      "version": "6.1.23",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.23.tgz",
+      "integrity": "sha512-f++BY9pTk+983xK1FLzlLpmM0i0z+jHmx3QESGkURMXujQZz1k5wzwX6hjnQ8goaD0B+sYnDK1yZ6MTyZfUaqA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "cacheable": "^1.8.8",
-        "flatted": "^3.3.2",
-        "hookified": "^1.7.0"
+        "cacheable": "^2.5.0",
+        "flatted": "^3.4.2",
+        "hookified": "^1.15.0"
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.2.tgz",
-      "integrity": "sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==",
-      "dev": true
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
+      "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/follow-redirects": {
       "version": "1.15.9",
@@ -3601,6 +3690,19 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-proxy": {
@@ -4462,6 +4564,19 @@
         "node": "*"
       }
     },
+    "node_modules/hashery": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/hashery/-/hashery-1.5.1.tgz",
+      "integrity": "sha512-iZyKG96/JwPz1N55vj2Ie2vXbhu440zfUfJvSwEqEbeLluk7NnapfGqa7LH0mOsnDxTF85Mx8/dyR6HfqcbmbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hookified": "^1.15.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
@@ -4489,18 +4604,20 @@
       }
     },
     "node_modules/hookified": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.7.0.tgz",
-      "integrity": "sha512-XQdMjqC1AyeOzfs+17cnIk7Wdfu1hh2JtcyNfBf5u9jHrT3iZUlGHxLTntFBuk5lwkqJ6l3+daeQdHK5yByHVA==",
-      "dev": true
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.15.1.tgz",
+      "integrity": "sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/html-tags": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.3.1.tgz",
-      "integrity": "sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-5.1.0.tgz",
+      "integrity": "sha512-n6l5uca7/y5joxZ3LUePhzmBFUJ+U2YWzhMa8XUTecSeSlQiZdF5XAd/Q3/WUl0VsXgUwWi8I7CNIwdI5WN1SQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=20.10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -4606,10 +4723,11 @@
       ]
     },
     "node_modules/ignore": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.3.tgz",
-      "integrity": "sha512-bAH5jbK/F3T3Jls4I0SO1hmPR0dKU0a7+SY6n1yzRtG54FLO8d6w/nxLFX2Nb7dBu6cCWXPaAME6cYqFUMmuCA==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 4"
       }
@@ -4911,6 +5029,7 @@
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
       "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -4920,15 +5039,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/import-fresh/node_modules/resolve-from": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/import-lazy": {
@@ -4941,13 +5051,15 @@
         "node": ">=6"
       }
     },
-    "node_modules/imurmurhash": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
       "dev": true,
-      "engines": {
-        "node": ">=0.8.19"
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/inflight": {
@@ -5023,7 +5135,8 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -5198,6 +5311,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-path-inside": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
+      "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-plain-obj": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
@@ -5358,13 +5484,25 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -5383,7 +5521,8 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
@@ -5417,12 +5556,13 @@
       "integrity": "sha512-b+z6yF1d4EOyDgylzQo5IminlUmzSeqR1hs/bzjBNjuGras4FXq/6TrzjxfN0j+TmI0ltJzTNlqXUMCniciwKQ=="
     },
     "node_modules/keyv": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.2.3.tgz",
-      "integrity": "sha512-AGKecUfzrowabUv0bH1RIR5Vf7w+l4S3xtQAypKaUpTdIR1EbrAcTxHCrpo9Q+IWeUlFE2palRtgIQcgm+PQJw==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@keyv/serialize": "^1.0.2"
+        "@keyv/serialize": "^1.1.1"
       }
     },
     "node_modules/kind-of": {
@@ -5435,10 +5575,11 @@
       }
     },
     "node_modules/known-css-properties": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.35.0.tgz",
-      "integrity": "sha512-a/RAk2BfKk+WFGhhOCAYqSiFLc34k8Mt/6NWRI4joER0EYUzXIcFivjjnoD3+XU1DggLn/tZc3DOAgke7l8a4A==",
-      "dev": true
+      "version": "0.37.0",
+      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.37.0.tgz",
+      "integrity": "sha512-JCDrsP4Z1Sb9JwG0aJ8Eo2r7k4Ou5MwmThS/6lcIe1ICyb7UBJKGRIUUdqc2ASdE/42lgz6zFUnzAIhtXnBVrQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/last-run": {
       "version": "2.0.0",
@@ -5510,7 +5651,8 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash": {
       "version": "4.17.21",
@@ -5598,28 +5740,31 @@
       }
     },
     "node_modules/mathml-tag-names": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz",
-      "integrity": "sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-4.0.0.tgz",
+      "integrity": "sha512-aa6AU2Pcx0VP/XWnh8IGL0SYSgQHDT6Ucror2j2mXeFAlN3ahaNs8EZtG1YiticMkSLj3Gt6VPFfZogt7G5iFQ==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/mdn-data": {
-      "version": "2.12.2",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
-      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
-      "dev": true
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/meow": {
-      "version": "13.2.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
-      "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-14.1.0.tgz",
+      "integrity": "sha512-EDYo6VlmtnumlcBCbh1gLJ//9jvM/ndXHfVXIFrZVr6fGcwTUyCTFNTLCKuY3ffbK8L/+3Mzqnd58RojiZqHVw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -6164,6 +6309,7 @@
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
       },
@@ -6176,6 +6322,7 @@
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -6200,6 +6347,7 @@
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
       "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "error-ex": "^1.3.1",
@@ -6662,7 +6810,8 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
       "integrity": "sha512-3sOlxmbKcSHMjlUXQZKQ06jOswE7oVkXPxmZdoB1r5l0q6gTFTQSHxNxOrCccElbW7dxNytifNEo8qidX2Vsig==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/postcss-merge-longhand": {
       "version": "8.0.1",
@@ -7014,6 +7163,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=12.0"
       },
@@ -7291,6 +7441,26 @@
         "once": "^1.3.1"
       }
     },
+    "node_modules/qified": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/qified/-/qified-0.10.1.tgz",
+      "integrity": "sha512-+Owyggi9IxT1ePKGafcI87ubSmxol6smwJ+RAHDQlx9+9cPwFWDiKFFCPuWhr9ignlGpZ9vDQLw67N4dcTVFEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hookified": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/qified/node_modules/hookified": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-2.2.0.tgz",
+      "integrity": "sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/query-string": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
@@ -7504,12 +7674,13 @@
       }
     },
     "node_modules/resolve-from": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=4"
       }
     },
     "node_modules/resolve-options": {
@@ -8406,9 +8577,9 @@
       }
     },
     "node_modules/stylelint": {
-      "version": "16.14.1",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.14.1.tgz",
-      "integrity": "sha512-oqCL7AC3786oTax35T/nuLL8p2C3k/8rHKAooezrPGRvUX0wX+qqs5kMWh5YYT4PHQgVDobHT4tw55WgpYG6Sw==",
+      "version": "17.14.1",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-17.14.1.tgz",
+      "integrity": "sha512-xVQwyiuxALUBNB2fBe0tmNemg9KqLtdj3T64mioFDar79B2cU8LIyz+3KL6LdiHs9NkeNfwxpKSaIVOY8f112g==",
       "dev": true,
       "funding": [
         {
@@ -8420,57 +8591,55 @@
           "url": "https://github.com/sponsors/stylelint"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "@csstools/css-parser-algorithms": "^3.0.4",
-        "@csstools/css-tokenizer": "^3.0.3",
-        "@csstools/media-query-list-parser": "^4.0.2",
-        "@csstools/selector-specificity": "^5.0.0",
-        "@dual-bundle/import-meta-resolve": "^4.1.0",
-        "balanced-match": "^2.0.0",
+        "@csstools/css-calc": "^3.2.1",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.6",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "@csstools/media-query-list-parser": "^5.0.0",
+        "@csstools/selector-resolve-nested": "^4.0.0",
+        "@csstools/selector-specificity": "^6.0.0",
         "colord": "^2.9.3",
-        "cosmiconfig": "^9.0.0",
-        "css-functions-list": "^3.2.3",
-        "css-tree": "^3.1.0",
-        "debug": "^4.3.7",
+        "cosmiconfig": "^9.0.2",
+        "css-functions-list": "^3.3.3",
+        "css-tree": "^3.2.1",
+        "debug": "^4.4.3",
         "fast-glob": "^3.3.3",
         "fastest-levenshtein": "^1.0.16",
-        "file-entry-cache": "^10.0.5",
+        "file-entry-cache": "^11.1.5",
         "global-modules": "^2.0.0",
-        "globby": "^11.1.0",
+        "globby": "^16.2.1",
         "globjoin": "^0.1.4",
-        "html-tags": "^3.3.1",
-        "ignore": "^7.0.3",
-        "imurmurhash": "^0.1.4",
-        "is-plain-object": "^5.0.0",
-        "known-css-properties": "^0.35.0",
-        "mathml-tag-names": "^2.1.3",
-        "meow": "^13.2.0",
+        "html-tags": "^5.1.0",
+        "ignore": "^7.0.5",
+        "import-meta-resolve": "^4.2.0",
+        "mathml-tag-names": "^4.0.0",
+        "meow": "^14.1.0",
         "micromatch": "^4.0.8",
         "normalize-path": "^3.0.0",
         "picocolors": "^1.1.1",
-        "postcss": "^8.5.1",
-        "postcss-resolve-nested-selector": "^0.1.6",
+        "postcss": "^8.5.16",
         "postcss-safe-parser": "^7.0.1",
-        "postcss-selector-parser": "^7.0.0",
+        "postcss-selector-parser": "^7.1.4",
         "postcss-value-parser": "^4.2.0",
-        "resolve-from": "^5.0.0",
-        "string-width": "^4.2.3",
-        "supports-hyperlinks": "^3.1.0",
+        "string-width": "^8.2.1",
+        "supports-hyperlinks": "^4.5.0",
         "svg-tags": "^1.0.0",
         "table": "^6.9.0",
-        "write-file-atomic": "^5.0.1"
+        "write-file-atomic": "^7.0.1"
       },
       "bin": {
         "stylelint": "bin/stylelint.mjs"
       },
       "engines": {
-        "node": ">=18.12.0"
+        "node": ">=20.19.0"
       }
     },
     "node_modules/stylelint-config-recommended": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-14.0.1.tgz",
-      "integrity": "sha512-bLvc1WOz/14aPImu/cufKAZYfXs/A/owZfSMZ4N+16WGXLoX5lOir53M6odBxvhgmgdxCVnNySJmZKx73T93cg==",
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-18.0.0.tgz",
+      "integrity": "sha512-mxgT2XY6YZ3HWWe3Di8umG6aBmWmHTblTgu/f10rqFXnyWxjKWwNdjSWkgkwCtxIKnqjSJzvFmPT5yabVIRxZg==",
       "dev": true,
       "funding": [
         {
@@ -8482,29 +8651,31 @@
           "url": "https://github.com/sponsors/stylelint"
         }
       ],
+      "license": "MIT",
       "engines": {
-        "node": ">=18.12.0"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "stylelint": "^16.1.0"
+        "stylelint": "^17.0.0"
       }
     },
     "node_modules/stylelint-config-recommended-scss": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-14.1.0.tgz",
-      "integrity": "sha512-bhaMhh1u5dQqSsf6ri2GVWWQW5iUjBYgcHkh7SgDDn92ijoItC/cfO/W+fpXshgTQWhwFkP1rVcewcv4jaftRg==",
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-17.0.1.tgz",
+      "integrity": "sha512-x5DVehzJudcwF0od3sGpgkln2PLLranFE7twwbp7dqDINCyZvwzFkMc6TLhNOvazRiVBJYATQLouJY0xPGB8WA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "postcss-scss": "^4.0.9",
-        "stylelint-config-recommended": "^14.0.1",
-        "stylelint-scss": "^6.4.0"
+        "stylelint-config-recommended": "^18.0.0",
+        "stylelint-scss": "^7.0.0"
       },
       "engines": {
-        "node": ">=18.12.0"
+        "node": ">=20"
       },
       "peerDependencies": {
         "postcss": "^8.3.3",
-        "stylelint": "^16.6.1"
+        "stylelint": "^17.0.0"
       },
       "peerDependenciesMeta": {
         "postcss": {
@@ -8513,9 +8684,9 @@
       }
     },
     "node_modules/stylelint-config-standard": {
-      "version": "36.0.1",
-      "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-36.0.1.tgz",
-      "integrity": "sha512-8aX8mTzJ6cuO8mmD5yon61CWuIM4UD8Q5aBcWKGSf6kg+EC3uhB+iOywpTK4ca6ZL7B49en8yanOFtUW0qNzyw==",
+      "version": "40.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-40.0.0.tgz",
+      "integrity": "sha512-EznGJxOUhtWck2r6dJpbgAdPATIzvpLdK9+i5qPd4Lx70es66TkBPljSg4wN3Qnc6c4h2n+WbUrUynQ3fanjHw==",
       "dev": true,
       "funding": [
         {
@@ -8527,31 +8698,33 @@
           "url": "https://github.com/sponsors/stylelint"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "stylelint-config-recommended": "^14.0.1"
+        "stylelint-config-recommended": "^18.0.0"
       },
       "engines": {
-        "node": ">=18.12.0"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "stylelint": "^16.1.0"
+        "stylelint": "^17.0.0"
       }
     },
     "node_modules/stylelint-config-standard-scss": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-standard-scss/-/stylelint-config-standard-scss-14.0.0.tgz",
-      "integrity": "sha512-6Pa26D9mHyi4LauJ83ls3ELqCglU6VfCXchovbEqQUiEkezvKdv6VgsIoMy58i00c854wVmOw0k8W5FTpuaVqg==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-standard-scss/-/stylelint-config-standard-scss-17.0.0.tgz",
+      "integrity": "sha512-uLJS6xgOCBw5EMsDW7Ukji8l28qRoMnkRch15s0qwZpskXvWt9oPzMmcYM307m9GN4MxuWLsQh4I6hU9yI53cQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "stylelint-config-recommended-scss": "^14.1.0",
-        "stylelint-config-standard": "^36.0.1"
+        "stylelint-config-recommended-scss": "^17.0.0",
+        "stylelint-config-standard": "^40.0.0"
       },
       "engines": {
-        "node": ">=18.12.0"
+        "node": ">=20"
       },
       "peerDependencies": {
         "postcss": "^8.3.3",
-        "stylelint": "^16.11.0"
+        "stylelint": "^17.0.0"
       },
       "peerDependenciesMeta": {
         "postcss": {
@@ -8560,44 +8733,63 @@
       }
     },
     "node_modules/stylelint-scss": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-6.11.0.tgz",
-      "integrity": "sha512-AvJ6LVzz2iXHxPlPTR9WVy73FC/vmohH54VySNlCKX1NIXNAeuzy/VbIkMJLMyw/xKYqkgY4kAgB+qy5BfCaCg==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-7.2.0.tgz",
+      "integrity": "sha512-6E79Bachv0Iz0gqRUZgdqdXCsiq26DWBWIBNHYtjTmAp3wJu6cp/I37VfW7BPntmh2puF3bY09XWl4HZGrLhzw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "css-tree": "^3.0.1",
+        "@csstools/css-calc": "^3.2.1",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.4",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "css-tree": "^3.2.1",
         "is-plain-object": "^5.0.0",
-        "known-css-properties": "^0.35.0",
-        "mdn-data": "^2.15.0",
+        "known-css-properties": "^0.37.0",
         "postcss-media-query-parser": "^0.2.3",
         "postcss-resolve-nested-selector": "^0.1.6",
-        "postcss-selector-parser": "^7.0.0",
+        "postcss-selector-parser": "^7.1.1",
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
-        "node": ">=18.12.0"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "stylelint": "^16.0.2"
+        "stylelint": "^16.8.2 || ^17.0.0"
       }
     },
-    "node_modules/stylelint-scss/node_modules/mdn-data": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.15.0.tgz",
-      "integrity": "sha512-KIrS0lFPOqA4DgeO16vI5fkAsy8p++WBlbXtB5P1EQs8ubBgguAInNd1DnrCeTRfGchY0kgThgDOOIPyOLH2dQ==",
-      "dev": true
+    "node_modules/stylelint/node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
-    "node_modules/stylelint/node_modules/balanced-match": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-2.0.0.tgz",
-      "integrity": "sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==",
-      "dev": true
+    "node_modules/stylelint/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
     },
     "node_modules/stylelint/node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -8637,32 +8829,24 @@
       }
     },
     "node_modules/stylelint/node_modules/globby": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-16.2.3.tgz",
+      "integrity": "sha512-VZX7TV7jmd/pn71vdnLKtgwy1IWqc3KjI9x1/UtPkwoKk5fKrNLY30ltDe3cAM5xruIN7YuuaulFt133jRrKZg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "array-union": "^2.1.0",
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.2.9",
-        "ignore": "^5.2.0",
-        "merge2": "^1.4.1",
-        "slash": "^3.0.0"
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "fast-glob": "^3.3.3",
+        "ignore": "^7.0.5",
+        "is-path-inside": "^4.0.0",
+        "slash": "^5.1.0",
+        "unicorn-magic": "^0.4.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/stylelint/node_modules/globby/node_modules/ignore": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
-      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-      "dev": true,
-      "engines": {
-        "node": ">= 4"
       }
     },
     "node_modules/stylelint/node_modules/kind-of": {
@@ -8678,15 +8862,53 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
-    },
-    "node_modules/stylelint/node_modules/slash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stylelint/node_modules/string-width": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+      "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
       "engines": {
-        "node": ">=8"
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stylelint/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/stylelint/node_modules/unicorn-magic": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.4.0.tgz",
+      "integrity": "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/super-regex": {
@@ -8717,19 +8939,46 @@
       }
     },
     "node_modules/supports-hyperlinks": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz",
-      "integrity": "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-4.5.0.tgz",
+      "integrity": "sha512-ZW2OvfeCXrNTbLakPUzjQG922EeGCOteFSVoek5DKStTh898wf7zgtuFlzQN8HfZCxC3Eh02yJVrRW51hADf+w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "has-flag": "^4.0.0",
-        "supports-color": "^7.0.0"
+        "has-flag": "^5.0.1",
+        "supports-color": "^10.2.2"
       },
       "engines": {
-        "node": ">=14.18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
+      }
+    },
+    "node_modules/supports-hyperlinks/node_modules/has-flag": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-5.0.1.tgz",
+      "integrity": "sha512-CsNUt5x9LUdx6hnk/E2SZLsDyvfqANZSUq4+D3D8RzDJ2M+HDTIkF60ibS1vHaK55vzgiZw1bEPFG9yH7l33wA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-hyperlinks/node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/supports-preserve-symlinks-flag": {
@@ -9558,16 +9807,16 @@
       "dev": true
     },
     "node_modules/write-file-atomic": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
-      "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-7.0.1.tgz",
+      "integrity": "sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
-        "imurmurhash": "^0.1.4",
         "signal-exit": "^4.0.1"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/write-file-atomic/node_modules/signal-exit": {
@@ -9575,6 +9824,7 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=14"
       },

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     "pixrem": "^5.0.0",
     "prettier": "3.9.4",
     "sass": "^1.101.0",
-    "stylelint": "^16.14.1",
-    "stylelint-config-standard-scss": "^14.0.0"
+    "stylelint": "^17.14.1",
+    "stylelint-config-standard-scss": "^17.0.0"
   },
   "overrides": {
     "ws": "^8.21.0"


### PR DESCRIPTION
Propage sur `main` les deux PR mergées sur `develop` ce matin.

- **#347** — pipeline de livraison staging/prod par release GitHub, e2e Playwright en gate, rollback en 1 clic. Vide au passage `cron.json` des tâches Aménagement héritées du fork (celle de 4h du matin faisait remonter un `Site.DoesNotExist` hebdomadaire dans Sentry).
- **#343** — tracking Matomo du simulateur et 4 compteurs métier.

CI verte sur les deux avant merge, rebasées sur l'état courant de `develop`.