### PR TITLE
nitrates(sécurité): durcir les headers HTTP (#265, findings ZAP DashLord)

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -191,6 +191,10 @@ AUTH_PASSWORD_VALIDATORS = [
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "envergo.middleware.csp.ContentSecurityPolicyMiddleware",
+    # REVERT_AT_MERGE_TIME_FOR_UPSTREAM_ENVERGO
+    # Headers de securite complementaires (Permissions-Policy, CORP) non geres
+    # nativement par Django 4.2. Findings ZAP DashLord #265.
+    "envergo.nitrates.middleware.SecurityHeadersMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "envergo.contrib.middleware.SetUrlConfBasedOnSite",
     "envergo.middleware.rate_limiting.RateLimitingMiddleware",

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -113,6 +113,13 @@ STORAGES = {
     "upload": {"BACKEND": "envergo.utils.storages.UploadS3Boto3Storage"},
 }
 
+# REVERT_AT_MERGE_TIME_FOR_UPSTREAM_ENVERGO
+# ZAP DashLord #265 : WhiteNoise ajoute par defaut `Access-Control-Allow-Origin: *`
+# sur tous les statiques (utile pour servir des fonts depuis un CDN cross-origin).
+# Nitrates sert tout en same-origin (pas de CDN), donc ce CORS ouvert est inutile
+# et remonte comme finding. On le desactive : plus d'en-tete ACAO sur les statiques.
+WHITENOISE_ALLOW_ALL_ORIGINS = False
+
 
 # TEMPLATES
 # ------------------------------------------------------------------------------

--- a/envergo/nitrates/middleware.py
+++ b/envergo/nitrates/middleware.py
@@ -1,0 +1,42 @@
+"""Middlewares specifiques au produit nitrates."""
+
+from django.utils.deprecation import MiddlewareMixin
+
+
+class SecurityHeadersMiddleware(MiddlewareMixin):
+    """Pose les headers de securite HTTP non geres nativement par Django 4.2.
+
+    Complete les headers deja fournis par Django (HSTS, X-Frame-Options,
+    Referrer-Policy, Cross-Origin-Opener-Policy, nosniff) et par le middleware
+    CSP. Findings du scan ZAP DashLord (#265).
+
+    Perimetre volontairement conservateur :
+    - Permissions-Policy : neutralise les API navigateur non utilisees par le
+      simulateur (camera, micro, USB, paiement...). La geolocalisation est
+      laissee active (`geolocation=(self)`) car la carte peut vouloir centrer
+      sur l'utilisateur.
+    - Cross-Origin-Resource-Policy: same-origin : empeche l'inclusion de nos
+      ressources par un autre site.
+
+    Cross-Origin-Embedder-Policy (COEP) est volontairement OMIS : `require-corp`
+    casserait le chargement des tuiles cartographiques IGN, de Matomo, Sentry et
+    Crisp (ressources tierces sans en-tete CORP), pour un benefice de securite
+    marginal sur ce type de site public.
+    """
+
+    #: API navigateur explicitement neutralisees. Liste allowlist "()" = interdit
+    #: partout ; `geolocation=(self)` = autorise seulement notre origine.
+    PERMISSIONS_POLICY = (
+        "accelerometer=(), autoplay=(), camera=(), display-capture=(), "
+        "encrypted-media=(), fullscreen=(self), geolocation=(self), "
+        "gyroscope=(), magnetometer=(), microphone=(), midi=(), payment=(), "
+        "usb=(), xr-spatial-tracking=()"
+    )
+
+    def process_response(self, request, response):
+        # Ne pas ecraser un header pose en amont (view ou autre middleware).
+        if "Permissions-Policy" not in response:
+            response["Permissions-Policy"] = self.PERMISSIONS_POLICY
+        if "Cross-Origin-Resource-Policy" not in response:
+            response["Cross-Origin-Resource-Policy"] = "same-origin"
+        return response

--- a/envergo/nitrates/tests/test_security_headers.py
+++ b/envergo/nitrates/tests/test_security_headers.py
@@ -1,0 +1,48 @@
+"""Headers de securite complementaires nitrates (#265, findings ZAP DashLord).
+
+Le middleware SecurityHeadersMiddleware pose Permissions-Policy et
+Cross-Origin-Resource-Policy, non geres nativement par Django 4.2. COEP est
+volontairement omis (casserait carto/Matomo/Sentry/Crisp).
+"""
+
+from django.http import HttpResponse
+
+from envergo.nitrates.middleware import SecurityHeadersMiddleware
+
+
+def _run(response=None):
+    mw = SecurityHeadersMiddleware(lambda req: HttpResponse("ok"))
+    return mw.process_response(None, response or HttpResponse("ok"))
+
+
+def test_permissions_policy_present():
+    response = _run()
+    assert "Permissions-Policy" in response
+    policy = response["Permissions-Policy"]
+    # API sensibles neutralisees
+    assert "camera=()" in policy
+    assert "microphone=()" in policy
+    assert "payment=()" in policy
+    # geolocation laissee active pour notre origine (carte)
+    assert "geolocation=(self)" in policy
+
+
+def test_corp_same_origin():
+    response = _run()
+    assert response["Cross-Origin-Resource-Policy"] == "same-origin"
+
+
+def test_coep_volontairement_absent():
+    """COEP omis : il casserait les ressources tierces (carto, Matomo...)."""
+    response = _run()
+    assert "Cross-Origin-Embedder-Policy" not in response
+
+
+def test_ne_surcharge_pas_un_header_existant():
+    """Une vue peut poser ses propres headers -> le middleware ne les ecrase pas."""
+    r = HttpResponse("ok")
+    r["Permissions-Policy"] = "geolocation=()"
+    r["Cross-Origin-Resource-Policy"] = "cross-origin"
+    _run(r)
+    assert r["Permissions-Policy"] == "geolocation=()"
+    assert r["Cross-Origin-Resource-Policy"] == "cross-origin"


### PR DESCRIPTION
Ferme les findings ZAP du DashLord sur les headers HTTP de sécurité (#265), au-delà du CSP déjà traité en #261.

## Ajouté
- **Permissions-Policy** : neutralise les API navigateur non utilisées (caméra, micro, USB, paiement, capteurs…), garde `geolocation=(self)` pour la carte. Posé par un middleware nitrates dédié (`SecurityHeadersMiddleware`).
- **Cross-Origin-Resource-Policy: same-origin** (même middleware).
- **CORS ouvert sur les statiques** : `WHITENOISE_ALLOW_ALL_ORIGINS = False` retire le `Access-Control-Allow-Origin: *` que WhiteNoise pose par défaut (nitrates sert tout en same-origin).

## Volontairement écarté (avec justification)
- **COEP** (`require-corp`) : casserait les tuiles carto IGN, Matomo, Sentry et Crisp. Bénéfice marginal pour un site public de ce type.
- **Cookie `visitorid` sans HttpOnly** : choix de design Envergo assumé (le JS front lit ce cookie pour l'analytics). Le corriger casserait le tracking.
- **SRI sur scripts tiers** : Sentry/Matomo servent des scripts versionnés dynamiquement, un hash figé casserait à leur prochaine mise à jour.

## Déjà couverts par ailleurs (rien à faire)
HSTS, X-Frame-Options DENY, nosniff, Referrer-Policy, Cross-Origin-Opener-Policy, cookies session/CSRF secure+httponly+samesite.

## Tests
- `test_security_headers.py` (4 tests) : présence Permissions-Policy + CORP, absence volontaire de COEP, non-écrasement d'un header posé en amont.
- Non-régression routing nitrates : OK.