### PR TITLE
nitrates(sécurité): commande admin de scan Nuclei — LOCAL ONLY (spike #97)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -297,6 +297,11 @@ data.*
 /playwright/.cache/
 .playwright-mcp/
 
+# Rapports de scan securite Nuclei (spike #97). LOCAL ONLY : ces rapports
+# exposent des details de securite (donnees publiques sensibles), ils ne
+# doivent JAMAIS etre commites ni partir en CI.
+/nuclei_reports/
+
 altis/
 
 # Local docker-compose override (ports, dev-only tweaks)

--- a/compose/django/Dockerfile
+++ b/compose/django/Dockerfile
@@ -56,6 +56,21 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
   && apt-get install -y nodejs
 
+# Nuclei (scanner de securite, spike #97) -- DEV LOCAL UNIQUEMENT.
+# Ce Dockerfile ne sert qu'au dev local (la prod Scalingo build via buildpacks,
+# cf. .buildpacks), et l'install est en plus gardee par BUILD_ENV=local : nuclei
+# n'atterrit jamais dans un runtime de production. Binaire Go autonome.
+RUN if [ "$BUILD_ENV" = "local" ]; then \
+  NUCLEI_VERSION=3.3.7 \
+  && ARCH=$(dpkg --print-architecture) \
+  && curl -fsSL -o /tmp/nuclei.zip \
+     "https://github.com/projectdiscovery/nuclei/releases/download/v${NUCLEI_VERSION}/nuclei_${NUCLEI_VERSION}_linux_${ARCH}.zip" \
+  && (command -v unzip >/dev/null || (apt-get update && apt-get install -y --no-install-recommends unzip && rm -rf /var/lib/apt/lists/*)) \
+  && unzip -o /tmp/nuclei.zip -d /usr/local/bin nuclei \
+  && chmod +x /usr/local/bin/nuclei \
+  && rm -f /tmp/nuclei.zip ; \
+  fi
+
 RUN locale-gen fr_FR.UTF-8 && update-locale LANG="fr_FR.UTF-8" LC_ALL="fr_FR.UTF-8"
 
 ENV LANG fr_FR.UTF-8

--- a/envergo/nitrates/management/commands/nuclei_scan.py
+++ b/envergo/nitrates/management/commands/nuclei_scan.py
@@ -85,14 +85,18 @@ class Command(BaseCommand):
             )
         )
 
-        cmd = self._build_command(runner, target, severity, jsonl_path)
+        cmd = self._build_command(runner, target, severity)
+        # On capture la sortie -jsonl sur stdout (plus fiable que -jsonl-export,
+        # qui n'ecrit pas toujours le fichier selon le type de finding). Le flux
+        # texte de progression de nuclei part sur stderr, pas sur stdout.
         try:
-            subprocess.run(cmd, check=False)
+            proc = subprocess.run(cmd, check=False, capture_output=True, text=True)
         except FileNotFoundError as exc:
             raise CommandError(
                 f"Impossible de lancer le scan ({exc}). Installe nuclei "
                 "(https://github.com/projectdiscovery/nuclei) ou Docker."
             )
+        jsonl_path.write_text(proc.stdout, encoding="utf-8")
 
         findings = self._parse_findings(jsonl_path)
         html_path = run_dir / "report.html"
@@ -123,37 +127,26 @@ class Command(BaseCommand):
             "deux : https://github.com/projectdiscovery/nuclei"
         )
 
-    def _build_command(self, runner, target, severity, jsonl_path):
+    def _build_command(self, runner, target, severity):
+        # -jsonl : chaque finding en JSON sur stdout (progression sur stderr).
+        base_args = [
+            "-target",
+            target,
+            "-severity",
+            severity,
+            "-jsonl",
+            "-no-color",
+        ]
         if runner["kind"] == "binary":
-            return [
-                "nuclei",
-                "-target",
-                target,
-                "-severity",
-                severity,
-                "-jsonl-export",
-                str(jsonl_path),
-                "-no-color",
-            ]
-        # Docker : on monte le dossier du run pour recuperer l'export.
-        run_dir = jsonl_path.parent
+            return ["nuclei"] + base_args
         return [
             "docker",
             "run",
             "--rm",
             "--add-host",
             "host.docker.internal:host-gateway",
-            "-v",
-            f"{run_dir}:/out",
             DOCKER_IMAGE,
-            "-target",
-            target,
-            "-severity",
-            severity,
-            "-jsonl-export",
-            "/out/findings.jsonl",
-            "-no-color",
-        ]
+        ] + base_args
 
     def _parse_findings(self, jsonl_path):
         findings = []

--- a/envergo/nitrates/management/commands/nuclei_scan.py
+++ b/envergo/nitrates/management/commands/nuclei_scan.py
@@ -1,0 +1,220 @@
+"""Scan de securite Nuclei (ProjectDiscovery) contre l'app nitrates -- LOCAL ONLY.
+
+Spike securite #97. Lance le scanner de vulnerabilites Nuclei contre une cible
+HTTP (par defaut l'app locale), et ecrit un rapport horodate dans un dossier
+LOCAL, jamais commite (cf. .gitignore) et jamais execute en CI : les rapports
+Nuclei exposent des details de securite qui ne doivent pas devenir publics.
+
+Nuclei est installe dans l'image de dev (compose/django/Dockerfile, garde
+BUILD_ENV=local -- la prod Scalingo build via buildpacks, pas ce Dockerfile).
+En repli, si le binaire `nuclei` est absent du PATH, on utilise l'image Docker
+officielle `projectdiscovery/nuclei` (necessite alors le socket Docker).
+
+Le dernier rapport est consultable depuis l'admin (page "Rapports Nuclei").
+
+Usage (depuis le conteneur, ex. `docker compose exec django ...`) :
+    python manage.py nuclei_scan                          # cible l'app locale
+    python manage.py nuclei_scan --target https://staging # scan de staging
+    python manage.py nuclei_scan --severity medium,high,critical
+"""
+
+import json
+import shutil
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+
+# Dossier LOCAL des rapports (gitignore). Sous ROOT_DIR pour rester dans le repo
+# de travail sans etre versionne.
+REPORTS_DIR = Path(settings.ROOT_DIR) / "nuclei_reports"
+
+# Cible par defaut : l'app servie en local. La commande tourne DANS le conteneur
+# django (`docker compose exec/run django`), donc l'app est joignable via le nom
+# de service `django` sur son port interne 8000 (DNS reseau compose). Pilotable
+# par env / argument (ex: --target http://localhost:8000 si nuclei sur le host).
+DEFAULT_TARGET = getattr(settings, "NUCLEI_DEFAULT_TARGET", "http://django:8000")
+
+DOCKER_IMAGE = "projectdiscovery/nuclei:latest"
+
+
+class Command(BaseCommand):
+    help = "Lance un scan de securite Nuclei (LOCAL ONLY). Rapport non commite."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--target",
+            default=DEFAULT_TARGET,
+            help=f"URL cible du scan (defaut: {DEFAULT_TARGET}).",
+        )
+        parser.add_argument(
+            "--severity",
+            default="low,medium,high,critical",
+            help="Niveaux de severite a rapporter (defaut: low..critical).",
+        )
+        parser.add_argument(
+            "--force-docker",
+            action="store_true",
+            help="Force l'usage de l'image Docker meme si nuclei est installe.",
+        )
+
+    def handle(self, *args, **options):
+        # Garde-fou : ne JAMAIS tourner en CI (rapports = donnees publiques
+        # sensibles). On refuse si un marqueur d'environnement CI est present.
+        if self._is_ci():
+            raise CommandError(
+                "nuclei_scan est interdit en CI (rapport public sensible). "
+                "Cette commande ne doit tourner qu'en local."
+            )
+
+        target = options["target"]
+        severity = options["severity"]
+
+        REPORTS_DIR.mkdir(parents=True, exist_ok=True)
+        stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+        run_dir = REPORTS_DIR / stamp
+        run_dir.mkdir()
+        jsonl_path = run_dir / "findings.jsonl"
+
+        runner = self._resolve_runner(options["force_docker"])
+        self.stdout.write(
+            self.style.WARNING(
+                f"Scan Nuclei -> {target} (severite: {severity}) via {runner['label']}"
+            )
+        )
+
+        cmd = self._build_command(runner, target, severity, jsonl_path)
+        try:
+            subprocess.run(cmd, check=False)
+        except FileNotFoundError as exc:
+            raise CommandError(
+                f"Impossible de lancer le scan ({exc}). Installe nuclei "
+                "(https://github.com/projectdiscovery/nuclei) ou Docker."
+            )
+
+        findings = self._parse_findings(jsonl_path)
+        html_path = run_dir / "report.html"
+        self._write_html_report(html_path, target, severity, findings, stamp)
+        # Pointeur "dernier rapport" pour l'admin (symlink relatif, robuste).
+        self._update_latest_pointer(run_dir)
+
+        self.stdout.write(
+            self.style.SUCCESS(f"{len(findings)} finding(s). Rapport : {html_path}")
+        )
+
+    def _is_ci(self):
+        import os
+
+        return any(
+            os.environ.get(var)
+            for var in ("CI", "GITHUB_ACTIONS", "GITLAB_CI", "JENKINS_URL")
+        )
+
+    def _resolve_runner(self, force_docker):
+        """Choisit nuclei local, sinon Docker."""
+        if not force_docker and shutil.which("nuclei"):
+            return {"kind": "binary", "label": "nuclei (local)"}
+        if shutil.which("docker"):
+            return {"kind": "docker", "label": DOCKER_IMAGE}
+        raise CommandError(
+            "Ni `nuclei` ni `docker` trouves dans le PATH. Installe l'un des "
+            "deux : https://github.com/projectdiscovery/nuclei"
+        )
+
+    def _build_command(self, runner, target, severity, jsonl_path):
+        if runner["kind"] == "binary":
+            return [
+                "nuclei",
+                "-target",
+                target,
+                "-severity",
+                severity,
+                "-jsonl-export",
+                str(jsonl_path),
+                "-no-color",
+            ]
+        # Docker : on monte le dossier du run pour recuperer l'export.
+        run_dir = jsonl_path.parent
+        return [
+            "docker",
+            "run",
+            "--rm",
+            "--add-host",
+            "host.docker.internal:host-gateway",
+            "-v",
+            f"{run_dir}:/out",
+            DOCKER_IMAGE,
+            "-target",
+            target,
+            "-severity",
+            severity,
+            "-jsonl-export",
+            "/out/findings.jsonl",
+            "-no-color",
+        ]
+
+    def _parse_findings(self, jsonl_path):
+        findings = []
+        if not jsonl_path.exists():
+            return findings
+        for line in jsonl_path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                findings.append(self._normalize(json.loads(line)))
+            except json.JSONDecodeError:
+                continue
+        return findings
+
+    def _normalize(self, finding):
+        """Aplatit les cles utiles au template.
+
+        Nuclei sort des cles avec tirets (`template-id`, `matched-at`) que le
+        moteur de template Django ne peut pas atteindre en notation point
+        (le `-` est lu comme un operateur). On expose des alias sans tiret.
+        """
+        info = finding.get("info", {}) or {}
+        return {
+            "severity": (info.get("severity") or "info"),
+            "template_id": finding.get("template-id") or finding.get("templateID", "-"),
+            "name": info.get("name", "-"),
+            "matched_at": (
+                finding.get("matched-at")
+                or finding.get("matched_at")
+                or finding.get("host", "-")
+            ),
+        }
+
+    def _write_html_report(self, html_path, target, severity, findings, stamp):
+        from django.template.loader import render_to_string
+
+        # Tri par severite decroissante pour lecture rapide.
+        order = {"critical": 0, "high": 1, "medium": 2, "low": 3, "info": 4}
+        findings_sorted = sorted(
+            findings,
+            key=lambda f: order.get(f.get("severity", "info"), 5),
+        )
+        html = render_to_string(
+            "nitrates/nuclei_report.html",
+            {
+                "target": target,
+                "severity": severity,
+                "stamp": stamp,
+                "findings": findings_sorted,
+                "count": len(findings_sorted),
+            },
+        )
+        html_path.write_text(html, encoding="utf-8")
+
+    def _update_latest_pointer(self, run_dir):
+        latest = REPORTS_DIR / "latest"
+        try:
+            if latest.is_symlink() or latest.exists():
+                latest.unlink()
+            latest.symlink_to(run_dir.name)
+        except OSError:
+            # FS sans symlink : on ecrit un fichier pointeur en repli.
+            (REPORTS_DIR / "latest.txt").write_text(run_dir.name, encoding="utf-8")

--- a/envergo/nitrates/templates/nitrates/nuclei_admin_index.html
+++ b/envergo/nitrates/templates/nitrates/nuclei_admin_index.html
@@ -1,0 +1,44 @@
+{% extends "nitrates_admin/base.html" %}
+
+{% block content %}
+  <div style="padding:1.5rem;">
+    <h1>Rapports de scan Nuclei</h1>
+
+    <p style="color:#555;max-width:60ch">
+      Scans de sécurité <strong>locaux</strong> générés par
+      <code>python manage.py nuclei_scan</code>. Les rapports vivent dans
+      <code>{{ reports_dir }}</code> (non versionné) et ne sont consultables qu'en
+      local. Ils ne partent jamais en CI ni sur staging/prod.
+    </p>
+
+    {% if has_reports %}
+      <p>
+        <a class="button"
+           href="{% url 'nitrates_admin_nuclei_report' 'latest' %}"
+           target="_blank">Voir le dernier rapport</a>
+      </p>
+      <table>
+        <thead>
+          <tr>
+            <th>Date du scan (UTC)</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for run in runs %}
+            <tr>
+              <td>{{ run.name }}</td>
+              <td>
+                <a href="{% url 'nitrates_admin_nuclei_report' run.name %}"
+                   target="_blank">Ouvrir</a>
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    {% else %}
+      <p>Aucun rapport pour l'instant. Lance un scan :</p>
+      <pre>python manage.py nuclei_scan</pre>
+    {% endif %}
+  </div>
+{% endblock %}

--- a/envergo/nitrates/templates/nitrates/nuclei_report.html
+++ b/envergo/nitrates/templates/nitrates/nuclei_report.html
@@ -1,0 +1,142 @@
+{# Rapport interne (noindex) : les meta SEO description/keywords n'ont pas de sens. #}
+{# djlint:off H030,H031 #}
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="utf-8">
+    <meta name="robots" content="noindex, nofollow">
+    <title>Rapport Nuclei - {{ stamp }}</title>
+    <style>
+      body {
+        font-family: system-ui, sans-serif;
+        margin: 2rem;
+        color: #1e1e1e;
+        background: #fff;
+      }
+
+      h1 {
+        font-size: 1.4rem;
+      }
+
+      .meta {
+        color: #555;
+        font-size: .9rem;
+        margin-bottom: 1.5rem;
+      }
+
+      .meta code {
+        background: #f0f0f0;
+        padding: .1rem .3rem;
+        border-radius: 3px;
+      }
+
+      table {
+        border-collapse: collapse;
+        width: 100%;
+      }
+
+      th,
+      td {
+        text-align: left;
+        padding: .5rem .6rem;
+        border-bottom: 1px solid #e0e0e0;
+        vertical-align: top;
+      }
+
+      th {
+        background: #f6f6f6;
+        font-size: .85rem;
+        text-transform: uppercase;
+        letter-spacing: .03em;
+      }
+
+      .sev {
+        font-weight: 600;
+        padding: .1rem .5rem;
+        border-radius: 3px;
+        font-size: .8rem;
+        white-space: nowrap;
+      }
+
+      .sev-critical {
+        background: #7d1128;
+        color: #fff;
+      }
+
+      .sev-high {
+        background: #c9302c;
+        color: #fff;
+      }
+
+      .sev-medium {
+        background: #ec971f;
+        color: #fff;
+      }
+
+      .sev-low {
+        background: #5bc0de;
+        color: #fff;
+      }
+
+      .sev-info {
+        background: #ddd;
+        color: #333;
+      }
+
+      .empty {
+        padding: 2rem;
+        text-align: center;
+        color: #2a7a2a;
+        font-size: 1.1rem;
+      }
+
+      .matched {
+        font-family: monospace;
+        font-size: .8rem;
+        color: #444;
+        word-break: break-all;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Rapport de scan Nuclei</h1>
+    <p class="meta">
+      Cible : <code>{{ target }}</code>
+      <br>
+      Sévérités scannées : <code>{{ severity }}</code>
+      <br>
+      Date (UTC) : <code>{{ stamp }}</code>
+      <br>
+      Findings : <strong>{{ count }}</strong>
+    </p>
+
+    {% if findings %}
+      <table>
+        <thead>
+          <tr>
+            <th>Sévérité</th>
+            <th>Template</th>
+            <th>Nom</th>
+            <th>URL / élément touché</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for f in findings %}
+            <tr>
+              <td>
+                <span class="sev sev-{{ f.severity }}">{{ f.severity }}</span>
+              </td>
+              <td>
+                <code>{{ f.template_id }}</code>
+              </td>
+              <td>{{ f.name }}</td>
+              <td class="matched">{{ f.matched_at }}</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    {% else %}
+      <p class="empty">Aucun finding pour les sévérités scannées. Rien à signaler.</p>
+    {% endif %}
+  </body>
+</html>

--- a/envergo/nitrates/urls.py
+++ b/envergo/nitrates/urls.py
@@ -11,6 +11,7 @@ from envergo.nitrates.views import (
     ZoneActionRenforceeGeoJSONView,
     ZoneVulnerableGeoJSONView,
 )
+from envergo.nitrates.views_admin_nuclei import nuclei_index, nuclei_report
 from envergo.nitrates.views_admin_ouverture import (
     ouverture_index,
     ouverture_toggle,
@@ -344,5 +345,16 @@ urlpatterns = [
         "admin/nitrates/ouverture-geographique/toggle-region/",
         ouverture_toggle_region,
         name="nitrates_admin_ouverture_toggle_region",
+    ),
+    # Rapports de scan Nuclei (spike securite #97). LOCAL ONLY.
+    path(
+        "admin/nitrates/nuclei/",
+        nuclei_index,
+        name="nitrates_admin_nuclei_index",
+    ),
+    path(
+        "admin/nitrates/nuclei/<str:stamp>/",
+        nuclei_report,
+        name="nitrates_admin_nuclei_report",
     ),
 ]

--- a/envergo/nitrates/views_admin_nuclei.py
+++ b/envergo/nitrates/views_admin_nuclei.py
@@ -1,0 +1,72 @@
+"""Admin de consultation des rapports de scan Nuclei (spike securite #97).
+
+Le scan tourne via `python manage.py nuclei_scan` et ecrit ses rapports dans un
+dossier LOCAL non versionne (cf. .gitignore). Cette vue liste les rapports
+disponibles et affiche le dernier -- LOCAL ONLY.
+
+Garde-fou : la vue refuse de servir quoi que ce soit hors environnement local
+(DEBUG). Les rapports Nuclei exposent des details de securite ; ils ne doivent
+jamais etre exposes sur staging/prod, meme derriere l'admin.
+"""
+
+from pathlib import Path
+
+from django.conf import settings
+from django.contrib.admin.views.decorators import staff_member_required
+from django.http import Http404, HttpResponse
+from django.shortcuts import render
+
+REPORTS_DIR = Path(settings.ROOT_DIR) / "nuclei_reports"
+
+
+def _local_only():
+    """Les rapports ne sont consultables qu'en local (DEBUG)."""
+    return getattr(settings, "DEBUG", False)
+
+
+def _list_runs():
+    """Liste les dossiers de run (horodates), du plus recent au plus ancien."""
+    if not REPORTS_DIR.exists():
+        return []
+    runs = [
+        d for d in REPORTS_DIR.iterdir() if d.is_dir() and (d / "report.html").exists()
+    ]
+    return sorted(runs, key=lambda d: d.name, reverse=True)
+
+
+@staff_member_required
+def nuclei_index(request):
+    """Liste des rapports + lien vers chacun."""
+    if not _local_only():
+        raise Http404("Rapports Nuclei disponibles en local uniquement.")
+    runs = _list_runs()
+    context = {
+        "runs": [{"name": r.name} for r in runs],
+        "has_reports": bool(runs),
+        "reports_dir": str(REPORTS_DIR),
+    }
+    return render(request, "nitrates/nuclei_admin_index.html", context)
+
+
+@staff_member_required
+def nuclei_report(request, stamp):
+    """Sert le rapport HTML d'un run donne (ou 'latest' pour le dernier)."""
+    if not _local_only():
+        raise Http404("Rapports Nuclei disponibles en local uniquement.")
+
+    if stamp == "latest":
+        runs = _list_runs()
+        if not runs:
+            raise Http404("Aucun rapport Nuclei genere.")
+        run_dir = runs[0]
+    else:
+        # Garde-fou path traversal : on n'accepte qu'un nom de dossier direct.
+        candidate = (REPORTS_DIR / stamp).resolve()
+        if candidate.parent != REPORTS_DIR.resolve() or not candidate.is_dir():
+            raise Http404("Rapport introuvable.")
+        run_dir = candidate
+
+    html_file = run_dir / "report.html"
+    if not html_file.exists():
+        raise Http404("Rapport introuvable.")
+    return HttpResponse(html_file.read_text(encoding="utf-8"))

--- a/envergo/templates/nitrates_admin/base.html
+++ b/envergo/templates/nitrates_admin/base.html
@@ -86,6 +86,9 @@
         <a href="{% url 'nitrates_admin_yaml_tree' %}" style="color:#fff;">Arbre actif</a>
         <a href="{% url 'nitrates_admin_validation_index' %}" style="color:#fff">Validation des feuilles</a>
         <a href="{% url 'nitrates_admin_ouverture_index' %}" style="color:#fff;">Ouverture géographique</a>
+        {% if debug %}
+          <a href="{% url 'nitrates_admin_nuclei_index' %}" style="color:#fff;">Rapports Nuclei</a>
+        {% endif %}
       </nav>
       <span style="margin-left:auto;color:#cdd6e4;">
         {% if user.is_authenticated %}{{ user.email }}{% endif %}


### PR DESCRIPTION
Spike sécurité #97 : un scanner de vulnérabilités **Nuclei** lançable en local, dont les rapports restent locaux (jamais commités, jamais en CI — les rapports Nuclei exposent des détails de sécurité qui ne doivent pas devenir publics).

## Ce que ça ajoute
- **Commande `manage.py nuclei_scan`** : lance Nuclei contre une cible HTTP (l'app locale par défaut, `--target` pour viser staging), écrit un rapport HTML horodaté dans `nuclei_reports/` (gitignoré). Options `--severity`, `--force-docker`. **Garde-fou anti-CI** : refuse de tourner si `CI`/`GITHUB_ACTIONS`/… est présent.
- **Page admin "Rapports Nuclei"** (`/admin/nitrates/nuclei/`) : liste les rapports par date, affiche le dernier. **Local-only** (404 hors DEBUG). Lien dans le header admin nitrates visible seulement en dev.
- **Nuclei installé dans l'image de DEV uniquement** (`compose/django/Dockerfile`, gardé `BUILD_ENV=local`). **La prod n'est pas touchée** : elle build via les buildpacks Scalingo (`.buildpacks`), pas ce Dockerfile. Repli sur l'image Docker `projectdiscovery/nuclei` si le binaire manque.
- **`.gitignore`** : `nuclei_reports/` jamais commité.

## Résultat du spike
Le scan fonctionne et détecte de vraies signatures (testé contre l'app locale : `tech-detect`, `django-variables-exposed`, `flask-werkzeug-debug`). En local ces findings viennent surtout du **mode DEBUG** (page d'erreur Django verbeuse) — le vrai intérêt est de pointer la commande sur **staging** (`--target https://nitrates-staging…`, DEBUG=False) pour des findings représentatifs de la prod.

## Notes
- Rien ne persiste en DB (pas de migration) : la page admin lit le dossier de rapports.
- Usage depuis le conteneur : `docker compose exec django python manage.py nuclei_scan` (nécessite un rebuild de l'image dev pour embarquer nuclei).