### PR TITLE
nitrates(front): #213 - prefetch intégral des QC, zéro resubmit au changement de réponse

### DIFF
--- a/e2e/nitrates/bug_213_changement_reponse_qc.spec.ts
+++ b/e2e/nitrates/bug_213_changement_reponse_qc.spec.ts
@@ -1,0 +1,190 @@
+import { test, expect, Page } from '@playwright/test';
+
+/**
+ * #213 — changement de reponse a une question complementaire (QC).
+ *
+ * Comportement attendu (prefetch integral, #213) :
+ *   - le serveur rend d'avance les QC de TOUTES les branches (cachees,
+ *     annotees data-qc-parent-champ/valeur), y compris celles heritees d'une
+ *     bascule cross-arbre (PAR -> PAN via noeud_depart) ;
+ *   - changer une reponse QC revele/masque la cascade cote client, SANS
+ *     resubmit : rien ne part au serveur tant qu'on n'a pas clique
+ *     « Suivant » / « Lancer la simulation » ;
+ *   - les QC aval devenues incoherentes sont masquees ET decochees ;
+ *   - changer un champ amont (ex. sous-fertilisant) ne rase PAS le volet QC
+ *     (anti-clignotement : c'est le rendu serveur suivant qui tranche).
+ *
+ * Parcours de reference : couvert interculture longue, CINE detruit avant le
+ * 31/12, fumier de volaille -> QC « plan d'epandage ».
+ */
+
+const REIMS_LNG = 4.0345;
+const REIMS_LAT = 49.2583;
+const QC_BLOC = '#qc-bloc';
+
+async function pick(page: Page, name: string, value: string) {
+  const input = page
+    .locator(`input[type=radio][name="${name}"][value="${value}"]:visible`)
+    .first();
+  await expect(input, `radio ${name}=${value} absent/invisible`).toHaveCount(1);
+  const id = await input.getAttribute('id');
+  await page.locator(`label[for="${id}"]`).first().click();
+  await page.waitForTimeout(500);
+}
+
+async function pickFlow(page: Page, name: string, index: number) {
+  const g = page.locator(`input[type=radio][name="${name}"]`);
+  await expect(g.nth(index), `radio ${name}[${index}] absent`).toHaveCount(1);
+  const id = await g.nth(index).getAttribute('id');
+  await page.locator(`label[for="${id}"]`).first().click();
+  await page.waitForTimeout(300);
+}
+
+async function saisirDate(page: Page, inputId: string, jjmm: string) {
+  const inp = page.locator(`#q_dates_couvert input[data-input-id="${inputId}"]`);
+  await inp.fill(jjmm);
+  await inp.blur();
+  await page.waitForTimeout(200);
+}
+
+async function submit(page: Page) {
+  const btn = page
+    .locator('button[type="submit"]', { hasText: /Lancer|Relancer|Suivant/ })
+    .first();
+  await btn.click();
+  await page.waitForTimeout(1800);
+}
+
+/** Pose un marqueur JS : perdu = la page a recharge (resubmit interdit). */
+async function marquerPage(page: Page) {
+  await page.evaluate(() => {
+    (window as any).__pas_de_reload = true;
+  });
+}
+async function pasDeReload(page: Page): Promise<boolean> {
+  return page.evaluate(() => (window as any).__pas_de_reload === true);
+}
+
+/** Etat d'un groupe QC : { hidden, coche } ou null si absent du DOM. */
+async function qcEtat(page: Page, champ: string) {
+  return page.evaluate((c) => {
+    const g = document.querySelector(
+      `.qc-question[data-qc-champ="${c}"]`,
+    ) as HTMLElement | null;
+    if (!g) return null;
+    const r = g.querySelector(
+      'input[type=radio]:checked',
+    ) as HTMLInputElement | null;
+    return { hidden: g.hidden, coche: r ? r.value : null };
+  }, champ);
+}
+
+async function parcoursJusquAuxQC(page: Page) {
+  await page.goto(`/simulateur/?lng=${REIMS_LNG}&lat=${REIMS_LAT}`);
+  await page.waitForLoadState('networkidle');
+  await pickFlow(page, 'cflow_destination', 0);
+  await pickFlow(page, 'cflow_type_couvert', 0);
+  await pickFlow(page, 'cflow_couvert_recolte', 1);
+  await saisirDate(page, 'date_semis_couvert', '15/08');
+  await saisirDate(page, 'date_destruction_couvert', '15/11');
+  await pick(page, 'categorie_fertilisant', 'fumiers');
+  await pick(page, 'sous_fertilisant', 'fumier_volaille');
+  await submit(page);
+  await expect(page.locator(QC_BLOC)).toBeVisible();
+}
+
+test('#213a : la cascade QC prefetchee se revele sans resubmit, jusqu au resultat en un seul Lancer', async ({
+  page,
+}) => {
+  test.setTimeout(90000);
+  await parcoursJusquAuxQC(page);
+
+  // La QC de la branche icpe_ed est deja dans le DOM, cachee, annotee.
+  let dig = await qcEtat(page, 'pas_un_digestats');
+  expect(dig, 'pas_un_digestats doit etre prefetchee').not.toBeNull();
+  expect(dig!.hidden, 'prefetchee = cachee tant que non pertinente').toBe(true);
+
+  // Repondre icpe_ed revele la QC enchainee SANS aller-retour serveur.
+  await marquerPage(page);
+  await pick(page, 'plan_epandage', 'icpe_ed');
+  expect(await pasDeReload(page), 'resubmit interdit au clic QC').toBe(true);
+  dig = await qcEtat(page, 'pas_un_digestats');
+  expect(dig!.hidden, 'la QC de la branche choisie doit se reveler').toBe(false);
+  expect(dig!.coche, 'revelee VIERGE (pas pre-remplie)').toBeNull();
+
+  // On repond a toute la cascade puis UN SEUL « Lancer » -> resultat direct.
+  await pick(page, 'pas_un_digestats', 'False');
+  await submit(page);
+  await expect(
+    page.locator('.result-col').first(),
+    'toutes les QC etaient repondues -> resultat en un seul aller-retour',
+  ).toBeVisible();
+});
+
+test('#213b : flip d une reponse QC apres resultat — revele/masque sans resubmit, y compris cross-arbre', async ({
+  page,
+}) => {
+  test.setTimeout(120000);
+  await parcoursJusquAuxQC(page);
+
+  // Chemin icpe_a (bascule PAR -> PAN) : iaa posee apres Lancer.
+  await pick(page, 'plan_epandage', 'icpe_a');
+  await submit(page);
+  const iaa = await qcEtat(page, 'fertilisant_iaa');
+  expect(iaa, 'fertilisant_iaa attendue apres icpe_a').not.toBeNull();
+  await pick(page, 'fertilisant_iaa', 'True');
+  await submit(page);
+  await expect(page.locator('.result-col').first()).toBeVisible();
+
+  // Modifier -> flip icpe_a -> icpe_ed : iaa (cross-arbre) se masque et se
+  // decoche, digestats se revele vierge. AUCUN resubmit.
+  await page.locator('[data-recap-modifier]').first().click();
+  await page.waitForTimeout(700);
+  await marquerPage(page);
+  await pick(page, 'plan_epandage', 'icpe_ed');
+  expect(await pasDeReload(page), 'resubmit interdit au flip QC').toBe(true);
+  const iaaApres = await qcEtat(page, 'fertilisant_iaa');
+  expect(iaaApres!.hidden, 'la QC de l ancienne branche doit se masquer').toBe(true);
+  expect(iaaApres!.coche, 'et se decocher (ne sera pas soumise)').toBeNull();
+  const digApres = await qcEtat(page, 'pas_un_digestats');
+  expect(digApres!.hidden, 'la QC de la nouvelle branche doit se reveler').toBe(false);
+  expect(digApres!.coche, 'revelee vierge').toBeNull();
+
+  // Volet toujours a l ecran, et « Lancer » disponible pour finaliser.
+  await expect(page.locator(QC_BLOC)).toBeVisible();
+  await pick(page, 'pas_un_digestats', 'False');
+  await submit(page);
+  await expect(
+    page.locator('.result-col').first(),
+    'apres flip + reponse, un seul Lancer donne le resultat',
+  ).toBeVisible();
+});
+
+test('#213c : changer le sous-fertilisant ne rase pas le volet QC (anti-clignotement)', async ({
+  page,
+}) => {
+  test.setTimeout(90000);
+  await parcoursJusquAuxQC(page);
+  await pick(page, 'plan_epandage', 'icpe_ed');
+  await pick(page, 'pas_un_digestats', 'False');
+  await submit(page);
+  await expect(page.locator('.result-col').first()).toBeVisible();
+
+  await page.locator('[data-recap-modifier]').first().click();
+  await page.waitForTimeout(700);
+  await marquerPage(page);
+  // Fumier compact : meme QC ICPE dans l arbre -> le volet ne doit pas
+  // disparaitre au changement (il sera confirme/ajuste au Lancer suivant).
+  await pick(page, 'sous_fertilisant', 'fumier_compact_non_susceptible_ecoulement');
+  expect(await pasDeReload(page), 'resubmit interdit au changement amont').toBe(true);
+  await expect(
+    page.locator(QC_BLOC),
+    'le volet QC ne doit pas disparaitre au changement d un champ amont',
+  ).toBeVisible();
+  const plan = await qcEtat(page, 'plan_epandage');
+  expect(plan, 'la QC plan_epandage reste a l ecran').not.toBeNull();
+  expect(plan!.hidden).toBe(false);
+
+  // Le resultat, lui, a bien ete invalide (il ne correspond plus aux choix).
+  await expect(page.locator('.result-col')).toHaveCount(0);
+});

--- a/e2e/nitrates/reset_form.spec.ts
+++ b/e2e/nitrates/reset_form.spec.ts
@@ -118,9 +118,16 @@ test.describe('Simulateur #135 : reset au changement de champ apres resultat', (
     await expect(page.locator('#qc-bloc[data-qc-en-attente]')).toHaveCount(0);
   });
 
-  test('editer une QC repondue retire le resultat (cas QC)', async ({ page }) => {
+  test('editer une QC repondue (via Modifier) garde le volet QC, sans resubmit (#213)', async ({
+    page,
+  }) => {
     // culture_printemps + type_II pose la QC fertirrigation ; on la repond via
     // l'URL pour obtenir un resultat AVEC QC recap editable.
+    // NB #213 : l'ancien comportement (raser resultat + bloc QC au clic) est
+    // remplace -- le volet QC RESTE a l'ecran, rien n'est soumis, et c'est le
+    // « Lancer » suivant qui tranche. Depuis #271, l'edition passe par le
+    // bouton « Modifier » de l'encart recap (le form est masque sur la page
+    // resultat).
     await page.goto(
       `/simulateur/?lng=${REIMS_LNG}&lat=${REIMS_LAT}` +
         '&occupation_sol=culture_principale&sous_culture=culture_printemps' +
@@ -129,24 +136,26 @@ test.describe('Simulateur #135 : reset au changement de champ apres resultat', (
 
     // Un resultat + le bloc QC (recap) sont presents.
     await expect(page.locator('#qc-bloc')).toHaveCount(1);
+    await page.locator('[data-recap-modifier]').first().click();
+    await expect(page.locator('#qc-bloc')).toBeVisible();
 
-    // L'user change la reponse a la QC fertirrigation.
+    // Marqueur anti-reload : le flip d'une QC ne doit RIEN soumettre.
+    await page.evaluate(() => {
+      (window as any).__pas_de_reload = true;
+    });
     await page.locator('label[for*="fertirrigation"][for*="True"]').first().click();
+    await page.waitForTimeout(600);
 
-    // Le resultat et le bloc QC disparaissent.
+    // Pas de resubmit, le volet QC reste, la nouvelle reponse est cochee.
+    expect(
+      await page.evaluate(() => (window as any).__pas_de_reload === true)
+    ).toBe(true);
+    await expect(page.locator('#qc-bloc')).toBeVisible();
+    await expect(
+      page.locator('input[name="fertirrigation"][value="True"]:visible')
+    ).toBeChecked();
+    // Le resultat, lui, a ete retire par « Modifier » (retour en saisie).
     await expect(page.locator('.result-col')).toHaveCount(0);
-    await expect(page.locator('#qc-bloc')).toHaveCount(0);
-
-    // L'URL miroir ne reprend PAS la reponse QC obsolete (fertirrigation).
-    await expect
-      .poll(() =>
-        page.evaluate(() =>
-          new URLSearchParams(location.search).get('fertirrigation')
-        )
-      )
-      .toBeNull();
-    const search = await page.evaluate(() => location.search);
-    expect(dupKeys(search)).toEqual([]);
   });
 });
 
@@ -223,22 +232,25 @@ test.describe('Simulateur #135 : pas de boucle infinie sur QC en attente', () =>
     await expect(page.locator('.result-col')).toHaveCount(1);
   });
 
-  test('changer un champ AMONT pendant une QC en attente elague bien', async ({
+  test('changer un champ AMONT pendant une QC en attente : URL elaguee, volet QC conserve (#213)', async ({
     page,
   }) => {
-    // Contre-cas : si l'utilisateur change la CATEGORIE (champ amont) alors
-    // qu'une QC est en attente, la QC obsolete DOIT disparaitre (le parcours
-    // change). C'est l'inverse du cas precedent : on elague bien ici.
+    // Si l'utilisateur change la CATEGORIE (champ amont) alors qu'une QC est
+    // en attente, l'URL est elaguee de l'aval (le parcours change) MAIS le
+    // volet QC n'est PAS rase cote client (#213, anti-clignotement) : le
+    // rendu serveur suivant tranche -- si la nouvelle branche pose la meme
+    // QC, l'utilisateur ne voit aucune coupure.
     await page.goto(URL_QC_EN_ATTENTE);
     await expect(page.locator('#qc-bloc[data-qc-en-attente]')).toHaveCount(1);
 
     // Change la categorie de fertilisant (amont de la QC).
     await page.locator('label[for="id_categorie_fertilisant__composts"]').click();
-    await page.waitForTimeout(150);
+    await page.waitForTimeout(300);
 
-    // La QC en attente obsolete disparait.
-    await expect(page.locator('#qc-bloc')).toHaveCount(0);
-    // sous_fertilisant reset par la cascade -> retire de l'URL.
+    // Le volet QC reste a l'ecran (pas de clignotement).
+    await expect(page.locator('#qc-bloc')).toHaveCount(1);
+    // sous_fertilisant reset par la cascade -> retire de l'URL (l'elagage
+    // MIROIR de l'URL, lui, reste inchange).
     await expect
       .poll(() =>
         page.evaluate(() =>

--- a/envergo/nitrates/tests/test_yaml_tree_parcours.py
+++ b/envergo/nitrates/tests/test_yaml_tree_parcours.py
@@ -2244,3 +2244,260 @@ def test_collecte_aval_branche_terminale_sans_noeud_s_arrete():
     questions = _collecter_questions(noeud, {"occupation_sol": "mais"}, {})
     champs = [q.champ for q in questions]
     assert champs == ["occupation_sol"]
+
+
+# ─── #213 : prefetch integral des QC (toutes branches, tous niveaux) ────────
+
+
+def _arbre_qc_deux_branches():
+    """QC plan-epandage-like a 2 branches, chacune menant a une QC differente
+    (modele du bug #213 : icpe_a -> fertilisant_iaa, icpe_ed -> digestats)."""
+    return {
+        "arbre": {
+            "noeud": {
+                "type_noeud": "formulaire",
+                "niveau": "complement",
+                "id": "q_plan",
+                "champ": "plan_epandage",
+                "texte": "Plan d'epandage ?",
+                "branches": [
+                    {
+                        "valeur": "icpe_a",
+                        "noeud": {
+                            "type_noeud": "formulaire",
+                            "niveau": "complement",
+                            "id": "q_iaa",
+                            "champ": "fertilisant_iaa",
+                            "texte": "IAA ?",
+                            "branches": [
+                                {
+                                    "valeur": True,
+                                    "regle": {"id": "r1", "type": "libre"},
+                                },
+                                {
+                                    "valeur": False,
+                                    "regle": {"id": "r2", "type": "libre"},
+                                },
+                            ],
+                        },
+                    },
+                    {
+                        "valeur": "icpe_ed",
+                        "noeud": {
+                            "type_noeud": "formulaire",
+                            "niveau": "complement",
+                            "id": "q_dig",
+                            "champ": "pas_un_digestats",
+                            "texte": "Digestats ?",
+                            "branches": [
+                                {
+                                    "valeur": True,
+                                    "regle": {"id": "r3", "type": "libre"},
+                                },
+                                {
+                                    "valeur": False,
+                                    "regle": {"id": "r4", "type": "libre"},
+                                },
+                            ],
+                        },
+                    },
+                ],
+            }
+        }
+    }
+
+
+def test_collecter_qc_213_repondue_prefetch_branches_non_prises():
+    """QC repondue : les QC des branches NON prises sont prefetchees,
+    annotees parent_champ/parent_valeur (revelees au flip cote front)."""
+    qc = collecter_qc_du_chemin(_arbre_qc_deux_branches(), {"plan_epandage": "icpe_a"})
+    champs = {q.champ for q in qc}
+    assert champs == {"plan_epandage", "fertilisant_iaa", "pas_un_digestats"}
+    # La QC de la branche prise est annotee par rapport a son parent QC.
+    iaa = next(q for q in qc if q.champ == "fertilisant_iaa")
+    assert iaa.parent_champ == "plan_epandage"
+    assert iaa.parent_valeur == "icpe_a"
+    # La QC de la branche non prise aussi, avec SA valeur declenchante.
+    dig = next(q for q in qc if q.champ == "pas_un_digestats")
+    assert dig.parent_champ == "plan_epandage"
+    assert dig.parent_valeur == "icpe_ed"
+    # La QC racine du chemin reste inconditionnelle (toujours visible).
+    plan = next(q for q in qc if q.champ == "plan_epandage")
+    assert plan.parent_champ is None
+
+
+def test_collecter_qc_213_bloquante_prefetch_toutes_branches():
+    """QC bloquante (pas de reponse) : TOUTES ses branches sont prefetchees,
+    la cascade complete est disponible avant meme la 1re reponse."""
+    qc = collecter_qc_du_chemin(_arbre_qc_deux_branches(), {})
+    champs = {q.champ for q in qc}
+    assert champs == {"plan_epandage", "fertilisant_iaa", "pas_un_digestats"}
+    iaa = next(q for q in qc if q.champ == "fertilisant_iaa")
+    assert (iaa.parent_champ, iaa.parent_valeur) == ("plan_epandage", "icpe_a")
+    dig = next(q for q in qc if q.champ == "pas_un_digestats")
+    assert (dig.parent_champ, dig.parent_valeur) == ("plan_epandage", "icpe_ed")
+
+
+def test_collecter_qc_213_prefetch_recursif_multi_niveaux():
+    """Le prefetch descend TOUS les niveaux : une QC sous une QC d'une branche
+    non prise est collectee, annotee par rapport a son parent QC IMMEDIAT."""
+    arbre = _arbre_qc_deux_branches()
+    # Sous q_dig (branche icpe_ed, valeur True) : une QC de 2e niveau.
+    arbre["arbre"]["noeud"]["branches"][1]["noeud"]["branches"][0] = {
+        "valeur": True,
+        "noeud": {
+            "type_noeud": "formulaire",
+            "niveau": "complement",
+            "id": "q_n2",
+            "champ": "qc_niveau_2",
+            "texte": "Niveau 2 ?",
+            "branches": [
+                {"valeur": "x", "regle": {"id": "r5", "type": "libre"}},
+            ],
+        },
+    }
+    qc = collecter_qc_du_chemin(arbre, {"plan_epandage": "icpe_a"})
+    n2 = next((q for q in qc if q.champ == "qc_niveau_2"), None)
+    assert n2 is not None
+    assert n2.parent_champ == "pas_un_digestats"
+    assert n2.parent_valeur is True
+
+
+def test_collecter_qc_213_diamant_fusionne_les_valeurs_declenchantes():
+    """Diamant : la MEME QC (via renvoi_vers) sous plusieurs branches du meme
+    parent fusionne ses valeurs declenchantes (le front revele pour chacune)."""
+    q_commune = {
+        "type_noeud": "formulaire",
+        "niveau": "complement",
+        "id": "q_icpe",
+        "champ": "plan_epandage",
+        "texte": "ICPE ?",
+        "branches": [
+            {"valeur": "oui", "regle": {"id": "r1", "type": "libre"}},
+            {"valeur": "non", "regle": {"id": "r2", "type": "libre"}},
+        ],
+    }
+    arbre = {
+        "arbre": {
+            "noeud": {
+                "type_noeud": "formulaire",
+                "niveau": "complement",
+                "id": "q_fert",
+                "champ": "qc_fertilisant",
+                "texte": "Fertilisant ?",
+                "branches": [
+                    {"valeur": "volaille", "noeud": q_commune},
+                    {"valeur": "compact", "renvoi_vers": "q_icpe"},
+                    {"valeur": "autre", "regle": {"id": "r3", "type": "libre"}},
+                ],
+            }
+        }
+    }
+    qc = collecter_qc_du_chemin(arbre, {})
+    icpe = next(q for q in qc if q.champ == "plan_epandage")
+    assert icpe.parent_champ == "qc_fertilisant"
+    vals = (
+        icpe.parent_valeur
+        if isinstance(icpe.parent_valeur, list)
+        else [icpe.parent_valeur]
+    )
+    assert set(vals) == {"volaille", "compact"}
+
+
+def test_collecter_qc_213_prefetch_traverse_catalogue_parametre():
+    """Les noeuds intermediaires (catalogue_parametre) des branches non prises
+    sont traverses de facon transparente par le prefetch."""
+    arbre = {
+        "arbre": {
+            "noeud": {
+                "type_noeud": "formulaire",
+                "niveau": "complement",
+                "id": "q_a",
+                "champ": "qc_a",
+                "texte": "A ?",
+                "branches": [
+                    {"valeur": "v1", "regle": {"id": "r1", "type": "libre"}},
+                    {
+                        "valeur": "v2",
+                        "noeud": {
+                            "type_noeud": "catalogue_parametre",
+                            "id": "cp",
+                            "branches": [
+                                {
+                                    "expression": "True",
+                                    "noeud": {
+                                        "type_noeud": "formulaire",
+                                        "niveau": "complement",
+                                        "id": "q_b",
+                                        "champ": "qc_b",
+                                        "texte": "B ?",
+                                        "branches": [
+                                            {
+                                                "valeur": "x",
+                                                "regle": {"id": "r2", "type": "libre"},
+                                            },
+                                        ],
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                ],
+            }
+        }
+    }
+    qc = collecter_qc_du_chemin(arbre, {"qc_a": "v1"})
+    b = next((q for q in qc if q.champ == "qc_b"), None)
+    assert b is not None
+    assert (b.parent_champ, b.parent_valeur) == ("qc_a", "v2")
+
+
+def test_collecter_qc_213_noeud_depart_herite_de_la_qc_ancetre():
+    """Arbre atteint via bascule cross-arbre (noeud_depart) : si le noeud
+    d'atterrissage est SOUS une QC de cet arbre, les QC collectees heritent
+    de cette QC ancetre comme parent -> le front peut les masquer si
+    l'utilisateur change la reponse parente (QC stale, cas PAR -> PAN)."""
+    arbre = {
+        "arbre": {
+            "noeud": {
+                "type_noeud": "formulaire",
+                "niveau": "complement",
+                "id": "q_plan",
+                "champ": "plan_epandage",
+                "texte": "Plan ?",
+                "branches": [
+                    {
+                        "valeur": "icpe_a",
+                        "noeud": {
+                            "type_noeud": "catalogue_parametre",
+                            "id": "cp_effluent",
+                            "branches": [
+                                {
+                                    "expression": "True",
+                                    "noeud": {
+                                        "type_noeud": "formulaire",
+                                        "niveau": "complement",
+                                        "id": "q_iaa",
+                                        "champ": "fertilisant_iaa",
+                                        "texte": "IAA ?",
+                                        "branches": [
+                                            {
+                                                "valeur": True,
+                                                "regle": {"id": "r1", "type": "libre"},
+                                            },
+                                        ],
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                    {"valeur": "icpe_ed", "regle": {"id": "r2", "type": "libre"}},
+                ],
+            }
+        }
+    }
+    # Atterrissage au catalogue_parametre situe SOUS plan_epandage=icpe_a.
+    qc = collecter_qc_du_chemin(arbre, {}, noeud_depart="cp_effluent")
+    iaa = next(q for q in qc if q.champ == "fertilisant_iaa")
+    assert iaa.parent_champ == "plan_epandage"
+    assert iaa.parent_valeur == "icpe_a"

--- a/envergo/nitrates/views.py
+++ b/envergo/nitrates/views.py
@@ -436,6 +436,7 @@ class MoulinetteView(View):
             "geo_appliquee": self.geo_appliquee,
             "cascade_fields": cascade_fields,
             "qc_actifs": [],
+            "qc_panel": [],
             "qc_repondues_champs": [],
         }
 
@@ -547,12 +548,14 @@ class MoulinetteView(View):
                 if any(x.champ == q.champ for x in qc_collectees):
                     continue
                 qc_collectees.append(q)
-        qc_repondues = []
+        # Panneau QC unifie (#213) : les QC du chemin (repondues + bloquante)
+        # ET les QC prefetchees des branches non prises, dans une seule liste
+        # ordonnee. Chaque entree porte son annotation parent (champ + valeurs
+        # declenchantes, jointes par "|") : le template rend cachees les
+        # conditionnelles, subsidiaires_cascade.js revele/masque au changement
+        # de reponse, sans aller-retour serveur.
+        qc_panel = []
         for q in qc_collectees:
-            if q.champ in qc_actifs:
-                # Deja en cours de saisie dans le panneau resultat (a droite),
-                # on ne le redouble pas a gauche.
-                continue
             raw = request.GET.get(q.champ) or ""
             # Stringify les valeurs des choix pour comparer avec ce qui
             # arrive par URL (toujours str). Sinon bool True != "True"
@@ -569,15 +572,54 @@ class MoulinetteView(View):
                 (c["libelle"] for c in choix if c["valeur"] == valeur),
                 valeur,
             )
-            qc_repondues.append(
+            parent_vals = (
+                q.parent_valeur
+                if isinstance(q.parent_valeur, list)
+                else ([] if q.parent_valeur is None else [q.parent_valeur])
+            )
+            qc_panel.append(
                 {
                     "champ": q.champ,
                     "valeur": valeur,
                     "texte": q.texte or q.champ,
                     "libelle": libelle,
                     "choix": choix,
+                    "parent_champ": q.parent_champ or "",
+                    "parent_valeur": "|".join(str(v) for v in parent_vals),
+                    "en_attente": q.champ in qc_actifs,
                 }
             )
+        # Filet de securite : si l'evaluateur a bute sur des questions que la
+        # collecte n'a pas retrouvees (divergence de descente), on les ajoute
+        # telles quelles (inconditionnelles) pour ne jamais perdre une QC en
+        # attente a l'ecran.
+        champs_panel = {e["champ"] for e in qc_panel}
+        if premier_qc is not None:
+            for q in premier_qc.questions_subsidiaires.questions:
+                if q.champ in champs_panel:
+                    continue
+                qc_panel.append(
+                    {
+                        "champ": q.champ,
+                        "valeur": request.GET.get(q.champ) or "",
+                        "texte": q.texte or q.champ,
+                        "libelle": "",
+                        "choix": [
+                            {
+                                "valeur": str(c["valeur"]),
+                                "libelle": c.get("libelle") or str(c["valeur"]),
+                            }
+                            for c in (q.choix or [])
+                        ],
+                        "parent_champ": q.parent_champ or "",
+                        "parent_valeur": (
+                            "" if q.parent_valeur is None else str(q.parent_valeur)
+                        ),
+                        "en_attente": True,
+                    }
+                )
+        # Sous-liste "repondues" (badge compteur du recap localisation).
+        qc_repondues = [e for e in qc_panel if e["valeur"] and not e["en_attente"]]
 
         ctx.update(
             {
@@ -592,8 +634,12 @@ class MoulinetteView(View):
                 "regulations_evaluees": regulations_evaluees,
                 "premier_evaluator_avec_questions": premier_qc,
                 "qc_actifs": qc_actifs,
+                "qc_panel": qc_panel,
                 "qc_repondues": qc_repondues,
-                "qc_repondues_champs": [e["champ"] for e in qc_repondues],
+                # Tous les champs QC presents dans le panneau ont des radios
+                # dans le form (visibles ou prefetchees cachees) : aucun ne
+                # doit etre re-injecte en hidden passthrough (double cle).
+                "qc_repondues_champs": [e["champ"] for e in qc_panel],
             }
         )
         return render(request, "nitrates/simulateur.html", ctx)

--- a/envergo/nitrates/yaml_tree/parcours.py
+++ b/envergo/nitrates/yaml_tree/parcours.py
@@ -885,8 +885,25 @@ def _collecter_aval_conditionnel(
 
     if type_noeud != "formulaire":
         return
-    # Skip si la sous-question est deja resolue par le contexte (pre-fill).
-    if contexte.get(sous["champ"]) is not None:
+    # Si la sous-question est deja resolue par le contexte (typiquement un
+    # pre-fill cascade), on ne la propose pas (redondance UX) mais on TRAVERSE
+    # la branche correspondante pour prefetcher les QC plus bas, en gardant
+    # l'annotation parent d'origine (#213).
+    valeur_prefill = contexte.get(sous["champ"])
+    if valeur_prefill is not None:
+        for sb in sous.get("branches", []):
+            if _valeurs_egales(sb.get("valeur"), valeur_prefill):
+                _collecter_aval_conditionnel(
+                    sb,
+                    contexte,
+                    questions,
+                    index_ids,
+                    resoudre_catalogue,
+                    parent_champ,
+                    parent_valeur,
+                    _visites_renvoi,
+                )
+                break
         return
     _ajouter_question(
         questions,
@@ -894,6 +911,25 @@ def _collecter_aval_conditionnel(
         parent_champ=parent_champ,
         parent_valeur=parent_valeur,
     )
+    # #213 : prefetch INTEGRAL. On descend recursivement dans TOUTES les
+    # branches de la sous-question : chaque QC plus profonde est annotee par
+    # rapport a son parent QC IMMEDIAT, et le front (subsidiaires_cascade.js)
+    # revele/masque la cascade complete sans aller-retour serveur. Copie de
+    # `_visites_renvoi` par branche : un meme sous-arbre `renvoi_vers` peut
+    # etre legitimement atteint depuis plusieurs branches soeurs (diamant) ;
+    # la copie garde la protection anti-cycle LE LONG d'un chemin sans
+    # interdire les diamants entre chemins.
+    for sb in sous.get("branches", []):
+        _collecter_aval_conditionnel(
+            sb,
+            contexte,
+            questions,
+            index_ids,
+            resoudre_catalogue,
+            parent_champ=sous["champ"],
+            parent_valeur=sb.get("valeur"),
+            _visites_renvoi=set(_visites_renvoi),
+        )
 
 
 def _ajouter_question(
@@ -902,9 +938,26 @@ def _ajouter_question(
     parent_champ: str | None = None,
     parent_valeur: Any = None,
 ) -> None:
-    """Ajoute une question si pas deja presente (par champ)."""
+    """Ajoute une question si pas deja presente (par champ).
+
+    Cas diamant (#213) : la MEME question (typiquement atteinte via
+    `renvoi_vers` depuis plusieurs branches) peut dependre de PLUSIEURS
+    valeurs du meme parent. On fusionne alors les valeurs declenchantes
+    dans `parent_valeur` (liste) au lieu d'ignorer la seconde occurrence :
+    le front revelera la question pour chacune de ces valeurs. Si la
+    question existe deja SANS condition (inconditionnelle, toujours
+    visible) ou sous un AUTRE parent, la premiere annotation gagne,
+    comme avant."""
     champ = noeud["champ"]
-    if any(q.champ == champ for q in questions):
+    existante = next((q for q in questions if q.champ == champ), None)
+    if existante is not None:
+        if parent_champ is not None and existante.parent_champ == parent_champ:
+            vals = existante.parent_valeur
+            if not isinstance(vals, list):
+                vals = [vals]
+            if not any(_valeurs_egales(v, parent_valeur) for v in vals):
+                vals.append(parent_valeur)
+            existante.parent_valeur = vals
         return
     questions.append(
         QuestionFormulaire(
@@ -989,10 +1042,32 @@ def collecter_qc_du_chemin(
         return qc
     index_ids = _build_id_index(arbre)
     depart = racine
+    parent_initial_champ: str | None = None
+    parent_initial_valeur: Any = None
     if noeud_depart:
         candidat = index_ids.get(noeud_depart)
         if isinstance(candidat, dict) and "champ" in candidat:
             depart = candidat
+            # #213 : le noeud d'atterrissage peut se trouver SOUS une QC de
+            # cet arbre (bascule cross-arbre declenchee par une reponse QC,
+            # ex. plan_epandage=icpe_a fait cul-de-sac dans le PAR et atterrit
+            # dans le PAN sous son propre noeud plan_epandage). Les QC
+            # collectees a partir de la doivent heriter de cette QC ancetre
+            # comme parent : sinon elles sont rendues inconditionnelles et le
+            # front ne peut pas les masquer quand l'utilisateur change la
+            # reponse parente (QC stale a l'ecran).
+            parent_initial_champ, parent_initial_valeur = _parent_qc_du_noeud(
+                racine, noeud_depart
+            )
+    # #213 : en plus des QC du chemin (repondues + bloquante), on prefetch
+    # les QC conditionnelles de TOUTES les branches non prises de chaque QC
+    # rencontree, annotees parent_champ/parent_valeur. Le front les rend
+    # cachees et les revele au changement de reponse, SANS aller-retour
+    # serveur. Elles sont collectees a part puis fusionnees : les QC du
+    # chemin priment (une QC a la fois sur le chemin ET atteignable par une
+    # branche alternative garde sa version chemin, enrichie des valeurs
+    # declenchantes supplementaires si meme parent).
+    conditionnelles: list[QuestionFormulaire] = []
     _suivre_chemin_pour_qc(
         depart,
         contexte,
@@ -1000,8 +1075,73 @@ def collecter_qc_du_chemin(
         qc,
         visites=set(),
         resoudre_catalogue=resoudre_catalogue,
+        parent_champ=parent_initial_champ,
+        parent_valeur=parent_initial_valeur,
+        conditionnelles=conditionnelles,
     )
+    _fusionner_conditionnelles(qc, conditionnelles)
     return qc
+
+
+def _parent_qc_du_noeud(racine: dict, noeud_id: str) -> tuple[str | None, Any]:
+    """QC ancetre la plus proche AU-DESSUS du noeud `noeud_id`, et la valeur
+    de la branche qui y mene : (champ, valeur), ou (None, None) si le noeud
+    n'est sous aucune QC. Descente DFS sur la structure (branches `noeud`
+    imbriquees ; les `renvoi_vers` ne sont pas suivis : un noeud atteint via
+    renvoi a son ancetre structurel comme parent, ce qui suffit pour
+    l'annotation)."""
+
+    def _dfs(noeud, parent_champ, parent_valeur):
+        if noeud.get("id") == noeud_id:
+            return (parent_champ, parent_valeur)
+        est_qc = (
+            noeud.get("type_noeud") == "formulaire"
+            and noeud.get("niveau") == "complement"
+        )
+        for branche in noeud.get("branches", []) or []:
+            if "noeud" not in branche:
+                continue
+            if est_qc:
+                p_champ, p_valeur = noeud.get("champ"), branche.get("valeur")
+            else:
+                p_champ, p_valeur = parent_champ, parent_valeur
+            trouve = _dfs(branche["noeud"], p_champ, p_valeur)
+            if trouve is not None:
+                return trouve
+        return None
+
+    return _dfs(racine, None, None) or (None, None)
+
+
+def _fusionner_conditionnelles(
+    qc: list[QuestionFormulaire],
+    conditionnelles: list[QuestionFormulaire],
+) -> None:
+    """Fusionne les QC prefetchees (branches non prises) dans la liste des QC
+    du chemin. Une QC deja presente cote chemin prime ; si elle est
+    conditionnelle sous le MEME parent, on lui adjoint les valeurs
+    declenchantes supplementaires (cas diamant, cf. _ajouter_question)."""
+    for cq in conditionnelles:
+        existante = next((x for x in qc if x.champ == cq.champ), None)
+        if existante is None:
+            qc.append(cq)
+            continue
+        if existante.parent_champ is None:
+            continue  # inconditionnelle : toujours visible, rien a fusionner
+        if cq.parent_champ != existante.parent_champ:
+            continue  # parents differents : la premiere annotation gagne
+        vals = existante.parent_valeur
+        if not isinstance(vals, list):
+            vals = [vals]
+        nouvelles = (
+            cq.parent_valeur
+            if isinstance(cq.parent_valeur, list)
+            else [cq.parent_valeur]
+        )
+        for v in nouvelles:
+            if not any(_valeurs_egales(v, x) for x in vals):
+                vals.append(v)
+        existante.parent_valeur = vals
 
 
 def _suivre_chemin_pour_qc(
@@ -1011,11 +1151,25 @@ def _suivre_chemin_pour_qc(
     qc: list[QuestionFormulaire],
     visites: set[str],
     resoudre_catalogue=None,
+    parent_champ: str | None = None,
+    parent_valeur: Any = None,
+    conditionnelles: list[QuestionFormulaire] | None = None,
 ) -> None:
     """Descend un noeud en suivant la branche dictee par `contexte`. Collecte
     les QC de niveau complement croisees. S'arrete si la valeur du champ
     courant n'est pas dans le contexte (= QC bloquante atteinte ; on l'ajoute
     AVEC ses choix arbre puis on stop).
+
+    #213 — deux extensions pour le prefetch integral :
+      - chaque QC du chemin situee SOUS une autre QC est annotee
+        parent_champ/parent_valeur (la QC parente + la valeur de la branche
+        prise) : le front peut ainsi la masquer/decocher si l'utilisateur
+        change la reponse parente, sans aller-retour serveur ;
+      - a chaque QC rencontree, les branches NON prises (toutes, si la QC est
+        bloquante) sont explorees via `_collecter_aval_conditionnel` et leurs
+        QC accumulees dans `conditionnelles` (fusionnees ensuite par
+        `collecter_qc_du_chemin`). Les noeuds intermediaires (catalogue SIG,
+        catalogue_parametre, renvois) restent traverses de facon transparente.
     """
     if "id" in noeud and noeud["id"] in visites:
         return
@@ -1039,6 +1193,9 @@ def _suivre_chemin_pour_qc(
                         qc,
                         visites,
                         resoudre_catalogue,
+                        parent_champ,
+                        parent_valeur,
+                        conditionnelles,
                     )
                 elif "renvoi_vers" in branche:
                     cible = index_ids.get(branche["renvoi_vers"])
@@ -1054,6 +1211,9 @@ def _suivre_chemin_pour_qc(
                             qc,
                             visites,
                             resoudre_catalogue,
+                            parent_champ,
+                            parent_valeur,
+                            conditionnelles,
                         )
                 return
         return
@@ -1063,8 +1223,11 @@ def _suivre_chemin_pour_qc(
     # n'est JAMAIS une question complementaire : il est fourni par la cascade
     # principale du formulaire (panneau de gauche). Le collecter ici le ferait
     # apparaitre a tort dans le bloc "Questions complementaires" (#222 retour Max).
-    if type_noeud == "formulaire" and noeud.get("niveau") == "complement":
-        _ajouter_question(qc, noeud)
+    est_qc = type_noeud == "formulaire" and noeud.get("niveau") == "complement"
+    if est_qc:
+        _ajouter_question(
+            qc, noeud, parent_champ=parent_champ, parent_valeur=parent_valeur
+        )
 
     # Noeud catalogue SIG : resolu a la volee (contexte ou callback) pour ne pas
     # bloquer la descente vers les QC en aval.
@@ -1073,15 +1236,51 @@ def _suivre_chemin_pour_qc(
     else:
         valeur = contexte.get(champ) if champ else None
     if valeur is None:
-        # On ne peut pas continuer plus loin sans reponse. Cas typique :
-        # 1ere QC pas repondue -> on s'arrete ici. Pour les noeuds non-QC
-        # (catalogue ou form principal), c'est pareil mais on a deja
-        # collecte ce qu'il fallait.
+        # On ne peut pas suivre le chemin plus loin sans reponse. Cas typique :
+        # QC bloquante -> on prefetch alors TOUTES ses branches (#213), pour
+        # que la cascade complete soit deja dans le DOM quand l'utilisateur
+        # repondra. Pour les noeuds non-QC (catalogue irresolvable ou form
+        # principal), on s'arrete comme avant.
+        if est_qc and conditionnelles is not None:
+            for sb in noeud.get("branches", []):
+                _collecter_aval_conditionnel(
+                    sb,
+                    contexte,
+                    conditionnelles,
+                    index_ids,
+                    resoudre_catalogue,
+                    parent_champ=champ,
+                    parent_valeur=sb.get("valeur"),
+                    _visites_renvoi=set(),
+                )
         return
 
     branche = _choisir_branche_safe(noeud, valeur)
     if branche is None:
         return
+    if est_qc:
+        # QC repondue : prefetch des branches NON prises (#213), pour qu'un
+        # changement de reponse revele leurs QC cote front, sans resubmit.
+        if conditionnelles is not None:
+            for sb in noeud.get("branches", []):
+                if sb is branche:
+                    continue
+                _collecter_aval_conditionnel(
+                    sb,
+                    contexte,
+                    conditionnelles,
+                    index_ids,
+                    resoudre_catalogue,
+                    parent_champ=champ,
+                    parent_valeur=sb.get("valeur"),
+                    _visites_renvoi=set(),
+                )
+        # La suite du chemin est conditionnee par CETTE QC : les QC plus bas
+        # heritent d'elle comme parent (valeur declaree par la branche prise,
+        # pas la valeur brute du contexte, pour matcher les radios rendus).
+        parent_suivant_champ, parent_suivant_valeur = champ, branche.get("valeur")
+    else:
+        parent_suivant_champ, parent_suivant_valeur = parent_champ, parent_valeur
     if "noeud" in branche:
         _suivre_chemin_pour_qc(
             branche["noeud"],
@@ -1090,6 +1289,9 @@ def _suivre_chemin_pour_qc(
             qc,
             visites,
             resoudre_catalogue,
+            parent_suivant_champ,
+            parent_suivant_valeur,
+            conditionnelles,
         )
     elif "renvoi_vers" in branche:
         cible = index_ids.get(branche["renvoi_vers"])
@@ -1105,6 +1307,9 @@ def _suivre_chemin_pour_qc(
                 qc,
                 visites,
                 resoudre_catalogue,
+                parent_suivant_champ,
+                parent_suivant_valeur,
+                conditionnelles,
             )
 
 

--- a/envergo/static/nitrates/reset_form.js
+++ b/envergo/static/nitrates/reset_form.js
@@ -197,13 +197,24 @@
     const resultCol = document.querySelector(".result-col");
     if (resultCol) resultCol.remove();
 
-    // 2. Retirer le bloc QC (questions complementaires sous le form).
+    // 2. Le bloc QC (#qc-bloc) est CONSERVE (#213). Le raser ici provoquait
+    //    un clignotement deletere : l'utilisateur change un champ amont (ex
+    //    fumier compact -> fumier de volaille), le volet QC disparait, et la
+    //    resoumission re-affiche exactement la meme question (la QC ICPE vaut
+    //    pour les deux branches). Regle : le client ne decide pas si les QC
+    //    restent pertinentes -- c'est le rendu serveur suivant qui tranche
+    //    (le volet disparait a ce moment-la SEULEMENT si la nouvelle branche
+    //    n'a pas de QC). Les reponses cochees restent portees par leurs
+    //    radios ; celles hors de la nouvelle branche seront ignorees par le
+    //    serveur, et subsidiaires_cascade.js masque/decoche deja les QC
+    //    conditionnelles devenues incoherentes.
+    //    On retire en revanche data-qc-en-attente : apres elagage on est en
+    //    mode SAISIE, la QC n'est plus l'etape qui commande le viewport --
+    //    form_autoscroll.js (estEnModeResultat) doit reprendre la main pour
+    //    accompagner la re-saisie du form principal. Sans ce retrait,
+    //    l'auto-scroll resterait neutralise (regression #272 constatee).
     const qcBloc = document.getElementById("qc-bloc");
-    if (qcBloc) qcBloc.remove();
-    // Au cas ou un autre panneau QC trainerait (defensif).
-    document
-      .querySelectorAll(".resultat-panel--questions")
-      .forEach((el) => el.remove());
+    if (qcBloc) qcBloc.removeAttribute("data-qc-en-attente");
 
     // 3. Repasser le layout en colonne unique.
     const row = document.querySelector(".results-row");

--- a/envergo/static/nitrates/subsidiaires_cascade.js
+++ b/envergo/static/nitrates/subsidiaires_cascade.js
@@ -41,8 +41,14 @@
   function rafraichirVisibilite(parentChamp) {
     const valeur = valeurActuelle(parentChamp);
     for (const g of dependants.get(parentChamp) || []) {
-      const attendue = g.dataset.qcParentValeur;
-      if (valeur !== null && String(valeur) === String(attendue)) {
+      // #213 : une QC atteignable depuis plusieurs branches du meme parent
+      // (diamant via renvoi_vers) declare ses valeurs declenchantes jointes
+      // par "|" (ex "icpe_a|icpe_ed"). On revele si la valeur cochee en est.
+      const attendues = String(g.dataset.qcParentValeur).split("|");
+      if (
+        valeur !== null &&
+        attendues.some((a) => String(valeur) === a)
+      ) {
         g.hidden = false;
       } else {
         g.hidden = true;

--- a/envergo/templates/nitrates/fragments/_panneau_form.html
+++ b/envergo/templates/nitrates/fragments/_panneau_form.html
@@ -355,7 +355,7 @@ questions/résultat. djLint (H025) croit à tort le <form> orphelin à cause des
   en colonne unique. Une fois tout repondu, ce bloc reste affiche en recap et
   le resultat apparait a droite.
         {% endcomment %}
-        {% if qc_en_attente or qc_repondues %}
+        {% if qc_panel %}
           <div class="form-section questions-complementaires-box"
                style="margin-top: 32px">{% include "nitrates/fragments/_qc_sous_form.html" %}</div>
         {% endif %}

--- a/envergo/templates/nitrates/fragments/_qc_sous_form.html
+++ b/envergo/templates/nitrates/fragments/_qc_sous_form.html
@@ -24,22 +24,21 @@ form="form-simulateur" (form_attr=""). subsidiaires_cascade.js opere sur
     questions ci-dessous.
   </p>
 
-  {% comment %}1. QC deja repondues (editables).{% endcomment %}
-  {% for entry in qc_repondues %}
-    {% include "nitrates/fragments/_qc_question_item.html" with q=entry id_prefix="id_qc_sf_done_" form_attr="" selected_valeur=entry.valeur forloop_first=forloop.first %}
+  {% comment %}
+  Boucle unifiee (#213) : qc_panel contient, dans l'ordre du parcours, les QC
+  repondues (editables), la/les QC en attente, ET les QC prefetchees des
+  branches non prises (annotees parent_champ/parent_valeur -> rendues cachees,
+  revelees par subsidiaires_cascade.js au changement de reponse, sans
+  aller-retour serveur). Le prefixe d'id distingue en attente (new) / recap
+  (done) pour le focus initial et les selecteurs existants.
+  {% endcomment %}
+  {% for entry in qc_panel %}
+    {% if entry.en_attente %}
+      {% include "nitrates/fragments/_qc_question_item.html" with q=entry id_prefix="id_qc_sf_new_" form_attr="" selected_valeur=entry.valeur forloop_first=forloop.first %}
+    {% else %}
+      {% include "nitrates/fragments/_qc_question_item.html" with q=entry id_prefix="id_qc_sf_done_" form_attr="" selected_valeur=entry.valeur forloop_first=forloop.first %}
+    {% endif %}
   {% endfor %}
-
-  {% comment %}2. QC en attente (cascade conditionnelle). La 1re n'est "first"
-  (pas de margin-top) que s'il n'y a aucune QC repondue au-dessus.{% endcomment %}
-  {% if premier_evaluator_avec_questions %}
-    {% for q in premier_evaluator_avec_questions.questions_subsidiaires.questions %}
-      {% if forloop.first and not qc_repondues %}
-        {% include "nitrates/fragments/_qc_question_item.html" with q=q id_prefix="id_qc_sf_new_" form_attr="" selected_valeur=data|get_item:q.champ forloop_first=True %}
-      {% else %}
-        {% include "nitrates/fragments/_qc_question_item.html" with q=q id_prefix="id_qc_sf_new_" form_attr="" selected_valeur=data|get_item:q.champ forloop_first=False %}
-      {% endif %}
-    {% endfor %}
-  {% endif %}
   {% comment %}Pas de bouton ici : le bouton principal du formulaire (cf.
   _panneau_form) sert de « Suivant » quand une QC est en attente.{% endcomment %}
 </div>


### PR DESCRIPTION
Fixes #213

Changer une réponse à une question complémentaire laissait l'écran incohérent (QC obsolète encore cochée, URL désynchronisée) et forçait un re-clic sur « Lancer la simulation ». Cause profonde : le prefetch des QC ne couvrait que la branche en cours, et la QC suivante pouvait vivre dans un autre arbre (bascule PAR -> PAN).

- collecte serveur étendue à toutes les branches de toutes les QC en aval (tous niveaux, nœuds intermédiaires traversés, diamants fusionnés, héritage de la QC ancêtre à l'atterrissage cross-arbre)
- panneau QC unifié : répondues + en attente + prefetchées cachées, révélation/masquage 100% client, rien ne part au serveur avant « Suivant »
- le volet QC n'est plus rasé au changement d'un champ amont (anti-clignotement)
- tests : +6 unitaires parcours, spec e2e #213 réécrit (3 scénarios), 2 tests reset_form réalignés sur le nouveau comportement

Validé à la main sur le container 8053 (testbook en commentaire de la carte). Les 7 e2e rouges préexistants (#271/#335) sont hors périmètre et échouent à l'identique sur main.
