### PR TITLE
nitrates(#285): bouton flottant « Signaler un bug » sur toutes les pages

### DIFF
--- a/envergo/nitrates/admin.py
+++ b/envergo/nitrates/admin.py
@@ -674,10 +674,15 @@ class ContenuRichDSFRAdmin(admin.ModelAdmin):
         )
 
 
-# ─── Retours utilisateurs (cartes #284/#287) ────────────────────────────────
+# ─── Retours utilisateurs (cartes #284/#287/#285) ───────────────────────────
 # Admin en lecture seule : les retours sont collectés côté public, on ne fait
 # que les consulter/exporter ici. On n'autorise pas la création/édition (ce
 # sont des données brutes d'utilisateurs, append-only).
+#
+# Pour un signalement « bug » (#285), le champ `contexte` embarque le maximum
+# d'infos techniques dumpées par le navigateur (URL, user-agent, taille écran,
+# logs console, requêtes réseau). On le rend lisible ci-dessous plutôt que de
+# laisser du JSON brut.
 
 
 @admin.register(RetourUtilisateur)
@@ -701,6 +706,7 @@ class RetourUtilisateurAdmin(admin.ModelAdmin):
         "email",
         "consentement_email",
         "region_code",
+        "contexte_lisible",
         "contexte",
         "cree_le",
     )
@@ -713,6 +719,62 @@ class RetourUtilisateurAdmin(admin.ModelAdmin):
     def apercu_commentaire(self, obj):
         txt = (obj.commentaire or "").strip()
         return (txt[:60] + "…") if len(txt) > 60 else txt
+
+    @admin.display(description="Contexte technique (bug)")
+    def contexte_lisible(self, obj):
+        """Rend le `contexte` d'un signalement bug (#285) sous forme lisible :
+        infos page + logs console + requêtes réseau. Pour les autres types, le
+        contexte est du JSON anonyme minimal, on le laisse tel quel."""
+        ctx = obj.contexte or {}
+        if not isinstance(ctx, dict) or not ctx:
+            return "—"
+
+        def _bloc(titre, corps):
+            return format_html(
+                '<div style="margin-bottom:1em"><strong>{}</strong>'
+                '<pre style="white-space:pre-wrap;background:#f6f6f6;'
+                'padding:.5em;border-radius:4px;max-height:22em;overflow:auto">'
+                "{}</pre></div>",
+                titre,
+                corps,
+            )
+
+        parties = []
+
+        infos = {
+            "URL": ctx.get("url"),
+            "Titre page": ctx.get("titre_page"),
+            "User-agent": ctx.get("user_agent"),
+            "Écran": ctx.get("viewport"),
+            "Référent": ctx.get("referrer"),
+            "Horodatage client": ctx.get("horodatage"),
+        }
+        infos_txt = "\n".join(f"{k} : {v}" for k, v in infos.items() if v)
+        if infos_txt:
+            parties.append(_bloc("Page", infos_txt))
+
+        logs = ctx.get("console") or []
+        if logs:
+            lignes = "\n".join(
+                f"[{e.get('level', '?')}] {e.get('message', '')}"
+                for e in logs
+                if isinstance(e, dict)
+            )
+            parties.append(_bloc(f"Console ({len(logs)} entrées)", lignes))
+
+        reseau = ctx.get("network") or []
+        if reseau:
+            lignes = "\n".join(
+                f"{e.get('method', '?')} {e.get('url', '')} "
+                f"→ {e.get('status', '?')}"
+                for e in reseau
+                if isinstance(e, dict)
+            )
+            parties.append(_bloc(f"Réseau ({len(reseau)} requêtes)", lignes))
+
+        if not parties:
+            return "—"
+        return mark_safe("".join(parties))
 
     def has_add_permission(self, request):
         return False

--- a/envergo/nitrates/migrations/0033_retour_type_bug.py
+++ b/envergo/nitrates/migrations/0033_retour_type_bug.py
@@ -1,0 +1,28 @@
+# Generated for #285 — ajout du type "bug" (bouton flottant feedback/bug).
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("nitrates", "0032_contenurichdsfr_glossaire"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="retourutilisateur",
+            name="type",
+            field=models.CharField(
+                choices=[
+                    ("feedback", "Feedback fin de simulation"),
+                    ("interet_region", "Intérêt région non ouverte"),
+                    ("bug", "Signalement bug / retour (bouton flottant)"),
+                ],
+                db_index=True,
+                help_text="Nature du retour : feedback simulation (#284), intérêt "
+                "région (#287) ou signalement bug (#285).",
+                max_length=20,
+            ),
+        ),
+    ]

--- a/envergo/nitrates/models_retour.py
+++ b/envergo/nitrates/models_retour.py
@@ -1,14 +1,17 @@
-"""Retours utilisateurs du simulateur nitrates (cartes #284 et #287).
+"""Retours utilisateurs du simulateur nitrates (cartes #284, #287 et #285).
 
-Un seul modèle générique `RetourUtilisateur` couvre deux intentions distinctes,
+Un seul modèle générique `RetourUtilisateur` couvre trois intentions distinctes,
 discriminées par le champ `type` :
 
 - **feedback** (#284) : en fin de simulation, « De 0 à 5, cet outil vous a-t-il
   été utile ? » + commentaire libre + email optionnel (devenir alpha-testeur).
 - **interet_region** (#287) : au clic sur une zone hors périmètre, capture d'un
   email « prévenez-moi à l'ouverture de ma région » + le code région tenté.
+- **bug** (#285) : bouton flottant discret présent sur toutes les pages. L'utilisateur
+  signale un bug ou un ressenti ; on capture en plus, dans `contexte`, le maximum
+  d'infos techniques (URL, user-agent, logs console, requêtes réseau) pour reproduire.
 
-RGPD (exigence forte des deux cartes) :
+RGPD (exigence forte des trois cartes) :
 - L'email est stocké SEUL, jamais joint aux données de simulation. Le champ
   `contexte` ne contient que des métadonnées ANONYMES (ex : type de résultat),
   aucune donnée localisante ni parcellaire.
@@ -30,12 +33,14 @@ class RetourUtilisateur(models.Model):
     class Type(models.TextChoices):
         FEEDBACK = "feedback", "Feedback fin de simulation"
         INTERET_REGION = "interet_region", "Intérêt région non ouverte"
+        BUG = "bug", "Signalement bug / retour (bouton flottant)"
 
     type = models.CharField(
         max_length=20,
         choices=Type.choices,
         db_index=True,
-        help_text="Nature du retour : feedback simulation (#284) ou intérêt région (#287).",
+        help_text="Nature du retour : feedback simulation (#284), intérêt "
+        "région (#287) ou signalement bug (#285).",
     )
 
     # #284 : note d'utilité 0-5 (null pour un intérêt région).
@@ -89,9 +94,12 @@ class RetourUtilisateur(models.Model):
     def __str__(self):
         if self.type == self.Type.FEEDBACK:
             note = self.note if self.note is not None else "?"
-            return f"Feedback {note}/5 — {self.cree_le:%Y-%m-%d %H:%M}"
+            return f"Feedback {note}/5 - {self.cree_le:%Y-%m-%d %H:%M}"
+        if self.type == self.Type.BUG:
+            apercu = (self.commentaire or "").strip()[:40]
+            return f"Bug/retour « {apercu or '(sans texte)'} » - {self.cree_le:%Y-%m-%d %H:%M}"
         return (
-            f"Intérêt région {self.region_code or '?'} — {self.cree_le:%Y-%m-%d %H:%M}"
+            f"Intérêt région {self.region_code or '?'} - {self.cree_le:%Y-%m-%d %H:%M}"
         )
 
     @property

--- a/envergo/nitrates/tests/test_retour_utilisateur.py
+++ b/envergo/nitrates/tests/test_retour_utilisateur.py
@@ -1,4 +1,4 @@
-"""Tests de l'endpoint de collecte des retours utilisateurs (#284/#287)."""
+"""Tests de l'endpoint de collecte des retours utilisateurs (#284/#287/#285)."""
 
 import json
 
@@ -151,6 +151,52 @@ def test_attacher_email_retour_inexistant(client):
         {"retour_id": 999999, "email": "x@y.fr", "consentement_email": True},
     )
     assert resp.status_code == 404
+
+
+def test_bug_signalement_sans_note_ni_email(client):
+    """#285 : un signalement bug n'exige ni note ni email. On enregistre le
+    commentaire + le contexte technique dumpé par le navigateur."""
+    resp = _post(
+        client,
+        {
+            "type": "bug",
+            "commentaire": "Le bouton Suivant ne réagit pas.",
+            "contexte": {
+                "url": "https://exemple.fr/simulateur",
+                "user_agent": "Mozilla/5.0",
+                "sous_type": "bug",
+                "console": [
+                    {"level": "error", "message": "boom", "t": "2026-08-13T10:00:00Z"}
+                ],
+                "network": [{"method": "GET", "url": "/x", "status": 500}],
+            },
+        },
+    )
+    assert resp.status_code == 201
+    r = RetourUtilisateur.objects.get(pk=resp.json()["id"])
+    assert r.type == RetourUtilisateur.Type.BUG
+    assert r.note is None
+    assert r.email == ""
+    assert r.commentaire == "Le bouton Suivant ne réagit pas."
+    assert r.contexte["sous_type"] == "bug"
+    assert r.contexte["console"][0]["level"] == "error"
+    assert r.contexte["network"][0]["status"] == 500
+
+
+def test_bug_ignore_email_sans_consentement(client):
+    """RGPD : même sur un bug, un email sans consentement est ignoré."""
+    resp = _post(
+        client,
+        {
+            "type": "bug",
+            "commentaire": "souci",
+            "email": "x@y.fr",
+            "consentement_email": False,
+        },
+    )
+    assert resp.status_code == 201
+    r = RetourUtilisateur.objects.get(pk=resp.json()["id"])
+    assert r.email == ""
 
 
 def test_get_refuse(client):

--- a/envergo/static/nitrates/bug_floater.css
+++ b/envergo/static/nitrates/bug_floater.css
@@ -1,0 +1,154 @@
+/* #285 — Bouton flottant « Signaler un bug » + pop-over.
+   Présent sur toutes les pages nitrates, ancré en bas à droite. Discret au
+   repos, s'ouvre en pop-over vers le haut. Style sobre DSFR. */
+
+.nitrates-bug {
+  position: fixed;
+  right: 1rem;
+  bottom: 1rem;
+  z-index: 1900; /* sous le popup feedback (#284, z 2000) et sous la modale carte */
+  font-size: 0.875rem;
+}
+
+/* ── Bouton déclencheur ─────────────────────────────────────────────────── */
+.nitrates-bug__toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.5rem 0.9rem;
+  border: 1px solid var(--border-default-grey, #ddd);
+  border-radius: 999px;
+  background: var(--background-default-grey, #fff);
+  color: var(--text-action-high-blue-france, #000091);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  line-height: 1;
+  cursor: pointer;
+  box-shadow: 0 2px 8px rgb(0 0 0 / 12%);
+  transition:
+    box-shadow 0.15s ease,
+    transform 0.15s ease,
+    background 0.15s ease;
+}
+
+.nitrates-bug__toggle:hover {
+  background: var(--background-alt-blue-france, #f5f5fe);
+  box-shadow: 0 4px 14px rgb(0 0 0 / 18%);
+  transform: translateY(-1px);
+}
+
+.nitrates-bug__toggle:focus-visible {
+  outline: 2px solid var(--text-action-high-blue-france, #000091);
+  outline-offset: 2px;
+}
+
+.nitrates-bug__toggle svg {
+  flex: 0 0 auto;
+}
+
+/* Sur petits écrans, le bouton se réduit à l'icône pour rester discret. */
+@media (width <= 576px) {
+  .nitrates-bug__toggle-label {
+    display: none;
+  }
+
+  .nitrates-bug__toggle {
+    padding: 0.6rem;
+  }
+}
+
+/* ── Pop-over ───────────────────────────────────────────────────────────── */
+.nitrates-bug__popover[hidden] {
+  display: none;
+}
+
+.nitrates-bug [hidden] {
+  display: none !important;
+}
+
+.nitrates-bug__popover {
+  position: absolute;
+  right: 0;
+  bottom: calc(100% + 0.6rem);
+  width: min(360px, calc(100vw - 2rem));
+  max-height: min(70vh, 560px);
+  overflow-y: auto;
+  padding: 1.1rem 1.1rem 1.25rem;
+  background: var(--background-default-grey, #fff);
+  border: 1px solid var(--border-default-grey, #ddd);
+  border-radius: 8px;
+  box-shadow: 0 8px 32px rgb(0 0 0 / 22%);
+  animation: nitrates-bug-pop 0.2s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+@keyframes nitrates-bug-pop {
+  from {
+    opacity: 0;
+    transform: translateY(8px) scale(0.98);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+.nitrates-bug__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.nitrates-bug__titre {
+  margin: 0;
+}
+
+.nitrates-bug__close {
+  flex: 0 0 auto;
+  width: 2rem;
+  height: 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  border-radius: 50%;
+  background: transparent;
+  font-size: 1.3rem;
+  line-height: 1;
+  color: var(--text-mention-grey, #666);
+  cursor: pointer;
+}
+
+.nitrates-bug__close:hover {
+  background: var(--background-alt-grey, #eee);
+}
+
+.nitrates-bug__type {
+  margin: 0 0 0.75rem;
+}
+
+.nitrates-bug__popover .fr-fieldset__legend {
+  padding-bottom: 0.25rem;
+}
+
+.nitrates-bug__popover textarea.fr-input {
+  resize: vertical;
+}
+
+.nitrates-bug__rgpd {
+  margin: 0.6rem 0 0;
+  color: var(--text-mention-grey, #666);
+}
+
+.nitrates-bug__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: 0.9rem;
+}
+
+.nitrates-bug__erreur {
+  margin-top: 0.5rem;
+}

--- a/envergo/static/nitrates/bug_floater.js
+++ b/envergo/static/nitrates/bug_floater.js
@@ -1,0 +1,329 @@
+/* #285 — Bouton flottant « Signaler un bug » (présent sur toutes les pages).
+ *
+ * Rôle :
+ *   1. Dès le chargement, installer des capteurs LÉGERS qui gardent en mémoire
+ *      (buffers circulaires bornés) les derniers logs console, les dernières
+ *      requêtes réseau (fetch + XHR) et les erreurs JS non capturées. Objectif :
+ *      qu'au moment où l'utilisateur signale un bug, on ait déjà le contexte
+ *      technique pour reproduire.
+ *   2. Gérer le pop-over (ouverture/fermeture, choix bug/retour, commentaire).
+ *   3. À l'envoi, POST JSON /api/retour/ (type "bug") avec, dans `contexte`, le
+ *      dump technique + les infos page (URL, user-agent, écran).
+ *
+ * Aucune donnée de simulation ni parcellaire n'est jointe : uniquement le texte
+ * de l'utilisateur et un contexte technique anonyme.
+ *
+ * NB : ce script est chargé en `defer` sur toutes les pages nitrates. Les
+ * capteurs s'installent donc au parse du script (après le HTML), ce qui suffit
+ * largement pour attraper les erreurs/logs de l'interaction utilisateur.
+ */
+(function () {
+  "use strict";
+
+  var MAX_CONSOLE = 100; // dernières entrées console gardées
+  var MAX_NETWORK = 40; // dernières requêtes réseau gardées
+  var MAX_MSG_LEN = 2000; // troncature d'un message console
+  var MAX_URL_LEN = 500;
+
+  // ── Buffers circulaires ───────────────────────────────────────────────────
+  var consoleBuf = [];
+  var networkBuf = [];
+
+  function pushBounded(buf, entry, max) {
+    buf.push(entry);
+    if (buf.length > max) buf.shift();
+  }
+
+  function trunc(str, max) {
+    str = String(str);
+    return str.length > max ? str.slice(0, max) + "…[tronqué]" : str;
+  }
+
+  function argsToMessage(args) {
+    try {
+      return Array.prototype.map
+        .call(args, function (a) {
+          if (a instanceof Error) return a.stack || a.message || String(a);
+          if (typeof a === "object") {
+            try {
+              return JSON.stringify(a);
+            } catch (e) {
+              return String(a);
+            }
+          }
+          return String(a);
+        })
+        .join(" ");
+    } catch (e) {
+      return "[message illisible]";
+    }
+  }
+
+  // ── Capteur console ───────────────────────────────────────────────────────
+  function installConsoleCapture() {
+    var levels = ["log", "info", "warn", "error", "debug"];
+    levels.forEach(function (level) {
+      var original = console[level];
+      if (typeof original !== "function") return;
+      console[level] = function () {
+        try {
+          pushBounded(
+            consoleBuf,
+            {
+              level: level,
+              message: trunc(argsToMessage(arguments), MAX_MSG_LEN),
+              t: new Date().toISOString(),
+            },
+            MAX_CONSOLE
+          );
+        } catch (e) {
+          /* ne jamais casser le vrai console */
+        }
+        return original.apply(console, arguments);
+      };
+    });
+  }
+
+  // ── Capteur erreurs non gérées ────────────────────────────────────────────
+  function installErrorCapture() {
+    window.addEventListener("error", function (e) {
+      var msg = e.message || "erreur";
+      if (e.filename) msg += " (" + e.filename + ":" + e.lineno + ")";
+      pushBounded(
+        consoleBuf,
+        { level: "error", message: trunc(msg, MAX_MSG_LEN), t: new Date().toISOString() },
+        MAX_CONSOLE
+      );
+    });
+    window.addEventListener("unhandledrejection", function (e) {
+      var reason = e && e.reason;
+      var msg =
+        reason instanceof Error ? reason.stack || reason.message : String(reason);
+      pushBounded(
+        consoleBuf,
+        {
+          level: "error",
+          message: "Promesse rejetée : " + trunc(msg, MAX_MSG_LEN),
+          t: new Date().toISOString(),
+        },
+        MAX_CONSOLE
+      );
+    });
+  }
+
+  // ── Capteur réseau (fetch + XHR) ──────────────────────────────────────────
+  function logNetwork(method, url, status, extra) {
+    pushBounded(
+      networkBuf,
+      {
+        method: (method || "GET").toUpperCase(),
+        url: trunc(url || "", MAX_URL_LEN),
+        status: status,
+        extra: extra || "",
+        t: new Date().toISOString(),
+      },
+      MAX_NETWORK
+    );
+  }
+
+  function installNetworkCapture() {
+    // fetch
+    if (typeof window.fetch === "function") {
+      var origFetch = window.fetch;
+      window.fetch = function (input, init) {
+        var url = typeof input === "string" ? input : input && input.url;
+        var method = (init && init.method) || (input && input.method) || "GET";
+        return origFetch.apply(this, arguments).then(
+          function (resp) {
+            logNetwork(method, url, resp.status);
+            return resp;
+          },
+          function (err) {
+            logNetwork(method, url, "ERR", String(err));
+            throw err;
+          }
+        );
+      };
+    }
+
+    // XMLHttpRequest
+    if (window.XMLHttpRequest) {
+      var origOpen = XMLHttpRequest.prototype.open;
+      var origSend = XMLHttpRequest.prototype.send;
+      XMLHttpRequest.prototype.open = function (method, url) {
+        this.__bugMethod = method;
+        this.__bugUrl = url;
+        return origOpen.apply(this, arguments);
+      };
+      XMLHttpRequest.prototype.send = function () {
+        var xhr = this;
+        xhr.addEventListener("loadend", function () {
+          logNetwork(xhr.__bugMethod, xhr.__bugUrl, xhr.status || "ERR");
+        });
+        return origSend.apply(this, arguments);
+      };
+    }
+  }
+
+  // ── CSRF ──────────────────────────────────────────────────────────────────
+  // Priorité à la variable globale exposée par multisite_base.html
+  // (var CSRF_TOKEN = '{{ csrf_token }}'), disponible sur toutes les pages.
+  // Fallback : champ caché {% csrf_token %} si présent (pages avec form).
+  function getCsrfToken() {
+    if (window.CSRF_TOKEN) return window.CSRF_TOKEN;
+    var input = document.querySelector("input[name=csrfmiddlewaretoken]");
+    return input && input.value ? input.value : "";
+  }
+
+  // ── Contexte technique joint au signalement ───────────────────────────────
+  function collecterContexte() {
+    return {
+      url: trunc(window.location.href, MAX_URL_LEN),
+      titre_page: trunc(document.title || "", 300),
+      user_agent: trunc(navigator.userAgent || "", 500),
+      viewport:
+        window.innerWidth +
+        "×" +
+        window.innerHeight +
+        " (dpr " +
+        (window.devicePixelRatio || 1) +
+        ")",
+      referrer: trunc(document.referrer || "", MAX_URL_LEN),
+      horodatage: new Date().toISOString(),
+      console: consoleBuf.slice(),
+      network: networkBuf.slice(),
+    };
+  }
+
+  // ── Pop-over UI ───────────────────────────────────────────────────────────
+  function init() {
+    var root = document.getElementById("nitrates-bug");
+    if (!root) return;
+
+    var toggle = root.querySelector("[data-bug-open]");
+    var popover = root.querySelector(".nitrates-bug__popover");
+    var voletForm = root.querySelector("[data-bug-volet-form]");
+    var voletMerci = root.querySelector("[data-bug-volet-merci]");
+    var headerTitre = root.querySelector("[data-bug-header-titre]");
+    var commentaire = root.querySelector("#nitrates-bug-commentaire");
+    var submit = root.querySelector("[data-bug-submit]");
+    var erreur = root.querySelector("[data-bug-erreur]");
+    var closes = Array.prototype.slice.call(
+      root.querySelectorAll("[data-bug-close]")
+    );
+
+    var ouvert = false;
+    var envoiEnCours = false;
+
+    function ouvrir() {
+      popover.hidden = false;
+      ouvert = true;
+      toggle.setAttribute("aria-expanded", "true");
+      if (commentaire) commentaire.focus();
+    }
+
+    function fermer() {
+      popover.hidden = true;
+      ouvert = false;
+      toggle.setAttribute("aria-expanded", "false");
+      toggle.focus();
+    }
+
+    function majEtatSubmit() {
+      var vide = !commentaire || !commentaire.value.trim();
+      submit.disabled = vide || envoiEnCours;
+    }
+
+    function typeChoisi() {
+      var checked = root.querySelector(
+        "input[name=nitrates-bug-type]:checked"
+      );
+      return checked ? checked.value : "bug";
+    }
+
+    toggle.addEventListener("click", function () {
+      if (ouvert) fermer();
+      else ouvrir();
+    });
+
+    closes.forEach(function (btn) {
+      btn.addEventListener("click", fermer);
+    });
+
+    // Échap ferme le pop-over.
+    document.addEventListener("keydown", function (e) {
+      if (e.key === "Escape" && ouvert) fermer();
+    });
+
+    // Clic hors du pop-over (mais pas sur le bouton) ferme.
+    document.addEventListener("click", function (e) {
+      if (ouvert && !root.contains(e.target)) fermer();
+    });
+
+    if (commentaire) {
+      commentaire.addEventListener("input", majEtatSubmit);
+    }
+    majEtatSubmit();
+
+    submit.addEventListener("click", function () {
+      if (envoiEnCours) return;
+      var texte = commentaire ? commentaire.value.trim() : "";
+      if (!texte) return;
+
+      envoiEnCours = true;
+      majEtatSubmit();
+      if (erreur) erreur.hidden = true;
+
+      // Le sous-type (bug / retour) est conservé dans le contexte : le modèle
+      // ne connaît qu'un type "bug" côté serveur, mais on distingue les deux
+      // intentions pour le tri en admin.
+      var contexte = collecterContexte();
+      contexte.sous_type = typeChoisi();
+
+      var payload = {
+        type: "bug",
+        commentaire: texte,
+        region_code: root.getAttribute("data-region-code") || "",
+        contexte: contexte,
+      };
+
+      fetch("/api/retour/", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-CSRFToken": getCsrfToken(),
+        },
+        body: JSON.stringify(payload),
+      })
+        .then(function (resp) {
+          if (!resp.ok) throw new Error("HTTP " + resp.status);
+          return resp.json();
+        })
+        .then(function () {
+          voletForm.hidden = true;
+          voletMerci.hidden = false;
+          // Sur l'écran de remerciement, on masque le titre « Un souci ? Un
+          // retour ? » pour ne garder que le message de merci (une seule ligne).
+          if (headerTitre) headerTitre.hidden = true;
+        })
+        .catch(function () {
+          if (erreur) erreur.hidden = false;
+        })
+        .finally(function () {
+          envoiEnCours = false;
+          majEtatSubmit();
+        });
+    });
+  }
+
+  // Capteurs installés immédiatement (au parse du script defer).
+  installConsoleCapture();
+  installErrorCapture();
+  installNetworkCapture();
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/envergo/templates/nitrates/base.html
+++ b/envergo/templates/nitrates/base.html
@@ -34,6 +34,7 @@ simulateur). static_v : cache-busting en dev (cf. nitrates_tags).
 {% block site_css %}
   {{ block.super }}
   <link href="{% static_v 'nitrates/nav.css' %}" rel="stylesheet">
+  <link href="{% static_v 'nitrates/bug_floater.css' %}" rel="stylesheet">
 {% endblock %}
 
 {% block footer %}
@@ -42,6 +43,7 @@ simulateur). static_v : cache-busting en dev (cf. nitrates_tags).
 
 {% block extra_body %}
   {{ block.super }}
+  {% include 'nitrates/fragments/_bug_floater.html' %}
   {% if is_building %}
     {% include 'nitrates/_bandeau_construction.html' %}
   {% endif %}

--- a/envergo/templates/nitrates/fragments/_bug_floater.html
+++ b/envergo/templates/nitrates/fragments/_bug_floater.html
@@ -1,0 +1,119 @@
+{% load nitrates_tags %}
+
+{% comment %}
+#285 — Bouton flottant « Signaler un bug » présent sur toutes les pages.
+
+Bouton discret ancré en bas à droite. Au clic, un pop-over s'ouvre avec :
+  - un choix (radio) : Bug / Retour ;
+  - un commentaire libre.
+À l'envoi, bug_floater.js POST vers /api/retour/ (type "bug") en joignant
+dans `contexte` le maximum d'infos techniques dumpées par le navigateur
+(URL, user-agent, écran, logs console capturés, requêtes réseau capturées)
+pour aider à reproduire.
+
+Aucune donnée de simulation ni parcellaire n'est jointe : seuls le texte de
+l'utilisateur et un contexte technique anonyme partent.
+{% endcomment %}
+
+<div class="nitrates-bug"
+     id="nitrates-bug"
+     data-region-code="{{ moulinette.catalog.region_code|default:'' }}">
+
+  {# ── Bouton flottant déclencheur ──────────────────────────────────────── #}
+  <button type="button"
+          class="nitrates-bug__toggle"
+          data-bug-open
+          aria-haspopup="dialog"
+          aria-expanded="false"
+          aria-controls="nitrates-bug-dialog"
+          title="Signaler un bug ou faire un retour">
+    <svg viewBox="0 0 24 24"
+         width="20"
+         height="20"
+         aria-hidden="true"
+         focusable="false">
+      <path fill="currentColor" d="M20 8h-2.81a5.985 5.985 0 0 0-1.82-1.96L17 4.41 15.59 3l-2.17 2.17a5.987 5.987 0 0 0-2.84 0L8.41 3 7 4.41l1.62 1.63A5.985 5.985 0 0 0 6.81 8H4v2h2.09c-.05.33-.09.66-.09 1v1H4v2h2v1c0 .34.04.67.09 1H4v2h2.81a6 6 0 0 0 10.38 0H20v-2h-2.09c.05-.33.09-.66.09-1v-1h2v-2h-2v-1c0-.34-.04-.67-.09-1H20V8Zm-6 8h-4v-2h4v2Zm0-4h-4v-2h4v2Z" />
+    </svg>
+    <span class="nitrates-bug__toggle-label">Signaler un bug</span>
+  </button>
+
+  {# ── Pop-over ─────────────────────────────────────────────────────────── #}
+  <div class="nitrates-bug__popover"
+       id="nitrates-bug-dialog"
+       role="dialog"
+       aria-modal="false"
+       aria-labelledby="nitrates-bug-titre"
+       hidden>
+    <div class="nitrates-bug__header">
+      <p class="nitrates-bug__titre fr-h6"
+         id="nitrates-bug-titre"
+         data-bug-header-titre>Un souci&nbsp;? Un retour&nbsp;?</p>
+      <button type="button"
+              class="nitrates-bug__close"
+              aria-label="Fermer"
+              data-bug-close>✕</button>
+    </div>
+
+    <div class="nitrates-bug__volet" data-bug-volet-form>
+      <fieldset class="fr-fieldset nitrates-bug__type"
+                aria-labelledby="nitrates-bug-type-legend">
+        <legend class="fr-fieldset__legend fr-text--sm" id="nitrates-bug-type-legend">De quoi s'agit-il&nbsp;?</legend>
+        <div class="fr-fieldset__content">
+          <div class="fr-radio-group fr-radio-group--sm">
+            <input type="radio"
+                   id="nitrates-bug-type-bug"
+                   name="nitrates-bug-type"
+                   value="bug"
+                   checked>
+            <label class="fr-label" for="nitrates-bug-type-bug">Un bug (ça ne marche pas)</label>
+          </div>
+          <div class="fr-radio-group fr-radio-group--sm">
+            <input type="radio"
+                   id="nitrates-bug-type-retour"
+                   name="nitrates-bug-type"
+                   value="retour">
+            <label class="fr-label" for="nitrates-bug-type-retour">Un retour / une suggestion</label>
+          </div>
+        </div>
+      </fieldset>
+
+      <label class="fr-label" for="nitrates-bug-commentaire">
+        Décrivez ce que vous observez
+        <span class="fr-hint-text">Que faisiez-vous&nbsp;? Qu'attendiez-vous&nbsp;?</span>
+      </label>
+      <textarea class="fr-input"
+                id="nitrates-bug-commentaire"
+                rows="4"
+                maxlength="4000"
+                placeholder="Ex : au clic sur « Suivant » la page ne change pas…"></textarea>
+
+      <p class="nitrates-bug__rgpd fr-text--xs">
+        Pour nous aider à reproduire, quelques infos techniques de votre
+        navigateur (adresse de la page, journal d'erreurs) sont jointes. Aucune
+        donnée personnelle ni de simulation n'est transmise.
+      </p>
+
+      <div class="nitrates-bug__actions">
+        <button type="button"
+                class="fr-btn fr-btn--tertiary-no-outline fr-btn--sm"
+                data-bug-close>Annuler</button>
+        <button type="button" class="fr-btn fr-btn--sm" data-bug-submit disabled>Envoyer</button>
+      </div>
+      <p class="nitrates-bug__erreur fr-error-text" data-bug-erreur hidden>Une erreur est survenue. Réessayez plus tard.</p>
+    </div>
+
+    <div class="nitrates-bug__volet" data-bug-volet-merci hidden>
+      <p class="fr-text--sm">Merci beaucoup&nbsp;! Votre signalement nous aide à corriger l'outil.</p>
+      <div class="nitrates-bug__actions">
+        <button type="button" class="fr-btn fr-btn--sm" data-bug-close>Fermer</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+{% comment %}
+Script chargé ici (dans le fragment) plutôt que via un bloc extra_js : certaines
+pages (le simulateur) redéfinissent extra_js sans block.super, ce qui écraserait
+le script. Rattaché au fragment, il est présent partout où le bouton l'est.
+{% endcomment %}
+<script defer src="{% static_v 'nitrates/bug_floater.js' %}"></script>


### PR DESCRIPTION
Carte #285.

Ajoute un bouton flottant discret « Signaler un bug » ancré en bas à droite, présent sur toutes les pages du simulateur. Au clic, un pop-over DSFR propose :
- un choix Bug / Retour ;
- un commentaire libre.

À l'envoi, le front POST vers `/api/retour/` avec un nouveau type `bug`, en joignant dans le champ `contexte` un dump technique du navigateur pour aider à reproduire : URL, user-agent, taille d'écran, derniers logs console capturés, dernières requêtes réseau (fetch + XHR) et erreurs JS non gérées. Les captures sont installées au plus tôt (buffers circulaires bornés) et le sous-type Bug/Retour est conservé dans `contexte.sous_type`.

### Réutilisation de l'existant
S'appuie sur l'infra `RetourUtilisateur` déjà en place (#284/#287) plutôt qu'un nouveau modèle : même endpoint, form, admin, rate-limit et gestion CSRF. Une migration ajoute le choix `bug`. L'admin rend le contexte technique lisible (Page / Console / Réseau).

### RGPD
Aucune donnée de simulation ni parcellaire n'est jointe. Un email éventuel reste soumis au consentement (règle héritée du form existant).

### Tests
- 2 nouveaux tests unitaires du type `bug` (sans note ni email, capture du contexte ; email sans consentement ignoré).
- Suite complète verte (282 passed, 1 skip).
- Vérifié e2e en conteneur isolé : bouton présent sur simulateur + définitions + mentions légales + accessibilité + contact ; flux complet bouton → pop-over → envoi → remerciement ; enregistrement DB confirmé (console/réseau capturés) ; rendu admin OK.