### PR TITLE
Ne plus exiger la déclaration du site en base pour que l'app démarre

### DIFF
--- a/envergo/contrib/apps.py
+++ b/envergo/contrib/apps.py
@@ -1,0 +1,10 @@
+from django.apps import AppConfig
+
+
+class ContribConfig(AppConfig):
+    name = "envergo.contrib"
+
+    def ready(self):
+        from envergo.contrib.sites_from_settings import patch_site_manager
+
+        patch_site_manager()

--- a/envergo/contrib/middleware.py
+++ b/envergo/contrib/middleware.py
@@ -1,23 +1,35 @@
-import logging
-
 from django.conf import settings
-from django.contrib.sites.models import Site
 from django.shortcuts import redirect
 
-logger = logging.getLogger(__name__)
+from envergo.contrib.sites_from_settings import build_site_from_settings
 
 
 class SetUrlConfBasedOnSite:
     """Route every request to the nitrates urlconf.
+
+    REVERT_AT_MERGE_TIME_FOR_UPSTREAM_ENVERGO
 
     Le fork ne sert que le site nitrates. Les urlconfs amenagement et
     haie restent dans le repo en code dormant pour faciliter un futur
     remerge avec MTES-MCT/envergo upstream, mais le middleware ne route
     plus vers eux.
 
-    Si le Host: HTTP entrant ne matche aucun Site en DB, on ne redirige
-    pas (le routing est deja force vers nitrates) : on log juste un
-    warning pour tracer les hits avec un domaine inattendu.
+    Upstream fait dependre l'identite du site d'une ligne en base
+    (Site.objects.get_current(request), qui matche le Host: HTTP sur
+    django_site.domain). Concretement il faut declarer son deploiement
+    en base pour que l'app reponde : une app fraiche, ou une base
+    reinitialisee, renvoie 500 partout (y compris /admin/login/) tant
+    que la ligne n'existe pas. On ne veut pas de ce couplage : le
+    domaine servi est une donnee de configuration, pas une donnee
+    metier, donc il vient de l'environnement.
+
+    `request.site` est desormais construit en memoire depuis
+    settings.ENVERGO_NITRATES_DOMAIN. Aucune requete DB sur le chemin
+    requete, aucune ligne a declarer : l'app demarre et sert.
+
+    Le modele Site reste dans INSTALLED_APPS (les FK TopBar.site et
+    analytics.Event.site en dependent, cf. code dormant upstream), il
+    n'est simplement plus consulte pour resoudre le site courant.
     """
 
     def __init__(self, get_response):
@@ -26,18 +38,7 @@ class SetUrlConfBasedOnSite:
     def __call__(self, request):
         request.urlconf = "config.urls_nitrates"
         request.base_template = "nitrates/base.html"
-        try:
-            request.site = Site.objects.get_current(request)
-        except Site.DoesNotExist:
-            # Host: ne matche aucun Site en DB. On ne redirige pas (routing
-            # deja force vers nitrates). Fallback sur le Site nitrates fixe
-            # pour que le code aval qui lit request.site.domain ne crash pas.
-            logger.warning(
-                "Request on unknown domain: %s%s",
-                request.get_host(),
-                request.get_full_path(),
-            )
-            request.site = Site.objects.filter(id=3).first()
+        request.site = build_site_from_settings()
         return self.get_response(request)
 
 

--- a/envergo/contrib/sites_from_settings.py
+++ b/envergo/contrib/sites_from_settings.py
@@ -1,0 +1,60 @@
+"""Resout le Site courant depuis les settings, sans jamais lire la base.
+
+REVERT_AT_MERGE_TIME_FOR_UPSTREAM_ENVERGO
+
+Upstream, l'identite du site servi est une ligne de la table
+django_site : `Site.objects.get_current(request)` matche le Host: HTTP
+entrant sur `django_site.domain` (ou, si SITE_ID est defini, fait un
+get(pk=SITE_ID)). Dans les deux cas il faut avoir declare son
+deploiement en base pour que l'app reponde. Une app fraiche, ou une
+base reinitialisee, renvoie 500 partout tant que la ligne n'existe
+pas -- y compris sur /admin/login/, parce que la LoginView de Django
+appelle get_current_site() pour son contexte de template.
+
+On refuse ce couplage : le domaine servi est une donnee de
+configuration (elle vient de l'environnement, via
+ENVERGO_NITRATES_DOMAIN), pas une donnee metier a saisir en base.
+
+`get_current()` est le point unique par lequel passent tous les
+appelants (LoginView de Django, get_current_site(), et le code dormant
+Envergo). On le remplace donc ici par une version qui construit le
+Site en memoire depuis les settings. Aucune requete, rien a declarer :
+l'app demarre et sert.
+
+Ce qui n'est PAS change :
+  - le modele Site reste installe : les FK reelles confs.TopBar.site et
+    analytics.Event.site en dependent (schema conserve pour le remerge
+    upstream) ;
+  - les autres managers (Site.objects.get/filter/all) restent
+    intacts, donc l'admin des sites et le code qui lit explicitement
+    une ligne continuent de voir la base telle qu'elle est.
+"""
+
+from django.conf import settings
+
+NITRATES_SITE_ID = 3
+
+
+def build_site_from_settings():
+    """Construit (sans le sauvegarder) le Site nitrates depuis les settings."""
+    from django.contrib.sites.models import Site
+
+    return Site(
+        id=NITRATES_SITE_ID,
+        domain=settings.ENVERGO_NITRATES_DOMAIN,
+        name="Simulateur nitrates",
+    )
+
+
+def patch_site_manager():
+    """Fait resoudre SiteManager.get_current() depuis les settings."""
+    from django.contrib.sites.models import SiteManager
+
+    if getattr(SiteManager, "_nitrates_patched", False):
+        return
+
+    def get_current(self, request=None):
+        return build_site_from_settings()
+
+    SiteManager.get_current = get_current
+    SiteManager._nitrates_patched = True


### PR DESCRIPTION
Closes #375

Le modèle Envergo fait dépendre l'identité du site servi d'une ligne en base
(`django_site`). Il faut donc déclarer son déploiement en base pour que l'app
réponde : une base fraîche ou réinitialisée renvoie 500 partout.

```
DoesNotExist at /admin/login/
Site matching query does not exist.
```

Le domaine servi est une donnée de configuration (variable d'environnement),
pas une donnée métier à saisir en base.

## Le fix

`SiteManager.get_current()` résout désormais le site depuis
`settings.ENVERGO_NITRATES_DOMAIN`, sans requête. C'est le point unique par
lequel passent tous les appelants — y compris la `LoginView` de Django, qui
appelle `get_current_site()` pour son contexte de template. C'était la cause
réelle du 500 sur `/admin/login/` : le `try/except DoesNotExist` du middleware
existait déjà et ne pouvait rien y faire.

Le middleware construit `request.site` depuis la même source.

## Volontairement pas fait

Retirer `django.contrib.sites` d'`INSTALLED_APPS` : les FK réelles
`confs.TopBar.site` et `analytics.Event.site` en dépendent. Les retirer
imposerait une migration destructive sur des tables conservées pour le remerge
upstream, pour un gain nul. Le modèle reste installé, simplement plus consulté
pour résoudre le site courant.

Les autres managers (`Site.objects.get/filter/all`) sont intacts : l'admin des
sites et le code qui lit explicitement une ligne voient la base telle qu'elle
est. Les chemins dormants Envergo (`petitions`, `evaluations`, `users.tasks`)
qui font `Site.objects.get(domain=...)` restent donc DB-dépendants — jamais
atteints sur ce fork.

## Vérifications

Vérifié en HTTP réel avec `django_site` **vidée** : `/`, `/admin/login/` et
`/simulateur/` répondent 200.

Suite de tests (`nitrates`, `config`, `confs`, `analytics`) : 1278 passed,
48 skipped, 2 failed. Les 2 échecs (`test_contenu_rich.py`, `IntegrityError`
sur `categorie` NOT NULL) ont été rejoués sur baseline sans ce patch et sont
**préexistants** — sans rapport avec Site, à traiter séparément.

Pas de test de non-régression verrouillant « l'app répond base vide » dans
cette PR.

## Remerge upstream

Marqué `REVERT_AT_MERGE_TIME_FOR_UPSTREAM_ENVERGO`.
