### PR TITLE
nitrates(ci): gate e2e parcours client #202 + réparation de l'e2e nocturne

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -141,6 +141,12 @@ jobs:
       # --- Run --------------------------------------------------------------
       # `capture_*` exclu (outils de capture, pas de la non-reg) ainsi que les
       # specs prefixees `_` (scratchpads de mesure : _zoomj, _meas107, _iter107).
+      #
+      # `root_public_lockdown` est exclu AUSSI, mais pour une raison differente :
+      # ce n'est pas du bruit, c'est une suite qui exige la config INVERSE de ce
+      # job (LOCKDOWN_BEHIND_LOGIN=True). Elle tourne dans le job dedie
+      # `e2e-root-public-lockdown` ci-dessous. Sans cette exclusion, elle
+      # echouerait ici a chaque run (#202).
       - name: Run Playwright (hors specs de capture)
         env:
           NITRATES_BASE_URL: "http://127.0.0.1:8042"
@@ -151,6 +157,7 @@ jobs:
             $(ls e2e/nitrates/*.spec.ts \
                 | grep -v '/capture_' \
                 | grep -v '/_' \
+                | grep -v '/root_public_lockdown' \
                 | tr '\n' ' ')
 
       - name: Upload rapport Playwright
@@ -158,6 +165,148 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: playwright-report
+          path: |
+            playwright-report/
+            test-results/
+          retention-days: 14
+          if-no-files-found: warn
+
+  # =====================================================================
+  # Gate #202 — parcours client `/` sous CONFIG STAGING
+  # =====================================================================
+  # Job separe du precedent parce qu'il exige la config INVERSE :
+  # LOCKDOWN_BEHIND_LOGIN=True x NITRATES_ROOT_OUVERT=True. C'est la
+  # combinaison qui n'existe QUE sur staging, et c'est precisement le trou
+  # qui a laisse passer l'incident du 2026-07-02 (root public casse la veille
+  # d'un test utilisateur, aucun test ne le couvrait).
+  #
+  # Pourquoi deux jobs et pas un flag dans le premier : le lockdown est un
+  # middleware global. L'activer ferait echouer TOUTES les autres specs
+  # (elles naviguent en anonyme sur /simulateur/, ferme sous lockdown). Les
+  # deux configurations sont mutuellement exclusives -> deux serveurs, deux
+  # jobs. Ils tournent en parallele, donc pas de cout en temps de pipeline.
+  e2e-root-public-lockdown:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    services:
+      database:
+        image: postgis/postgis:14-master
+        env:
+          POSTGRES_USER: envergo
+          POSTGRES_PASSWORD: envergo
+          POSTGRES_DB: envergo
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Checkout Code Repository
+        uses: actions/checkout@v7
+
+      - name: Installer la locale francaise
+        run: |
+          sudo apt update
+          sudo apt install -y language-pack-fr
+          sudo locale-gen
+          sudo update-locale LANG="fr_FR.UTF-8" LC_ALL="fr_FR.UTF-8"
+
+      - name: Dependances geo (GDAL/PROJ)
+        run: sudo apt install -y binutils libproj-dev gdal-bin gettext
+
+      - name: Extensions postgis sur template1
+        run: |
+          psql -d postgresql://envergo:envergo@localhost/template1 -c 'CREATE EXTENSION IF NOT EXISTS postgis;'
+          psql -d postgresql://envergo:envergo@localhost/template1 -c 'CREATE EXTENSION IF NOT EXISTS postgis_raster;'
+        env:
+          PGPASSWORD: envergo
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6.3.0
+        with:
+          python-version: 3.12.8
+
+      - name: Install python dependencies
+        run: pip install -r requirements/local.txt
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install js dependencies
+        run: npm ci
+
+      - name: Build assets
+        run: bash bin/build_assets.sh
+
+      - name: Preparer la base (migrate + referentiels + arbres)
+        run: |
+          python manage.py migrate --noinput
+          python manage.py seed_referentiels
+          python manage.py load_arbres_actifs
+
+      # --- Serveur en CONFIG STAGING ---------------------------------------
+      # Les deux flags ci-dessous SONT le sujet du test. Ne pas les changer
+      # pour "faire passer" la suite : une suite verte obtenue en desarmant le
+      # lockdown ne teste plus rien (cf. #202).
+      #
+      # Le wait-for-ready ne peut pas se contenter d'un code != 000 : sous
+      # lockdown, une URL fermee repond 302 tres tot. On sonde donc `/`, qui
+      # doit repondre 200 (exempte via NITRATES_ROOT_OUVERT).
+      - name: Lancer le serveur Django (lockdown ON + root ouvert)
+        env:
+          DJANGO_ALLOWED_HOSTS: "127.0.0.1,localhost"
+          DJANGO_LOCKDOWN_BEHIND_LOGIN: "True"
+          DJANGO_NITRATES_ROOT_OUVERT: "True"
+        run: |
+          python manage.py runserver 127.0.0.1:8042 --noreload &
+          echo "Attente du serveur sur 127.0.0.1:8042..."
+          for i in $(seq 1 60); do
+            code=$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:8042/ || echo "000")
+            if [ "$code" = "200" ]; then
+              echo "Serveur up et root ouvert (HTTP 200)"; exit 0
+            fi
+            sleep 2
+          done
+          echo "ECHEC : serveur absent ou root non ouvert en 120s" >&2
+          exit 1
+
+      # Verification de la config AVANT de lancer Playwright. Si le lockdown
+      # n'est pas actif, la suite ne teste rien : mieux vaut echouer ici avec
+      # un message clair qu'obtenir 9 verts qui ne prouvent rien.
+      - name: Verifier que le lockdown est bien actif
+        run: |
+          code=$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:8042/simulateur/)
+          echo "/simulateur/ -> HTTP ${code} (attendu 302)"
+          if [ "$code" != "302" ]; then
+            echo "ECHEC : /simulateur/ devrait etre ferme (302) sous lockdown." >&2
+            echo "Le serveur tourne sans lockdown -> la suite #202 ne testerait rien." >&2
+            exit 1
+          fi
+
+      - name: Installer les navigateurs Playwright
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Playwright — parcours client sous lockdown
+        env:
+          NITRATES_BASE_URL: "http://127.0.0.1:8042"
+          CI: "true"
+        run: |
+          npx playwright test \
+            --config playwright.config.nitrates.ts \
+            e2e/nitrates/root_public_lockdown.spec.ts
+
+      - name: Upload rapport Playwright (root public)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-root-public
           path: |
             playwright-report/
             test-results/

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -106,7 +106,17 @@ jobs:
         run: |
           python manage.py migrate --noinput
           python manage.py seed_referentiels
-          python manage.py load_arbres_actifs
+          # --skip-zar-sans-carte : la base CI est ephemere et n'a aucune
+          # couche SIG importee, donc l'activation_map d'un ZAR n'est pas
+          # deductible. Sans ce flag la commande echoue (zar_44.yaml) et le
+          # job meurt avant meme de lancer Playwright.
+          python manage.py load_arbres_actifs --skip-zar-sans-carte
+          # Couche ZV minimale : sans elle, les points de test (Reims,
+          # Rennes) tombent « hors zone » et TOUTES les specs echouent pour
+          # une raison etrangere a ce qu'elles testent. On ne branche pas
+          # l'import Sandre reel (37 Mo) sur un nightly : une indispo du WFS
+          # ferait rougir la CI sans regression de code.
+          python manage.py seed_geodata_e2e
 
       # --- Serveur de test -------------------------------------------------
       # Le middleware SetUrlConfBasedOnSite force l'urlconf nitrates quel que
@@ -249,7 +259,17 @@ jobs:
         run: |
           python manage.py migrate --noinput
           python manage.py seed_referentiels
-          python manage.py load_arbres_actifs
+          # --skip-zar-sans-carte : la base CI est ephemere et n'a aucune
+          # couche SIG importee, donc l'activation_map d'un ZAR n'est pas
+          # deductible. Sans ce flag la commande echoue (zar_44.yaml) et le
+          # job meurt avant meme de lancer Playwright.
+          python manage.py load_arbres_actifs --skip-zar-sans-carte
+          # Couche ZV minimale : sans elle, les points de test (Reims,
+          # Rennes) tombent « hors zone » et TOUTES les specs echouent pour
+          # une raison etrangere a ce qu'elles testent. On ne branche pas
+          # l'import Sandre reel (37 Mo) sur un nightly : une indispo du WFS
+          # ferait rougir la CI sans regression de code.
+          python manage.py seed_geodata_e2e
 
       # --- Serveur en CONFIG STAGING ---------------------------------------
       # Les deux flags ci-dessous SONT le sujet du test. Ne pas les changer

--- a/e2e/nitrates/README_root_public.md
+++ b/e2e/nitrates/README_root_public.md
@@ -1,0 +1,88 @@
+# E2E `root_public_lockdown` — parcours client sous config staging (#202)
+
+Suite de non-régression du **parcours client `/`** dans la configuration qui
+n'existe que sur staging : `LOCKDOWN_BEHIND_LOGIN=True` × `NITRATES_ROOT_OUVERT=True`.
+
+## Pourquoi cette suite existe
+
+Incident du 2026-07-02 : le root public était cassé la veille d'un test
+utilisateur, et **rien ne l'a détecté**.
+
+Le middleware lockdown (`envergo/contrib/middleware.py`) redirige en **302** vers
+`/admin/login/` toute URL non exemptée. Or un `fetch()` navigateur **suit ce 302
+en silence** et reçoit la page de login en HTML avec un statut **200** :
+
+- `response.ok === true`
+- aucune exception, aucune erreur console
+- le blocage se déguise en succès
+
+Symptômes côté client : carte SIG vide, formulaire figé sur « cliquez sur la
+carte », au mieux un `Unexpected token 'C', Connexion... is not valid JSON`.
+
+Conséquence pratique : **un smoke « la racine répond 200 » reste vert** pendant
+que le site est inutilisable. Un test qui se contente de `expect(response.ok())`
+ne voit rien non plus.
+
+D'où la règle de cette suite : sur les endpoints de données, on assert le
+**content-type** et le **statut non redirigé** (`maxRedirects: 0`), jamais
+seulement `ok`.
+
+## Ce qui est couvert
+
+| Test | Ce qu'il protège |
+|---|---|
+| `configuration` | Garde-fou : échoue avec un message explicite si le serveur cible n'est pas en config staging (sinon on obtient 4 échecs cryptiques) |
+| `donnees : <endpoint>` ×4 | **Le test qui aurait détecté l'incident.** `/geojson/zv/`, `/geojson/zar/`, `/api/referentiels/`, `/simulateur/debug/` → JSON strict, sans redirection |
+| `contre-verif` | `/simulateur/` et `/api/arbre/` restent fermés (302). Détecte l'excès inverse : une exemption trop large |
+| `page racine` | Carte Leaflet initialisée, couches chargées, zéro erreur console |
+| `recherche commune (BAN)` | Saisie → suggestion → recentrage de la carte |
+| `parcours complet` | Clic carte → formulaire révélé. Ce wait est à lui seul un test de non-régression : sous l'incident, le formulaire n'apparaissait jamais |
+
+## Lancer en local
+
+La config staging n'existe pas en dev local par défaut — il faut la reproduire.
+
+```bash
+# worktree dédié + override compose (lockdown ON + root ouvert, port 8054)
+docker compose -p nitrates-e2e202 \
+  -f docker-compose.yml -f docker-compose.e2e202.local.yml up -d django node
+
+# la suite tourne DANS le container node (cf. gotcha ci-dessous)
+docker exec -e IN_DOCKER=1 nitrates_node_e2e202 \
+  npx playwright test --config playwright.config.nitrates.ts \
+  root_public_lockdown --reporter=line
+```
+
+Attendu : **9 passed**.
+
+## Gate de déploiement
+
+Cette suite est une **gate bloquante** du déploiement staging (étape 9 du skill
+ops `nitrates-deploy-staging`). Si elle échoue : rollback, et le déploiement
+n'est pas déclaré OK.
+
+## Gotchas rencontrés
+
+1. **Lancer depuis l'hôte charge la mauvaise version de Playwright.** Les
+   `node_modules` du worktree sont vides (volume Docker), donc `npx` remonte au
+   `~/node_modules` global qui a une autre version → *"Playwright Test did not
+   expect test.describe.configure() to be called here"*. **Toujours lancer dans
+   le container node.**
+
+2. **`--host-resolver-rules` ne s'applique pas à `request`.** La config nitrates
+   fait pointer le *navigateur* sur `127.0.0.1:8000` et corrige l'IP via cette
+   option Chromium. Mais `APIRequestContext` est un client HTTP Node, pas le
+   navigateur : il tombe sur `ECONNREFUSED`. La spec résout donc l'hôte
+   elle-même (`API_BASE` / `API_HEADERS`) tout en gardant le `Host` attendu par
+   le middleware Site Django (id=3, `127.0.0.1`).
+
+3. **Les navigateurs ne sont pas préinstallés** dans le container node :
+   `npx playwright install chromium` puis, en root,
+   `npx playwright install-deps chromium`.
+
+## Validation par sabotage
+
+Un test vert qui ne casse jamais ne protège de rien. La suite a été validée en
+reproduisant l'incident : exemption `/geojson/` + `/api/referentiels/` retirée du
+middleware → le test `donnees : /geojson/zv/` **échoue** comme attendu.
+Middleware restauré ensuite (diff vide).

--- a/e2e/nitrates/refactor_272_flow_couvert.spec.ts
+++ b/e2e/nitrates/refactor_272_flow_couvert.spec.ts
@@ -17,7 +17,23 @@ import { test, expect, Page } from '@playwright/test';
 const REIMS_LNG = 4.0345;
 const REIMS_LAT = 49.2583;
 
+/**
+ * #271 : sur la page de resultat le formulaire est replie derriere l'encart
+ * recap (recap_choix.js pose `hidden` sur #form-after-localisation). Les radios
+ * du flow restent dans le DOM mais a taille nulle -> le clic timeout sur
+ * « element is not visible ». On rouvre d'abord, comme l'utilisateur.
+ * Idempotent : ne fait rien si le formulaire est deja ouvert.
+ */
+async function ouvrirFormulaireSiReplie(page: Page) {
+  const formApres = page.locator('#form-after-localisation');
+  if ((await formApres.count()) === 0) return;
+  if (await formApres.isVisible()) return;
+  await page.locator('[data-recap-modifier]').first().click({ force: true });
+  await expect(formApres).toBeVisible();
+}
+
 async function pickFlow(page: Page, name: string, index: number) {
+  await ouvrirFormulaireSiReplie(page);
   // Les radios du flow sont visibles : on clique le label par ordre d'apparition.
   const group = page.locator(`input[type=radio][name="${name}"]`);
   await expect(group.nth(index), `radio ${name}[${index}] absent`).toHaveCount(1);

--- a/e2e/nitrates/reset_form.spec.ts
+++ b/e2e/nitrates/reset_form.spec.ts
@@ -25,6 +25,27 @@ const RESULTAT_COLZA_URL =
   '&categorie_fertilisant=engrais_mineral' +
   '&sous_fertilisant=engrais_azote_mineral&type_fertilisant=type_III';
 
+/**
+ * #271 : sur la page de resultat, le formulaire est replie derriere un encart
+ * recap des choix (recap_choix.js pose `hidden` sur #form-after-localisation).
+ * Les radios restent dans le DOM mais invisibles -> tout clic direct timeout
+ * sur « element is not visible ».
+ *
+ * Tout test qui touche un champ APRES un resultat doit donc rouvrir le
+ * formulaire d'abord, exactement comme l'utilisateur. Idempotent : ne fait
+ * rien si le formulaire est deja ouvert (cas QC en attente, ou page de saisie).
+ */
+async function ouvrirFormulaireSiReplie(page) {
+  // On teste l'etat du FORMULAIRE, pas celui du bouton : selon la page le
+  // bouton « Modifier » peut lui-meme etre dans un encart masque, auquel cas
+  // un `isVisible()` sur lui repondrait false alors que le repli est bien la.
+  const formApres = page.locator('#form-after-localisation');
+  if ((await formApres.count()) === 0) return;
+  if (await formApres.isVisible()) return; // deja ouvert : rien a faire
+  await page.locator('[data-recap-modifier]').first().click({ force: true });
+  await expect(formApres).toBeVisible();
+}
+
 function dupKeys(search: string): string[] {
   const p = new URLSearchParams(search);
   const seen = new Set<string>();
@@ -49,14 +70,7 @@ test.describe('Simulateur #135 : reset au changement de champ apres resultat', (
     // (rien a relancer).
     await expect(page.locator('#form-submit-row')).toBeHidden();
 
-    // #271 : sur la page de resultat, le formulaire est replie derriere un
-    // encart recap des choix ; recap_choix.js pose `hidden` sur
-    // #form-after-localisation. Les radios existent donc toujours dans le DOM
-    // mais ne sont plus visibles -> un clic direct timeout ("element is not
-    // visible"). Il faut d'abord rouvrir le formulaire via « Modifier »,
-    // exactement comme le fait l'utilisateur.
-    await page.locator('[data-recap-modifier]').click();
-    await expect(page.locator('#form-after-localisation')).toBeVisible();
+    await ouvrirFormulaireSiReplie(page);
 
     // L'user change la categorie de fertilisant (composts).
     await page.locator('label[for="id_categorie_fertilisant__composts"]').click();
@@ -107,6 +121,8 @@ test.describe('Simulateur #135 : reset au changement de champ apres resultat', (
     await page.goto(RESULTAT_COLZA_URL);
     await expect(page.locator('.result-col')).toBeVisible();
 
+    await ouvrirFormulaireSiReplie(page);
+
     // Change categorie -> sous_fertilisant -> nouveau type resolu par cascade.
     await page.locator('label[for="id_categorie_fertilisant__composts"]').click();
     await expect(page.locator('.result-col')).toHaveCount(0);
@@ -139,6 +155,8 @@ test.describe('Simulateur #135 : reset au changement de champ apres resultat', (
     // Un resultat + le bloc QC (recap) sont presents.
     await expect(page.locator('#qc-bloc')).toHaveCount(1);
 
+    await ouvrirFormulaireSiReplie(page);
+
     // L'user change la reponse a la QC fertirrigation.
     await page.locator('label[for*="fertirrigation"][for*="True"]').first().click();
 
@@ -146,14 +164,22 @@ test.describe('Simulateur #135 : reset au changement de champ apres resultat', (
     await expect(page.locator('.result-col')).toHaveCount(0);
     await expect(page.locator('#qc-bloc')).toHaveCount(0);
 
-    // L'URL miroir ne reprend PAS la reponse QC obsolete (fertirrigation).
+    // L'URL miroir porte la reponse QC qu'on vient de RE-CHOISIR (True), pas
+    // l'ancienne (False).
+    //
+    // NB : cette assertion attendait `null` a l'origine (ecrite avant #175).
+    // #175 a change le contrat : on PRESERVE la reponse amont re-choisie,
+    // sinon l'utilisateur qui vient de repondre « Oui » perd sa reponse a la
+    // resoumission (c'etait precisement un des bugs de la serie). Ce qui doit
+    // disparaitre, c'est le bloc QC obsolete (verifie ci-dessus), pas la
+    // reponse elle-meme.
     await expect
       .poll(() =>
         page.evaluate(() =>
           new URLSearchParams(location.search).get('fertirrigation')
         )
       )
-      .toBeNull();
+      .toBe('True');
     const search = await page.evaluate(() => location.search);
     expect(dupKeys(search)).toEqual([]);
   });
@@ -340,6 +366,8 @@ test.describe('Simulateur #135 : reset sur saisie couvert (flow #272)', () => {
   }) => {
     await page.goto(URL_RESULTAT_COUVERT);
     await expect(page.locator('.result-col')).toBeVisible();
+
+    await ouvrirFormulaireSiReplie(page);
 
     // Le flow #272 est reconstruit depuis l'URL (Q1..Q3 cochees). On change
     // l'axe "recolte" (Q3) -> pilote le vrai sous_culture_form -> dispatch

--- a/e2e/nitrates/reset_form.spec.ts
+++ b/e2e/nitrates/reset_form.spec.ts
@@ -49,6 +49,15 @@ test.describe('Simulateur #135 : reset au changement de champ apres resultat', (
     // (rien a relancer).
     await expect(page.locator('#form-submit-row')).toBeHidden();
 
+    // #271 : sur la page de resultat, le formulaire est replie derriere un
+    // encart recap des choix ; recap_choix.js pose `hidden` sur
+    // #form-after-localisation. Les radios existent donc toujours dans le DOM
+    // mais ne sont plus visibles -> un clic direct timeout ("element is not
+    // visible"). Il faut d'abord rouvrir le formulaire via « Modifier »,
+    // exactement comme le fait l'utilisateur.
+    await page.locator('[data-recap-modifier]').click();
+    await expect(page.locator('#form-after-localisation')).toBeVisible();
+
     // L'user change la categorie de fertilisant (composts).
     await page.locator('label[for="id_categorie_fertilisant__composts"]').click();
 

--- a/e2e/nitrates/root_public_lockdown.spec.ts
+++ b/e2e/nitrates/root_public_lockdown.spec.ts
@@ -1,0 +1,260 @@
+import { test, expect, Page } from '@playwright/test';
+
+/**
+ * #202 — Parcours CLIENT `/` (root public) sous config staging.
+ *
+ * Contexte : incident du 2026-07-02. Aucun test ne couvrait la combinaison
+ * `LOCKDOWN_BEHIND_LOGIN=True` × `NITRATES_ROOT_OUVERT=True`, qui n'existe
+ * QUE sur staging. Le bug ne vivait que là.
+ *
+ * Le mecanisme de l'incident, et pourquoi il est passe inapercu :
+ * le middleware lockdown repond 302 vers /admin/login/ sur toute URL non
+ * exemptee. Un `fetch()` suit ce 302 EN SILENCE et recoit du HTML de login
+ * en 200 -> `response.ok === true`, aucune exception, aucune erreur console.
+ * Le blocage se deguise en succes. Symptomes cote client : carte SIG vide,
+ * formulaire fige sur "cliquez sur la carte", et au mieux un
+ * "Unexpected token 'C', Connexion... is not valid JSON" au moment du
+ * .json(). Un test qui se contente de `expect(response.ok())` ne voit RIEN.
+ *
+ * D'ou la regle de ce fichier : sur les endpoints de donnees, on assert le
+ * **content-type** et le **statut non-redirige**, jamais seulement `ok`.
+ *
+ * PREREQUIS — ces tests n'ont de sens que face a un serveur lance en config
+ * staging imitee. Cf. docker-compose.e2e202.local.yml (worktree
+ * nitrates-e2e-202, port 8054) :
+ *   DJANGO_LOCKDOWN_BEHIND_LOGIN=True
+ *   DJANGO_NITRATES_ROOT_OUVERT=True
+ * Lance contre un serveur ouvert (dev local par defaut), les tests de
+ * fermeture echouent : c'est voulu, ils garantissent que le lockdown ferme
+ * bien ce qu'il doit fermer. Le test `configuration` ci-dessous le dit
+ * explicitement plutot que de laisser 4 echecs cryptiques.
+ */
+
+// Leaflet + WMTS IGN + GeoJSON ZV : les workers paralleles peuvent OOM-crash
+// le conteneur node. Meme choix que simulateur.spec.ts.
+test.describe.configure({ mode: 'serial' });
+
+/**
+ * Base URL pour les appels API directs (`request`).
+ *
+ * Subtilite Docker : en container, la config nitrates fait pointer le
+ * navigateur sur `127.0.0.1:8000` et corrige l'IP via l'option Chromium
+ * `--host-resolver-rules MAP 127.0.0.1 django`. Mais APIRequestContext
+ * (`request`) est un client HTTP Node, PAS le navigateur : cette option ne
+ * s'applique pas a lui, et il tombe sur ECONNREFUSED 127.0.0.1:8000.
+ *
+ * On resout donc l'hote nous-memes pour les appels API, tout en gardant le
+ * Host header attendu par le middleware Site Django (id=3, 127.0.0.1).
+ * Le navigateur, lui, continue d'utiliser le baseURL de la config.
+ */
+const IN_DOCKER = process.env.IN_DOCKER === '1';
+const API_BASE = IN_DOCKER
+  ? 'http://django:8000'
+  : process.env.NITRATES_BASE_URL || 'http://127.0.0.1:8042';
+/** Host header a envoyer avec les appels API en container (cf. Site Django). */
+const API_HEADERS = IN_DOCKER ? { Host: '127.0.0.1:8000' } : {};
+
+/** GET API sans suivre les redirections, avec le bon Host. */
+function getApi(request: any, chemin: string) {
+  return request.get(`${API_BASE}${chemin}`, {
+    maxRedirects: 0,
+    headers: API_HEADERS,
+  });
+}
+
+// Reims (Marne, Grand Est, ZV bassin Seine-Normandie) — parcelle en zone
+// vulnerable, donc parcours complet jusqu'au resultat.
+const REIMS_LNG = 4.0345;
+const REIMS_LAT = 49.2583;
+
+/** Endpoints de DONNEES que le root public doit servir en JSON sans auth. */
+const ENDPOINTS_DATA_OUVERTS = [
+  '/geojson/zv/',
+  '/geojson/zar/',
+  '/api/referentiels/',
+  `/simulateur/debug/?lat=${REIMS_LAT}&lng=${REIMS_LNG}`,
+];
+
+/** Endpoints qui doivent RESTER fermes meme quand le root est ouvert. */
+const ENDPOINTS_FERMES = ['/simulateur/', '/api/arbre/'];
+
+/**
+ * Messages console qu'on tolere : le fond de carte IGN et l'API adresse sont
+ * des services externes, intermittents, hors de notre controle. Tout le reste
+ * est une regression.
+ */
+const CONSOLE_TOLERE = [
+  'geo.api.gouv.fr',
+  'api-adresse.data.gouv.fr',
+  'data.geopf.fr',
+  'wxs.ign.fr',
+  'favicon',
+  'ERR_INTERNET_DISCONNECTED',
+];
+
+function collecteErreursConsole(page: Page): string[] {
+  const erreurs: string[] = [];
+  page.on('console', (msg) => {
+    if (msg.type() !== 'error') return;
+    const texte = msg.text();
+    if (CONSOLE_TOLERE.some((t) => texte.includes(t))) return;
+    erreurs.push(texte);
+  });
+  page.on('pageerror', (err) => erreurs.push(`pageerror: ${err.message}`));
+  return erreurs;
+}
+
+/** Simule le clic carte Leaflet (plus fiable que des coords DOM sur une carte tuilee). */
+async function clicCarte(page: Page, lng: number, lat: number) {
+  await expect(page.locator('#nitrates-map')).toHaveClass(/leaflet-container/);
+  await page.evaluate(([lg, lt]) => {
+    const w = window as any;
+    w.nitratesMap.fire('click', { latlng: w.L.latLng(lt, lg) });
+  }, [lng, lat]);
+}
+
+test.describe('#202 — root public sous lockdown (config staging)', () => {
+  test('configuration : le serveur cible est bien en config staging imitee', async ({
+    request,
+  }) => {
+    const root = await getApi(request, '/');
+    expect(
+      root.status(),
+      "`/` doit etre accessible sans auth (NITRATES_ROOT_OUVERT=True attendu)"
+    ).toBe(200);
+
+    const simulateur = await getApi(request, '/simulateur/');
+    expect(
+      simulateur.status(),
+      "`/simulateur/` doit etre ferme (302). Si tu obtiens 200, le serveur " +
+        'tourne SANS lockdown : lance-le via docker-compose.e2e202.local.yml, ' +
+        'sinon cette suite ne teste pas la config staging.'
+    ).toBe(302);
+  });
+
+  // --- Le test qui aurait detecte l'incident -----------------------------
+
+  for (const chemin of ENDPOINTS_DATA_OUVERTS) {
+    test(`donnees : ${chemin} repond en JSON strict, sans redirection`, async ({
+      request,
+    }) => {
+      // maxRedirects: 0 — on veut voir le 302 s'il existe, PAS le suivre.
+      // C'est toute la difference avec le fetch() du navigateur qui, lui,
+      // le suit en silence et transforme le blocage en faux succes.
+      const reponse = await getApi(request, chemin);
+
+      expect(
+        reponse.status(),
+        `${chemin} redirige (302) : le lockdown intercepte un endpoint qui ` +
+          'doit etre exempte. Cote navigateur ca se traduit par du HTML de ' +
+          'login recu en 200 -> carte vide / formulaire fige.'
+      ).toBe(200);
+
+      const contentType = reponse.headers()['content-type'] || '';
+      expect(
+        contentType,
+        `${chemin} ne renvoie pas du JSON (content-type: "${contentType}"). ` +
+          "Si c'est du text/html, c'est la page de login deguisee en succes."
+      ).toContain('application/json');
+
+      // Le corps doit reellement parser : ceinture et bretelles contre une
+      // page HTML servie avec un content-type menteur.
+      await expect(
+        reponse.json(),
+        `${chemin} : content-type JSON mais corps non parsable`
+      ).resolves.toBeDefined();
+    });
+  }
+
+  test('contre-verif : les endpoints fermes redirigent bien vers le login', async ({
+    request,
+  }) => {
+    for (const chemin of ENDPOINTS_FERMES) {
+      const reponse = await getApi(request, chemin);
+      expect(
+        reponse.status(),
+        `${chemin} devrait rester ferme (302) quand le root est ouvert. ` +
+          "Un 200 ici = fuite d'acces : l'exemption root ouvre trop large."
+      ).toBe(302);
+      expect(reponse.headers()['location'] || '').toContain('/login/');
+    }
+  });
+
+  // --- Parcours client complet ------------------------------------------
+
+  test('la page racine se charge : carte Leaflet + hero, sans erreur console', async ({
+    page,
+  }) => {
+    const erreurs = collecteErreursConsole(page);
+    await page.goto('/');
+
+    await expect(page.locator('h1')).toContainText("conditions d'épandage");
+    await expect(page.locator('#nitrates-map')).toHaveClass(/leaflet-container/);
+
+    // La couche ZV vient d'un fetch sur /geojson/zv/ : si le lockdown
+    // l'interceptait, on aurait une carte sans overlay et zero erreur.
+    await expect
+      .poll(
+        () =>
+          page.evaluate(() => {
+            const w = window as any;
+            return w.nitratesMap ? Object.keys(w.nitratesMap._layers || {}).length : 0;
+          }),
+        { timeout: 15000, message: 'aucune couche Leaflet chargee' }
+      )
+      .toBeGreaterThan(0);
+
+    expect(erreurs, `erreurs console: ${erreurs.join(' | ')}`).toEqual([]);
+  });
+
+  test('recherche commune (BAN) : la suggestion recentre la carte', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator('#nitrates-map')).toHaveClass(/leaflet-container/);
+
+    const centreAvant = await page.evaluate(() => {
+      const c = (window as any).nitratesMap.getCenter();
+      return [c.lat, c.lng];
+    });
+
+    await page.locator('#map-search').fill('Reims');
+
+    const suggestions = page.locator('#map-search-list li');
+    await expect(suggestions.first()).toBeVisible({ timeout: 15000 });
+    await suggestions.first().click();
+
+    await expect
+      .poll(
+        async () => {
+          const c = await page.evaluate(() => {
+            const ctr = (window as any).nitratesMap.getCenter();
+            return [ctr.lat, ctr.lng];
+          });
+          return Math.abs(c[0] - centreAvant[0]) + Math.abs(c[1] - centreAvant[1]);
+        },
+        { timeout: 15000, message: 'la carte ne s’est pas recentree' }
+      )
+      .toBeGreaterThan(0.01);
+  });
+
+  test('parcours complet : clic carte -> formulaire -> simulation -> resultat', async ({
+    page,
+  }) => {
+    const erreurs = collecteErreursConsole(page);
+    await page.goto('/');
+    await clicCarte(page, REIMS_LNG, REIMS_LAT);
+
+    // Le formulaire n'apparait que si /simulateur/debug/ a repondu en JSON
+    // avec `simulateur_ouvert`. Sous l'incident, ce fetch recevait du HTML
+    // de login -> le formulaire ne s'affichait JAMAIS. Ce wait est donc,
+    // a lui seul, un test de non-regression de l'incident.
+    await expect
+      .poll(
+        () =>
+          page.locator('[data-cascade="categorie_culture"] input[type="radio"]').count(),
+        { timeout: 20000, message: 'formulaire jamais revele apres le clic carte' }
+      )
+      .toBeGreaterThan(0);
+
+    expect(erreurs, `erreurs console: ${erreurs.join(' | ')}`).toEqual([]);
+  });
+});

--- a/e2e/nitrates/root_public_lockdown.spec.ts
+++ b/e2e/nitrates/root_public_lockdown.spec.ts
@@ -90,6 +90,12 @@ const CONSOLE_TOLERE = [
   'wxs.ign.fr',
   'favicon',
   'ERR_INTERNET_DISCONNECTED',
+  // Artefact de l'environnement de test, pas une regression applicative :
+  // Chromium ignore l'en-tete Cross-Origin-Opener-Policy quand l'origine
+  // n'est ni HTTPS ni `localhost`. Or les runs tapent une IP/hostname en
+  // clair (127.0.0.1:8042 en CI, django:8000 en container) -> warning
+  // systematique. En prod le site est en HTTPS, l'en-tete est honore.
+  'Cross-Origin-Opener-Policy',
 ];
 
 function collecteErreursConsole(page: Page): string[] {

--- a/e2e/nitrates/simulateur.spec.ts
+++ b/e2e/nitrates/simulateur.spec.ts
@@ -71,6 +71,15 @@ const CATEGORIES_COUVERT = [
 
 async function clickCascadeRadio(page, name, value) {
   if (name === 'categorie_culture') {
+    // #335 : « sol_non_cultive » a ete remonte de Q2 vers Q1. C'est desormais
+    // une reponse directe de la question destination, qui court-circuite Q2
+    // (cf. question_couvert_flow.js : pilotherCascade au clic, Q2 reste
+    // cachee). Passer par cflow_type_couvert comme avant fait timeout : le
+    // radio n'existe plus a ce niveau.
+    if (value === 'sol_non_cultive') {
+      await clickFlowRadio(page, 'cflow_destination', 'sol_non_cultive');
+      return;
+    }
     if (CATEGORIES_COUVERT.includes(value)) {
       await clickFlowRadio(page, 'cflow_destination', 'couvert');
       await clickFlowRadio(page, 'cflow_type_couvert', value);

--- a/envergo/nitrates/management/commands/load_arbres_actifs.py
+++ b/envergo/nitrates/management/commands/load_arbres_actifs.py
@@ -57,6 +57,15 @@ class Command(BaseCommand):
             help="Ne charger qu'un fichier précis (ex 'region_44' ou 'region_44.yaml').",
         )
         parser.add_argument(
+            "--skip-zar-sans-carte",
+            action="store_true",
+            help=(
+                "Passe (au lieu d'échouer) les ZAR dont l'activation_map n'est "
+                "pas déductible. Réservé aux bases éphémères sans couche SIG "
+                "importée (CI e2e) : sur un env réel, l'échec est voulu."
+            ),
+        )
+        parser.add_argument(
             "--skip-si-identique",
             action="store_true",
             help=(
@@ -81,6 +90,7 @@ class Command(BaseCommand):
         arbres_dir = specs_dir / ARBRES_ACTIFS_SUBDIR
         only = options["only"]
         skip_identique = options["skip_si_identique"]
+        skip_zar_sans_carte = options["skip_zar_sans_carte"]
 
         if not arbres_dir.is_dir():
             raise CommandError(f"Répertoire introuvable : {arbres_dir}")
@@ -140,6 +150,12 @@ class Command(BaseCommand):
                 ).first()
                 if actif and actif.activation_map_id:
                     import_kwargs["activation_map"] = str(actif.activation_map_id)
+                elif skip_zar_sans_carte:
+                    skips.append(f.name)
+                    self.stdout.write(
+                        f"  {f.name:22s} [skip — ZAR sans activation_map déductible]"
+                    )
+                    continue
                 else:
                     raise CommandError(
                         f"{f.name} : ZAR sans activation_map déductible "

--- a/envergo/nitrates/management/commands/seed_geodata_e2e.py
+++ b/envergo/nitrates/management/commands/seed_geodata_e2e.py
@@ -32,11 +32,27 @@ from envergo.geodata.models import MAP_TYPES, Department, Map, Zone
 # Le code bassin est porte par l'attribut `CdEuBassin` (ancien schema Sandre,
 # cf. bassins.bassin_code_from_attributes) : sans lui, la vue debug affiche un
 # bassin inconnu et debug_view.spec.ts echoue sur « OUI ... Seine-Normandie ».
+# Une zone par bassin DCE metropolitain : `map_overlays.spec.ts` verifie que
+# l'overlay ZV rend les 8 bassins avec des couleurs distinctes. Une fixture a
+# 2 zones ferait echouer ce test pour une raison etrangere a la carte.
+# Les boites ne se chevauchent pas, sinon un point de test appartiendrait a
+# deux bassins et la resolution deviendrait ambigue.
 BOITES = {
-    # Reims / Marne — bassin Seine-Normandie. Couvre 4.03/49.26 et 3.97/49.05.
+    # --- Boites portant les points de test des specs -------------------
+    # Reims / Marne — Seine-Normandie. Couvre 4.03/49.26 et 3.97/49.05.
     "e2e-reims": ((3.5, 48.8, 4.5, 49.5), "FRH"),
-    # Rennes / Ille-et-Vilaine — utilise par debug_view et map_overlays.
+    # Rennes / Ille-et-Vilaine — Loire-Bretagne. debug_view + map_overlays.
     "e2e-rennes": ((-2.0, 47.9, -1.2, 48.4), "FRG"),
+    # --- Boites de remplissage : uniquement la pour que les 8 bassins
+    # existent dans l'overlay. Aucune spec ne clique dedans, leur position
+    # est approximative (mais placee dans la bonne region pour rester
+    # lisible sur une capture).
+    "e2e-artois": ((2.0, 50.0, 3.0, 50.8), "FRA"),
+    "e2e-meuse": ((5.0, 48.6, 5.6, 49.4), "FRB1"),
+    "e2e-sambre": ((3.7, 50.0, 4.2, 50.3), "FRB2"),
+    "e2e-rhin": ((7.3, 48.3, 8.0, 49.0), "FRC"),
+    "e2e-rhone": ((4.8, 43.5, 5.8, 44.5), "FRD"),
+    "e2e-adour": ((0.5, 43.5, 1.5, 44.5), "FRF"),
 }
 
 # Departements de test. La vue debug affiche le departement et la region

--- a/envergo/nitrates/management/commands/seed_geodata_e2e.py
+++ b/envergo/nitrates/management/commands/seed_geodata_e2e.py
@@ -1,0 +1,117 @@
+"""Pose des donnees geo *minimales* pour les tests e2e sur base ephemere.
+
+Pourquoi cette commande existe
+------------------------------
+Les specs Playwright nitrates simulent un clic sur la carte a des
+coordonnees reelles (Reims, Rennes) et attendent un resultat reglementaire.
+Ce resultat n'existe que si le point tombe dans une zone vulnerable : sans
+couche ZV en base, le simulateur repond « Hors zone » et les ~100 specs
+echouent toutes, pour une raison qui n'a rien a voir avec ce qu'elles
+testent.
+
+L'import reel (`import_nitrates_zv`) telecharge ~37 Mo depuis le WFS Sandre.
+Le brancher sur un nightly le rendrait dependant d'un service externe : une
+indisponibilite Sandre ferait passer la CI au rouge sans regression de code.
+On seede donc ici des rectangles grossiers autour des points testes : la
+couche ZV, et les departements que la vue debug resout geographiquement.
+
+Ce n'est PAS un substitut a la vraie couche : la geometrie est fausse
+(des boites), seule l'appartenance des points de test est correcte. Reserve
+aux bases jetables. La commande refuse de s'executer si des zones reelles
+sont deja presentes, pour ne jamais polluer un environnement importe.
+"""
+
+from django.contrib.gis.geos import MultiPolygon, Polygon
+from django.core.management.base import BaseCommand, CommandError
+
+from envergo.geodata.models import MAP_TYPES, Department, Map, Zone
+
+# Boites (lng_min, lat_min, lng_max, lat_max) larges autour des points que
+# les specs utilisent. Larges volontairement : un point de test ajoute a
+# proximite ne doit pas silencieusement retomber « hors zone ».
+# Le code bassin est porte par l'attribut `CdEuBassin` (ancien schema Sandre,
+# cf. bassins.bassin_code_from_attributes) : sans lui, la vue debug affiche un
+# bassin inconnu et debug_view.spec.ts echoue sur « OUI ... Seine-Normandie ».
+BOITES = {
+    # Reims / Marne — bassin Seine-Normandie. Couvre 4.03/49.26 et 3.97/49.05.
+    "e2e-reims": ((3.5, 48.8, 4.5, 49.5), "FRH"),
+    # Rennes / Ille-et-Vilaine — utilise par debug_view et map_overlays.
+    "e2e-rennes": ((-2.0, 47.9, -1.2, 48.4), "FRG"),
+}
+
+# Departements de test. La vue debug affiche le departement et la region
+# resolus geographiquement (`geodata.Department`) : sans eux, le cartouche
+# reste vide et debug_view.spec.ts echoue sur « 51 » / « Grand Est ».
+# L'import reel (ADMIN EXPRESS COG, ~250 Mo depuis l'IGN) est hors de portee
+# d'un nightly, meme raison que pour la ZV.
+DEPARTEMENTS = {
+    # Marne — Grand Est. Doit couvrir Reims.
+    "51": (3.5, 48.8, 4.5, 49.5),
+    # Ille-et-Vilaine — Bretagne. Doit couvrir Rennes.
+    "35": (-2.0, 47.9, -1.2, 48.4),
+}
+
+
+class Command(BaseCommand):
+    help = "Seede ZV + departements minimaux (rectangles) pour l'e2e sur base jetable."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--force",
+            action="store_true",
+            help="Seede meme si des zones existent deja (les remplace).",
+        )
+
+    def handle(self, *args, **options):
+        carte, _ = Map.objects.get_or_create(
+            map_type=MAP_TYPES.zv_nitrates,
+            defaults={
+                "name": "ZV nitrates — national",
+                "description": "Couche ZV de test (e2e).",
+            },
+        )
+
+        existantes = Zone.objects.filter(map=carte)
+        # Garde-fou : sur un env qui a deja la vraie couche (des milliers de
+        # zones Sandre), ecraser serait destructeur et silencieux.
+        deja_seedees = set(
+            existantes.values_list("attributes__e2e_seed", flat=True)
+        ) <= {True}
+        if existantes.exists() and not deja_seedees and not options["force"]:
+            raise CommandError(
+                f"{existantes.count()} zone(s) deja en base sur la carte ZV et "
+                "elles ne viennent pas de ce seed. Refus d'ecraser une couche "
+                "importee. Utiliser --force si la base est bien jetable."
+            )
+
+        existantes.delete()
+
+        for nom, (bbox, code_bassin) in sorted(BOITES.items()):
+            boite = Polygon.from_bbox(bbox)
+            boite.srid = 4326
+            Zone.objects.create(
+                map=carte,
+                geometry=MultiPolygon(boite, srid=4326),
+                attributes={
+                    "e2e_seed": True,
+                    "name": nom,
+                    "CdEuBassin": code_bassin,
+                },
+            )
+            self.stdout.write(f"  {nom:12s} {code_bassin}  bbox={bbox}")
+
+        for code, bbox in sorted(DEPARTEMENTS.items()):
+            boite = Polygon.from_bbox(bbox)
+            boite.srid = 4326
+            Department.objects.update_or_create(
+                department=code,
+                defaults={"geometry": MultiPolygon(boite, srid=4326)},
+            )
+            self.stdout.write(f"  departement {code}  bbox={bbox}")
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Seed e2e : {len(BOITES)} zone(s) ZV, "
+                f"{len(DEPARTEMENTS)} departement(s)."
+            )
+        )

--- a/envergo/static/nitrates/reset_form.js
+++ b/envergo/static/nitrates/reset_form.js
@@ -184,9 +184,16 @@
   // - un resultat final (.result-col), OU
   // - un bloc QC (recap repondu OU en attente : changer un champ amont
   //   invalide aussi le parcours qui a mene a cette QC).
+  // - OU un retour en saisie DEPUIS un resultat (#271 : « Modifier » replie
+  //   l'encart recap et retire .result-col). Sans ce troisieme cas, le miroir
+  //   d'URL s'arretait net apres « Modifier » : les parametres devenus
+  //   obsoletes (type_fertilisant d'une categorie qu'on vient de changer)
+  //   restaient dans l'URL et repartaient a la resoumission GET.
   function rendurServeurAffiche() {
     return !!(
-      document.querySelector(".result-col") || document.getElementById("qc-bloc")
+      document.querySelector(".result-col") ||
+      document.getElementById("qc-bloc") ||
+      (form && form.hasAttribute("data-miroir-url-actif"))
     );
   }
 
@@ -424,8 +431,15 @@
     // Idem si le radio est dans le bloc QC (recap repondu) ET qu'aucun resultat
     // final n'est affiche : on est encore en phase de saisie QC, pas sur un
     // resultat finalise -> ne pas elaguer. (Cas ou plusieurs QC s'enchainent.)
+    // `.result-col` seule ne suffit PAS a repondre « un resultat a-t-il ete
+    // rendu ? » depuis #271 : « Modifier » la retire tout en restant sur un
+    // parcours issu d'un resultat. On accepte donc aussi le marqueur de
+    // miroir, sinon editer une reponse QC apres « Modifier » laissait le bloc
+    // QC obsolete a l'ecran (il n'etait jamais elague).
     const qcBloc = document.getElementById("qc-bloc");
-    const resultatFinal = document.querySelector(".result-col");
+    const resultatFinal =
+      document.querySelector(".result-col") ||
+      (form && form.hasAttribute("data-miroir-url-actif"));
     if (qcBloc && qcBloc.contains(target) && !resultatFinal) return;
 
     // Sinon : un champ (cascade AMONT, ou reponse QC recap) a change alors
@@ -447,6 +461,18 @@
   }
 
   form.addEventListener("change", onChangeChamp);
+
+  // Arme le miroir d'URL des qu'un rendu serveur est present au chargement.
+  // Le marqueur SURVIT volontairement a « Modifier » (#271) et au retour en
+  // saisie : une fois qu'on vient d'un resultat, l'URL doit rester le reflet
+  // fidele du formulaire jusqu'a la prochaine navigation, sinon elle porte des
+  // reponses qui ne sont plus a l'ecran.
+  if (
+    document.querySelector(".result-col") ||
+    document.getElementById("qc-bloc")
+  ) {
+    form.setAttribute("data-miroir-url-actif", "");
+  }
 
   // Expose pour les tests unitaires (jsdom / node) sans polluer l'API
   // publique : uniquement la fonction pure de construction du dict.


### PR DESCRIPTION
# #202 — gate e2e parcours client + réparation de l'e2e nocturne

Trois choses, chacune découverte en testant la précédente.

## 1. La gate #202

Un job e2e dédié au parcours client `/` sous la configuration qui n'existe que
sur staging : `LOCKDOWN_BEHIND_LOGIN=True` × `NITRATES_ROOT_OUVERT=True`. C'est
le trou qui a laissé passer l'incident du 2026-07-02 (root public cassé la
veille d'un test utilisateur, aucun test ne le couvrait).

Job séparé parce que les deux configs sont mutuellement exclusives : le lockdown
est un middleware global, l'activer ferait échouer toutes les autres specs. Les
deux jobs tournent en parallèle, donc pas de coût en pipeline.

Le point clé des assertions : sur les endpoints de données, on vérifie le
content-type et le statut non-redirigé, jamais seulement `response.ok`. Sous
lockdown un `fetch()` suit le 302 vers le login en silence et reçoit du HTML en
200 : le blocage se déguise en succès.

## 2. La réparation du nocturne

Le job « E2E nitrates » était rouge chaque nuit. Deux causes, toutes deux dues
au fait que la base CI est éphémère et sans couche SIG :

- `load_arbres_actifs` s'arrêtait sur `zar_44.yaml` (l'activation_map d'un ZAR
  se déduit de l'actif en base, absent sur une base neuve). Le job mourait avant
  de lancer Playwright. D'où le flag `--skip-zar-sans-carte`, utilisé uniquement
  en CI : hors CI l'échec reste voulu.
- Une fois ce blocage levé, les ~100 specs échouaient toutes : les points de
  test tombaient « hors zone » faute de couche ZV, et le cartouche debug restait
  vide faute de départements. `seed_geodata_e2e` pose des données minimales :
  une zone par bassin DCE (`map_overlays` vérifie les 8) et les départements des
  points de test.

On ne branche pas les imports réels sur un nightly (37 Mo Sandre, 250 Mo IGN) :
une indisponibilité de la source ferait rougir la CI sans régression de code.

## 3. Deux bugs applicatifs, corrigés (pas contournés)

Une fois la CI capable de tourner, deux tests restaient rouges. Vérification
faite contre `main` : ils échouaient déjà là-bas. Ce sont de vrais bugs.

Même racine : #271 a replié le formulaire derrière l'encart récap sur la page de
résultat, et « Modifier » retire `.result-col`. Or deux mécanismes de
`reset_form.js` déduisaient « un résultat a-t-il été rendu ? » de la seule
présence de cet élément.

**Bug 1 — le miroir d'URL s'arrêtait après « Modifier ».** Les paramètres
devenus obsolètes (`type_fertilisant` d'une catégorie qu'on venait de changer)
restaient dans l'URL et repartaient à la resoumission GET. Côté utilisateur :
une URL rechargée ou partagée portait un état incohérent.

**Bug 2 — le bloc QC obsolète ne disparaissait plus.** Le garde-fou anti-boucle
se déclenchait à tort et laissait à l'écran une question complémentaire qui ne
correspondait plus au parcours.

Fix : un marqueur explicite `data-miroir-url-actif`, posé dès qu'un rendu
serveur existe et qui survit au retour en saisie. On ne déduit plus un état
logique de la présence d'un nœud DOM que d'autres modules suppriment. Le
garde-fou de la QC EN ATTENTE (la vraie boucle infinie #135) est inchangé, et
ses tests passent.

## Vérifications

Rejoué en local sur une base éphémère dédiée (postgres isolé, pas la DB de dev
partagée - c'est justement elle, déjà peuplée, qui masquait le bug `zar_44`) :

- échec `zar_44.yaml` reproduit à l'identique, puis levé par le flag
- suite complète : **102/102**
- gate #202 sous lockdown : **9/9**
- tests unitaires JS : **68/68**

## Points à relire

- `seed_geodata_e2e` pose des géométries **fausses** (des boîtes). Seule
  l'appartenance des points de test est correcte. La commande refuse de
  s'exécuter si des zones non-seedées sont déjà présentes, pour ne jamais
  écraser un environnement importé, mais c'est un garde-fou à challenger.
- Les codes de bassin (`CdEuBassin`) sont posés à la main. À vérifier par
  quelqu'un qui connaît le découpage.
- Une assertion de `reset_form.spec.ts` est corrigée : elle attendait que la
  réponse QC re-choisie disparaisse de l'URL, ce qui contredit #175 (on préserve
  la réponse amont, sinon l'utilisateur la ressaisit). C'est un arbitrage
  produit, à confirmer.
