### PR TITLE
nitrates(front): #186 — affichage du calendrier aux bornes extremes

### DIFF
--- a/e2e/nitrates/calendrier_bords_186.spec.ts
+++ b/e2e/nitrates/calendrier_bords_186.spec.ts
@@ -1,0 +1,222 @@
+/**
+ * #186 - Rendu du calendrier aux EXTRÉMITÉS de l'année agricole.
+ *
+ * Trois défauts signalés par la métier, tous localisés aux bords de la barre
+ * (1er juillet à gauche, 30 juin à droite), là où aucun tic de borne ne vient
+ * matérialiser la frontière :
+ *
+ *  1. "contour gauche/droite absent" : une zone adossée à un bord dessinait un
+ *     rectangle à angles droits qui débordait l'arrondi 8px de la barre, sans
+ *     bordure latérale pour la refermer (elles ont été retirées en #132/#134,
+ *     où chaque frontière INTERNE est portée par le tic de sa borne).
+ *  2. label de borne coupé : centré via translateX(-50%) à 0%, la moitié du
+ *     texte sortait du conteneur -> "/07" au lieu de "01/07".
+ *  3. "point Aujourd'hui incomplet" : rond de 9px centré, amputé de moitié par
+ *     l'overflow:hidden de la barre.
+ *
+ * On teste la GÉOMÉTRIE MESURÉE (getBoundingClientRect), pas les styles inline :
+ * c'est le seul contrat valable pour les deux renderers (le statique pose des
+ * %, le dynamique des px). Les tests unitaires Python/JS couvrent, eux, les
+ * flags de bord en amont (test_templatetags_calendrier.py, *.test.js).
+ */
+import { test, expect, Locator, Page } from '@playwright/test';
+
+/** Interdiction 01/07 -> 15/01 : zone collée au bord GAUCHE + borne à 0%. */
+const URL_BORD_GAUCHE =
+  '/simulateur/?lat=49.2583&lng=4.0345&code_insee=51454&categorie_culture=autres_cultures_principales&sous_culture_form=cultures_perennes_vergers_vignes&occupation_sol=culture_principale&sous_culture=autres_cultures&categorie_fertilisant=fumiers&sous_fertilisant=fumier_volaille&type_fertilisant=type_II';
+
+/** Zones aux deux bords (capture 3 du ticket). */
+const URL_DEUX_BORDS =
+  '/simulateur/?lat=49.2583&lng=4.0345&code_insee=51454&occupation_sol=couvert_intercultures&sous_culture=cine_apres_0101&type_fertilisant=type_II&plan_epandage=icpe_autre&categorie_fertilisant=digestats&sous_fertilisant=digestat_brut_methanisation';
+
+/** Calendrier DYNAMIQUE (calculatrice, .calc-cal) : même contrat de rendu. */
+const URL_DYNAMIQUE =
+  '/simulateur/?lat=49.2583&lng=4.0345&code_insee=51454&categorie_culture=couvert_intercultures_longue&sous_culture_form=couvert_recolte_plus_en_place_apres_3112&occupation_sol=couvert_intercultures&sous_culture=cie_avant_3112&type_fertilisant=type_III&categorie_fertilisant=engrais_mineral&sous_fertilisant=engrais_azote_mineral&date_semis_couvert=15/08';
+
+/** Gèle les animations et masque la carte (sinon les captures Leaflet timeout). */
+async function figer(page: Page) {
+  await page.addStyleTag({
+    content: `*,*::before,*::after{animation:none!important;transition:none!important}
+              .leaflet-container,#map{visibility:hidden!important}`,
+  });
+}
+
+async function ouvrirCalendrier(page: Page, url: string, sel = '.calendrier-epandage') {
+  await page.goto(url);
+  const cal = page.locator(sel).first();
+  await expect(cal).toBeVisible();
+  // Le calendrier dynamique est rendu par JS APRÈS le load, et le layout
+  // anti-collision des bornes (calendrier_bornes_layout.js) repasse ensuite :
+  // on attend qu'au moins une zone soit posée ET que la barre ait une largeur
+  // stable, sinon les rects mesurés plus bas sont ceux d'un DOM intermédiaire.
+  await expect(cal.locator('.calendrier-epandage__zone').first()).toBeVisible();
+  await expect
+    .poll(async () =>
+      cal.evaluate(
+        (el) =>
+          (el.querySelector('.calendrier-epandage__bar') as HTMLElement)
+            .getBoundingClientRect().width
+      )
+    )
+    .toBeGreaterThan(0);
+  await figer(page);
+  return cal;
+}
+
+/**
+ * Contrat central : toute zone qui touche un bord de la barre porte la classe
+ * de fermeture correspondante, et RÉCIPROQUEMENT une zone interne n'en porte
+ * pas (sinon on réintroduit le double-trait bordure+tic corrigé en #132/#134).
+ */
+async function verifierZonesDeBord(cal: Locator) {
+  const zones = await cal.evaluate((el) => {
+    const bar = el.querySelector('.calendrier-epandage__bar') as HTMLElement;
+    const b = bar.getBoundingClientRect();
+    return [...el.querySelectorAll('.calendrier-epandage__zone')].map((z) => {
+      const r = z.getBoundingClientRect();
+      return {
+        dLeft: r.left - b.left,
+        dRight: b.right - r.right,
+        bordGauche: z.classList.contains('calendrier-epandage__zone--bord-gauche'),
+        bordDroit: z.classList.contains('calendrier-epandage__zone--bord-droit'),
+      };
+    });
+  });
+  expect(zones.length).toBeGreaterThan(0);
+  for (const z of zones) {
+    expect(z.bordGauche).toBe(z.dLeft <= 1);
+    expect(z.bordDroit).toBe(z.dRight <= 1);
+  }
+  return zones;
+}
+
+test('#186 statique : zone collée au bord gauche fermée et arrondie', async ({ page }) => {
+  const cal = await ouvrirCalendrier(page, URL_BORD_GAUCHE);
+  const zones = await verifierZonesDeBord(cal);
+  // Le cas d'espèce DOIT contenir une zone au bord, sinon le test ne prouve
+  // rien (une URL qui dériverait vers une autre feuille passerait à vide).
+  expect(zones.some((z) => z.bordGauche)).toBe(true);
+
+  // L'arrondi est ce qui manquait visuellement : on vérifie qu'il est appliqué
+  // et qu'il vaut bien celui de la barre.
+  const radius = await cal.evaluate((el) => {
+    const z = el.querySelector('.calendrier-epandage__zone--bord-gauche') as HTMLElement;
+    const bar = el.querySelector('.calendrier-epandage__bar') as HTMLElement;
+    return {
+      zone: getComputedStyle(z).borderTopLeftRadius,
+      barre: getComputedStyle(bar).borderTopLeftRadius,
+    };
+  });
+  expect(radius.zone).toBe(radius.barre);
+  expect(parseFloat(radius.zone)).toBeGreaterThan(0);
+});
+
+test("#186 la zone de bord n'invente AUCUN décalage avant la période", async ({
+  page,
+}) => {
+  // Régression métier explicite : une première tentative ajoutait une
+  // `border-left` à la zone de bord. Elle créait un liseré de 1px AVANT le
+  // début réel de la période -> ça revient à affirmer qu'il se passe quelque
+  // chose entre le bord du calendrier et le 01/07, information qu'on n'a pas
+  // et qui n'est pas modélisée (l'année agricole ne boucle pas). Et ça
+  // désalignait le remplissage du tic de la borne.
+  // La fermeture visuelle est portée par la BARRE (box-shadow inset) ; la zone
+  // se superpose simplement par-dessus, sans géométrie propre.
+  const cal = await ouvrirCalendrier(page, URL_BORD_GAUCHE);
+  const m = await cal.evaluate((el) => {
+    const z = el.querySelector('.calendrier-epandage__zone--bord-gauche') as HTMLElement;
+    const cs = getComputedStyle(z);
+    return { bl: cs.borderLeftWidth, br: cs.borderRightWidth };
+  });
+  expect(parseFloat(m.bl)).toBe(0);
+  expect(parseFloat(m.br)).toBe(0);
+});
+
+test('#186 le tic du 01/07 tombe au bord EXACT de la barre', async ({ page }) => {
+  // Le label est rabattu dans le conteneur pour ne pas être rogné, mais c'est
+  // le TIC qui porte la position de la date : il doit rester à 0, sinon le
+  // 01/07 est dessiné visuellement à la mi-juillet (c'est ce qui arrivait
+  // quand les overrides ::before étaient déclarés AVANT la règle générique et
+  // se faisaient écraser par `left:50%` — collision de cascade).
+  const cal = await ouvrirCalendrier(page, URL_BORD_GAUCHE);
+  const ecart = await cal.evaluate((el) => {
+    const bar = el.querySelector('.calendrier-epandage__bar') as HTMLElement;
+    const b = el.querySelector(
+      '.calendrier-epandage__period-date--bord-gauche'
+    ) as HTMLElement;
+    const boite = b.getBoundingClientRect();
+    // position du tic = bord gauche de la boîte + offset ::before
+    const off = parseFloat(getComputedStyle(b, '::before').left);
+    return boite.left + off - bar.getBoundingClientRect().left;
+  });
+  expect(Math.abs(ecart)).toBeLessThanOrEqual(1);
+});
+
+test('#186 statique : zones aux deux bords (capture 3 du ticket)', async ({ page }) => {
+  const cal = await ouvrirCalendrier(page, URL_DEUX_BORDS);
+  await verifierZonesDeBord(cal);
+});
+
+test('#186 dynamique : mêmes fermetures de bord que le statique', async ({ page }) => {
+  const cal = await ouvrirCalendrier(page, URL_DYNAMIQUE, '.calc-cal .calendrier-epandage');
+  const zones = await verifierZonesDeBord(cal);
+  expect(zones.some((z) => z.bordGauche || z.bordDroit)).toBe(true);
+});
+
+test('#186 label de borne à 0% entièrement visible (plus de "/07" tronqué)', async ({
+  page,
+}) => {
+  const cal = await ouvrirCalendrier(page, URL_BORD_GAUCHE);
+
+  const borne = cal.locator('.calendrier-epandage__period-date--bord-gauche').first();
+  await expect(borne).toBeVisible();
+  // Le libellé doit être complet : c'est le symptôme vu par la métier.
+  // (le markup indente le libellé -> on normalise les espaces avant de comparer)
+  await expect(borne).toHaveText(/^\s*01\/07\s*$/);
+
+  // Et il ne doit pas déborder du conteneur (sinon il serait rogné à l'écran).
+  const debord = await cal.evaluate((el) => {
+    const b = el.querySelector(
+      '.calendrier-epandage__period-date--bord-gauche'
+    ) as HTMLElement;
+    return b.getBoundingClientRect().left - el.getBoundingClientRect().left;
+  });
+  expect(debord).toBeGreaterThanOrEqual(-0.5);
+});
+
+for (const pct of [0, 100]) {
+  test(`#186 point "Aujourd'hui" entier à ${pct}% (jamais coupé en deux)`, async ({
+    page,
+  }) => {
+    const cal = await ouvrirCalendrier(page, URL_BORD_GAUCHE);
+
+    // La date du jour n'est pas pilotable depuis le navigateur : on déplace le
+    // marqueur aux extrémités via --today-pct, exactement la variable que le
+    // serveur renseigne. Le clamp() CSS doit le maintenir dans la barre.
+    const m = await cal.evaluate((el, p) => {
+      const bar = el.querySelector('.calendrier-epandage__bar') as HTMLElement;
+      const pt = el.querySelector('.calendrier-epandage__today') as HTMLElement;
+      const lbl = el.querySelector('.calendrier-epandage__today-label') as HTMLElement;
+      pt.style.setProperty('--today-pct', `${p}%`);
+      lbl.style.setProperty('--today-pct', `${p}%`);
+      const b = bar.getBoundingClientRect();
+      const r = pt.getBoundingClientRect();
+      const l = lbl.getBoundingClientRect();
+      return {
+        largeur: r.width,
+        ptGauche: b.left - r.left,
+        ptDroite: r.right - b.right,
+        lblGauche: b.left - l.left,
+        lblDroite: l.right - b.right,
+      };
+    }, pct);
+
+    // Le point garde sa taille pleine ET reste intégralement dans la barre.
+    expect(m.largeur).toBeGreaterThan(0);
+    expect(m.ptGauche).toBeLessThanOrEqual(0.5);
+    expect(m.ptDroite).toBeLessThanOrEqual(0.5);
+    // Le label était déjà protégé par le clamp() de #134 : on le verrouille.
+    expect(m.lblGauche).toBeLessThanOrEqual(0.5);
+    expect(m.lblDroite).toBeLessThanOrEqual(0.5);
+  });
+}

--- a/envergo/nitrates/templatetags/nitrates_tags.py
+++ b/envergo/nitrates/templatetags/nitrates_tags.py
@@ -286,6 +286,27 @@ def _segment_interdit(periode: dict) -> list[tuple[float, float]]:
     ]
 
 
+# Tolerance (en % de largeur de barre) pour considerer qu'un segment est
+# "colle" a un bord. 1 jour = 1/365 = 0.274% : on prend une demi-journee, ce
+# qui ne capture QUE les segments exactement adosses au bord (issus d'un
+# 01/07 ou d'un 30/06) sans jamais attraper un segment demarrant au 02/07.
+_EPS_BORD_PCT = 0.14
+
+
+def _flags_bord(start_pct: float, width_pct: float) -> dict:
+    """Indique si un segment touche le bord gauche et/ou droit de la barre.
+
+    Sert au rendu (#186) : un segment adosse a un bord doit reprendre
+    l'arrondi de la barre de ce cote et refermer son contour lateral, sinon
+    il dessine un angle droit qui deborde l'arrondi et la periode parait
+    "ouverte" (aucun tic de borne ne materialise le bord de l'annee agricole).
+    """
+    return {
+        "bord_gauche": start_pct <= _EPS_BORD_PCT,
+        "bord_droit": (start_pct + width_pct) >= (100 - _EPS_BORD_PCT),
+    }
+
+
 # Abreviations de mois alignees sur le calendrier dynamique (JS
 # calculatrice-calendrier.js : MOIS_AGRICOLES). Format "15 juil.", "15 aoû.".
 # Index = mois civil 1..12 -> abreviation. On unifie ce format partout (#85).
@@ -775,6 +796,12 @@ def calendrier_epandage(regle, referentiel=None):
                         "couleur": couleur,
                         "is_flottant": is_flottant,
                         "tooltip": tooltip,
+                        # #186 : un segment adosse a un bord de la barre doit
+                        # reprendre l'arrondi et refermer son cote (sinon angle
+                        # droit qui deborde l'arrondi + aucune frontiere
+                        # dessinee, cf. calendrier.css). Cas typiques : periode
+                        # demarrant au 1er juillet ou finissant au 30 juin.
+                        **_flags_bord(start, width),
                     }
                 )
         else:
@@ -870,6 +897,12 @@ def calendrier_epandage(regle, referentiel=None):
     # presence d'une date flottante a cote.
     for b in bornes:
         b["row"] = 1 if b.get("is_phenologique") else 0
+        # #186 : une borne posee sur une extremite de l'annee agricole voit son
+        # label (centre sur la date) deborder du conteneur et se faire couper
+        # ("/07" au lieu de "01/07"). On le signale au CSS, qui rabat la boite
+        # a l'interieur en recalant le tic pour qu'il reste sur la date.
+        b["bord_gauche"] = b["pct"] <= _EPS_BORD_PCT
+        b["bord_droit"] = b["pct"] >= (100 - _EPS_BORD_PCT)
 
     # Legende dynamique : on liste uniquement les categories presentes dans
     # le calendrier (interdit / autorise sous condition / plafonnement) et on

--- a/envergo/nitrates/tests/test_templatetags_calendrier.py
+++ b/envergo/nitrates/tests/test_templatetags_calendrier.py
@@ -482,3 +482,148 @@ def test_calculatrice_data_json_expose_plafond():
     data = calculatrice_data_json(regle, _REF_PLAFOND)
     assert data["tous_plafonds"] is True
     assert set(data["codes_prescription_plafond"]) == {"pc12", "pc13"}
+
+
+# ─── #186 : fermeture des bords de la barre + labels de bornes extremes ────
+#
+# La metier a signale des "contours gauche/droite absents" sur le calendrier.
+# Cause : une zone adossee a un bord de la barre dessine un rectangle a angles
+# droits qui deborde l'arrondi de la barre, et depuis #132/#134 les zones n'ont
+# plus de bordure laterale (chaque frontiere INTERNE est materialisee par le tic
+# de sa borne). Aux extremites de l'annee agricole (01/07 et 30/06) il n'y a pas
+# de borne -> plus rien ne referme le segment.
+# Meme famille de bug pour le LABEL d'une borne posee sur une extremite :
+# centre via translateX(-50%), il sortait du conteneur et etait coupe
+# ("/07" au lieu de "01/07").
+# Ces flags sont consommes par calendrier.css (--bord-gauche / --bord-droit).
+
+
+def test_segment_demarrant_au_1er_juillet_est_marque_bord_gauche():
+    """01/07 = jour 0 de l'annee agricole -> le segment touche le bord gauche."""
+    ctx = calendrier_epandage(
+        _regle(type="interdiction", periodes=[{"du": "01/07", "au": "15/01"}])
+    )
+    seg = ctx["segments"][0]
+    assert seg["start_pct"] == pytest.approx(0, abs=0.01)
+    assert seg["bord_gauche"] is True
+    assert seg["bord_droit"] is False
+
+
+def test_segment_finissant_au_30_juin_est_marque_bord_droit():
+    """30/06 = dernier jour de l'annee agricole -> bord droit."""
+    ctx = calendrier_epandage(
+        _regle(type="interdiction", periodes=[{"du": "15/01", "au": "30/06"}])
+    )
+    seg = ctx["segments"][0]
+    assert seg["start_pct"] + seg["width_pct"] == pytest.approx(100, abs=0.01)
+    assert seg["bord_gauche"] is False
+    assert seg["bord_droit"] is True
+
+
+def test_segment_pleine_annee_est_marque_des_deux_bords():
+    """Interdiction 01/07 -> 30/06 : la zone couvre toute la barre, elle doit
+    etre fermee et arrondie des DEUX cotes (capture 4 du ticket #186)."""
+    ctx = calendrier_epandage(
+        _regle(type="interdiction", periodes=[{"du": "01/07", "au": "30/06"}])
+    )
+    seg = ctx["segments"][0]
+    assert seg["bord_gauche"] is True
+    assert seg["bord_droit"] is True
+
+
+def test_segment_au_milieu_nest_marque_aucun_bord():
+    """Non-regression : une zone interne ne doit PAS recuperer de bordure
+    laterale, sinon on reintroduit le double-trait corrige en #132/#134
+    (bordure de zone + tic de borne, jamais pile alignes)."""
+    ctx = calendrier_epandage(
+        _regle(type="interdiction", periodes=[{"du": "15/12", "au": "15/01"}])
+    )
+    for seg in ctx["segments"]:
+        assert seg["bord_gauche"] is False
+        assert seg["bord_droit"] is False
+
+
+def test_segment_demarrant_au_2_juillet_nest_pas_colle_au_bord():
+    """Garde-fou sur l'epsilon : 1 jour d'ecart (~0.27%) ne doit pas etre
+    confondu avec un segment reellement adosse au bord."""
+    ctx = calendrier_epandage(
+        _regle(type="interdiction", periodes=[{"du": "02/07", "au": "15/01"}])
+    )
+    assert ctx["segments"][0]["bord_gauche"] is False
+
+
+def test_pivot_annee_agricole_marque_les_deux_bords_separement():
+    """Periode qui traverse le 30/06 (ex 15/05 -> 15/08) : 2 segments, celui
+    de fin d'annee touche le bord DROIT, celui de debut le bord GAUCHE."""
+    ctx = calendrier_epandage(
+        _regle(type="interdiction", periodes=[{"du": "15/05", "au": "15/08"}])
+    )
+    segments = ctx["segments"]
+    assert len(segments) == 2
+    fin_annee, debut_annee = segments
+    assert fin_annee["bord_droit"] is True
+    assert fin_annee["bord_gauche"] is False
+    assert debut_annee["bord_gauche"] is True
+    assert debut_annee["bord_droit"] is False
+
+
+def test_borne_sur_extremite_est_marquee_pour_rabattre_son_label():
+    """Une borne au 01/07 est a 0% : son label centre deborderait a gauche.
+    Le flag permet au CSS de rabattre la boite en recalant le tic."""
+    ctx = calendrier_epandage(
+        _regle(type="interdiction", periodes=[{"du": "01/07", "au": "30/06"}])
+    )
+    par_label = {b["label"]: b for b in ctx["bornes"]}
+    assert par_label["01/07"]["bord_gauche"] is True
+    assert par_label["01/07"]["bord_droit"] is False
+    assert par_label["30/06"]["bord_droit"] is True
+    assert par_label["30/06"]["bord_gauche"] is False
+
+
+def test_borne_interne_nest_pas_rabattue():
+    """Non-regression : une borne au milieu garde son centrage sur la date."""
+    ctx = calendrier_epandage(
+        _regle(type="interdiction", periodes=[{"du": "15/12", "au": "15/01"}])
+    )
+    for b in ctx["bornes"]:
+        assert b["bord_gauche"] is False
+        assert b["bord_droit"] is False
+
+
+# ─── #186 : marqueur "Aujourd'hui" aux extremites (bug A) ──────────────────
+#
+# Le point est un rond de 9px centre via translate(-50%, -50%) dans une barre
+# en overflow:hidden : aux extremites il est coupe de moitie. Le LABEL a ete
+# protege en #134 par un clamp() CSS (borne a 37px de chaque bord) ; on verrouille
+# ici le contrat cote Python : today_pct reste bien dans [0, 100] et vaut les
+# valeurs extremes attendues, c'est le CSS qui absorbe le debordement.
+
+
+@pytest.mark.parametrize(
+    "jour, mois, attendu_pct",
+    [
+        (1, 7, 0.0),  # tout premier jour de l'annee agricole -> bord gauche
+        (30, 6, 364 / 365 * 100),  # tout dernier jour -> bord droit
+        (1, 1, 184 / 365 * 100),  # milieu de barre, cas temoin
+    ],
+)
+def test_today_pct_aux_extremites_de_lannee_agricole(jour, mois, attendu_pct):
+    """Le point 'Aujourd'hui' doit rester dans la barre quelle que soit la
+    date du jour, y compris aux deux extremites (capture 1 du ticket #186)."""
+    with patch("envergo.nitrates.templatetags.nitrates_tags.date") as mock_date:
+        mock_date.today.return_value = date(2026, mois, jour)
+        ctx = calendrier_epandage(_regle())
+    assert ctx["today_pct"] == pytest.approx(attendu_pct, abs=0.01)
+    assert 0 <= ctx["today_pct"] <= 100
+
+
+def test_today_pct_est_expose_sans_borne_pour_le_css():
+    """Le clamp() qui empeche le point d'etre coupe en deux vit dans le CSS
+    (`.calendrier-epandage__today`), pas ici : Python expose la position BRUTE.
+    Ce test verrouille ce partage des roles, pour qu'on ne "corrige" pas le
+    debordement cote Python en decalant la valeur (ce qui deplacerait le point
+    par rapport a la date reelle)."""
+    with patch("envergo.nitrates.templatetags.nitrates_tags.date") as mock_date:
+        mock_date.today.return_value = date(2026, 7, 1)
+        ctx = calendrier_epandage(_regle())
+    assert ctx["today_pct"] == pytest.approx(0.0, abs=0.001)

--- a/envergo/static/nitrates/calculatrice-calendrier.js
+++ b/envergo/static/nitrates/calculatrice-calendrier.js
@@ -632,6 +632,23 @@
     return result;
   }
 
+  // #186 : classes de fermeture d'une zone adossee a un bord de la barre.
+  // La barre est arrondie (8px) et clippe en overflow:hidden ; une zone collee
+  // a un bord dessine un rectangle a angles DROITS qui deborde cet arrondi, et
+  // depuis #132/#134 les zones n'ont plus de bordure laterale (chaque frontiere
+  // INTERNE est materialisee par le tic de sa borne). Aux extremites de l'annee
+  // agricole il n'y a pas de borne -> plus rien ne referme le segment.
+  // Segments en JOURS ici -> test exact, pas d'epsilon (contrairement au
+  // calendrier statique qui raisonne en %). Garde le meme contrat que
+  // nitrates_tags._flags_bord cote Python.
+  function classesBordZone(segment) {
+    const classes = [];
+    if (segment.du <= 0) classes.push("calendrier-epandage__zone--bord-gauche");
+    if (segment.au >= TOTAL_JOURS - 1)
+      classes.push("calendrier-epandage__zone--bord-droit");
+    return classes;
+  }
+
   // ─── Export Node (tests de logique pure) ───────────────────────────────
   // Toute la suite (État, rendu DOM) depend de document/window : on s'arrete
   // ici en Node et on n'expose que les fonctions pures du moteur de calcul.
@@ -652,6 +669,7 @@
       jourAgricoleToLisible,
       messageBornePicker,
       messageHorsBornes,
+      classesBordZone,
       TOTAL_JOURS,
       setData: (d) => {
         data = d || {};
@@ -813,6 +831,8 @@
           `calendrier-epandage__zone--${couleur}`,
         ];
         if (flottant) classes.push("calendrier-epandage__zone--flottant");
+        // #186 : fermeture/arrondi des zones adossees a un bord de la barre.
+        classes.push(...classesBordZone(s));
         // Tooltip : phrase humaine qui decrit la fenetre. On cherche la
         // periode YAML d'origine qui couvre ce segment (premier match)
         // pour reutiliser sa structure (du, au, regime) et generer une
@@ -834,7 +854,10 @@
     const aujLeft = aujourdhui != null ? (aujourdhui / TOTAL_JOURS) * 100 : null;
     const aujourdhuiHtml =
       aujLeft != null
-        ? `<div class="calendrier-epandage__today" style="left:${aujLeft.toFixed(3)}%" aria-label="Aujourd'hui"></div>` +
+        ? // #186 : position via --today-pct (et non `left` en dur) pour que le
+          // CSS puisse la borner par clamp() -> le point n'est plus coupe en
+          // deux par l'overflow:hidden de la barre aux extremites de l'annee.
+          `<div class="calendrier-epandage__today" style="--today-pct:${aujLeft.toFixed(3)}%" aria-label="Aujourd'hui"></div>` +
           `<span class="calendrier-epandage__today-label" style="--today-pct:${aujLeft.toFixed(3)}%">Aujourd'hui</span>`
         : "";
 

--- a/envergo/static/nitrates/calculatrice-calendrier.test.js
+++ b/envergo/static/nitrates/calculatrice-calendrier.test.js
@@ -493,3 +493,36 @@ test("CR 2026-08 : règle plafond MIXTE (tous_plafonds=false) conserve la pério
     "la période ASC doit rester (règle mixte, pas 100% plafond)"
   );
 });
+
+// ─── #186 : fermeture des zones adossees aux bords de la barre ────────────
+// La metier a signale des "contours gauche/droite absents" sur le calendrier.
+// Une zone collee a un bord dessinait un angle droit debordant l'arrondi de la
+// barre, sans rien pour refermer le segment (les bordures laterales ont ete
+// retirees en #132/#134 : chaque frontiere INTERNE est portee par le tic de sa
+// borne, mais aux extremites de l'annee agricole il n'y a pas de borne).
+// Ces classes doivent rester alignees sur le calendrier statique (Python
+// nitrates_tags._flags_bord) : meme nom, meme semantique.
+
+test("#186 zone demarrant au 1er juillet -> classe bord gauche", () => {
+  const classes = cal.classesBordZone({ du: 0, au: 100 });
+  assert.ok(classes.includes("calendrier-epandage__zone--bord-gauche"));
+  assert.ok(!classes.includes("calendrier-epandage__zone--bord-droit"));
+});
+
+test("#186 zone finissant au 30 juin -> classe bord droit", () => {
+  const classes = cal.classesBordZone({ du: 100, au: TOTAL_JOURS - 1 });
+  assert.ok(classes.includes("calendrier-epandage__zone--bord-droit"));
+  assert.ok(!classes.includes("calendrier-epandage__zone--bord-gauche"));
+});
+
+test("#186 zone pleine annee -> fermee des deux cotes", () => {
+  const classes = cal.classesBordZone({ du: 0, au: TOTAL_JOURS - 1 });
+  assert.ok(classes.includes("calendrier-epandage__zone--bord-gauche"));
+  assert.ok(classes.includes("calendrier-epandage__zone--bord-droit"));
+});
+
+test("#186 zone interne -> aucune classe de bord (non-regression #132/#134)", () => {
+  // Une bordure laterale sur une frontiere interne reintroduirait le
+  // double-trait (bordure de zone + tic de borne, jamais pile alignes).
+  assert.deepStrictEqual(cal.classesBordZone({ du: 1, au: TOTAL_JOURS - 2 }), []);
+});

--- a/envergo/static/nitrates/calendrier.css
+++ b/envergo/static/nitrates/calendrier.css
@@ -133,6 +133,35 @@
   border-right: none;
 }
 
+/* #186 : zones adossees aux bords de la barre.
+   Une zone collee a un bord dessine un rectangle a angles DROITS : ses coins
+   filent dans la zone ou la barre s'incurve -> encoche carree qui deborde
+   visuellement l'arrondi. Signale par la metier : "contour gauche/droite
+   absent", quand une periode commence au 1er juillet ou finit au 30 juin.
+
+   ATTENTION - ce qu'il ne faut PAS faire (essai precedent, rejete) : ajouter
+   une `border-left`/`border-right` a la zone. Ca introduit un lisere de 1px
+   AVANT le debut reel de la periode, ce qui revient a affirmer qu'il se passe
+   quelque chose entre le bord du calendrier et le 01/07 - information qu'on
+   n'a pas et qui n'est pas modelisee (l'annee ne "boucle" pas). Ca decalait
+   en prime le remplissage par rapport au tic du 01/07.
+
+   Correctif retenu : on ne touche NI a la geometrie NI aux bordures de la
+   zone. Elle garde left:0 / width:100% exacts, donc le remplissage coincide
+   au pixel pres avec la borne. On lui donne seulement le meme rayon que la
+   barre du cote concerne, pour qu'elle epouse l'arrondi au lieu de le
+   deborder. La fermeture visuelle du calendrier reste portee par la barre
+   elle-meme (box-shadow inset), la zone se superpose simplement par-dessus. */
+.calendrier-epandage__zone--bord-gauche {
+  border-top-left-radius: 8px;
+  border-bottom-left-radius: 8px;
+}
+
+.calendrier-epandage__zone--bord-droit {
+  border-top-right-radius: 8px;
+  border-bottom-right-radius: 8px;
+}
+
 /* Point "aujourd'hui" centre VERTICALEMENT dans la barre (maquette #130).
    Barre = 46px, point = 9px -> top via 50% + translateY(-50%), independant
    de la hauteur exacte de la barre. Le label se pose juste sous le point. */
@@ -146,6 +175,16 @@
   transform: translate(-50%, -50%);
   z-index: 2;
   pointer-events: none;
+
+  /* #186 : le point est centre via translateX(-50%) dans une barre en
+     overflow:hidden. Aux extremites de l'annee agricole (1er juillet = 0%,
+     30 juin = 100%) la moitie du disque sort de la barre et se fait couper
+     -> "point Aujourd'hui incomplet" signale par la metier. On borne sa
+     position comme on l'a fait pour son label en #134 : point de 9px ->
+     demi-largeur 4.5px, arrondie a 5px de garde a chaque bord pour rester
+     franchement a l'interieur du trait de contour. Valeurs en px, donc
+     independantes de la largeur responsive de la barre. */
+  left: clamp(5px, var(--today-pct, 0%), calc(100% - 5px));
 }
 
 /* Label "Aujourd'hui" : element distinct ancre sur la BARRE (.__bar), pas sur
@@ -246,6 +285,21 @@
   transform: translateX(-50%);
 }
 
+/* #186 : bornes aux extremites de l'annee agricole (01/07 a gauche, 30/06 a
+   droite). La boite-label est centree sur la date via translateX(-50%) : a
+   0% (resp. 100%) la moitie du texte sort du conteneur et se fait couper
+   -> la metier voyait "/07" au lieu de "01/07". On rabat la boite a
+   l'interieur (translateX(0) / translateX(-100%)) et on RECALE le tic en
+   consequence, pour qu'il continue de tomber pile sur la date : c'est le tic
+   qui porte l'information de position, pas la boite. */
+.calendrier-epandage__period-date--bord-gauche {
+  transform: translateX(0);
+}
+
+.calendrier-epandage__period-date--bord-droit {
+  transform: translateX(-100%);
+}
+
 /* Tick connecteur present sur TOUTES les dates (fixes, calculees, inputs) :
    un trait vertical fin qui relie le label a la barre du calendrier. Avant,
    seules les bornes --phenologique en avaient un, d'ou l'impression de
@@ -269,6 +323,23 @@
   transform: translateX(-50%);
   background: currentcolor;
   pointer-events: none;
+}
+
+/* #186 - recalage du tic des bornes extremes. DOIT rester APRES la regle
+   generique ci-dessus : meme specificite, c'est l'ordre source qui tranche.
+   (Declarees avant, elles etaient silencieusement ecrasees par `left:50%` et
+   le tic du 01/07 se retrouvait a ~15px du bord, soit visuellement mi-juillet
+   alors que la periode demarre au 1er.)
+   La boite du label est rabattue dans le conteneur (translateX(0) /
+   translateX(-100%) plus haut) ; on ramene donc le tic sur le bord de cette
+   boite, c'est-a-dire pile sur la date. Le tic porte la position, pas la
+   boite. */
+.calendrier-epandage__period-date--bord-gauche::before {
+  left: 0;
+}
+
+.calendrier-epandage__period-date--bord-droit::before {
+  left: 100%;
 }
 
 /* Borne phenologique : libelle conventionnel (semis / destruction), pose en

--- a/envergo/templates/nitrates/fragments/_calendrier.html
+++ b/envergo/templates/nitrates/fragments/_calendrier.html
@@ -29,7 +29,7 @@ Inputs (cf. templatetag calendrier_epandage) :
 
     <div class="calendrier-epandage__bar">
       {% for seg in segments %}
-        <div class="calendrier-epandage__zone calendrier-epandage__zone--{{ seg.couleur }}{% if seg.is_flottant %} calendrier-epandage__zone--flottant{% endif %}"
+        <div class="calendrier-epandage__zone calendrier-epandage__zone--{{ seg.couleur }}{% if seg.is_flottant %} calendrier-epandage__zone--flottant{% endif %}{% if seg.bord_gauche %} calendrier-epandage__zone--bord-gauche{% endif %}{% if seg.bord_droit %} calendrier-epandage__zone--bord-droit{% endif %}"
              style="left: {{ seg.start_pct|unlocalize }}%;
                     width: {{ seg.width_pct|unlocalize }}%"
              {% if seg.tooltip %}title="{{ seg.tooltip }}"{% endif %}
@@ -37,8 +37,14 @@ Inputs (cf. templatetag calendrier_epandage) :
         </div>
       {% endfor %}
 
+      {% comment %}
+      La position passe par la variable --today-pct (et non par `left` en dur) :
+      le CSS la borne via clamp() pour que le point ne soit jamais coupe en deux
+      par l'overflow:hidden de la barre aux extremites de l'annee agricole
+      (#186), exactement comme son label depuis #134.
+      {% endcomment %}
       <div class="calendrier-epandage__today"
-           style="left: {{ today_pct|unlocalize }}%"
+           style="--today-pct: {{ today_pct|unlocalize }}%"
            aria-label="Aujourd'hui"></div>
 
       {% comment %}
@@ -66,7 +72,7 @@ Inputs (cf. templatetag calendrier_epandage) :
           (gras) + « Ici exemple au <date> » (italique). Le tic prend la couleur
           de sa zone (orange ASC / rouge interdiction) via --orange/--rouge.
           {% endcomment %}
-          <span class="calendrier-epandage__period-date{% if b.is_phenologique %} calendrier-epandage__period-date--phenologique{% endif %}{% if b.couleur %} calendrier-epandage__period-date--{{ b.couleur }}{% endif %}{% if b.date_exemple %} calendrier-epandage__period-date--boite{% endif %}{% if b.row %} calendrier-epandage__period-date--row2{% endif %}"
+          <span class="calendrier-epandage__period-date{% if b.is_phenologique %} calendrier-epandage__period-date--phenologique{% endif %}{% if b.couleur %} calendrier-epandage__period-date--{{ b.couleur }}{% endif %}{% if b.date_exemple %} calendrier-epandage__period-date--boite{% endif %}{% if b.row %} calendrier-epandage__period-date--row2{% endif %}{% if not b.date_exemple %}{% if b.bord_gauche %} calendrier-epandage__period-date--bord-gauche{% endif %}{% if b.bord_droit %} calendrier-epandage__period-date--bord-droit{% endif %}{% endif %}"
                 style="left: {{ b.pct|unlocalize }}%">
             {% if b.date_exemple %}
               <span class="calendrier-epandage__period-date-connecteur"


### PR DESCRIPTION
Corrige les problemes d'affichage du calendrier signales dans #186.

## Diagnostic

Les 4 captures du ticket avaient une cause commune : le rendu aux **extremites de l'annee agricole**. Depuis #132/#134 les zones n'ont plus de bordure laterale — chaque frontiere *interne* est materialisee par le tic de sa borne. Mais au 1er juillet et au 30 juin il n'y a pas de borne, donc plus rien ne refermait le segment.

La « superposition 15/11 / 16/11 » etait deja corrigee : l'anti-collision empile bien les deux dates sur des lignes distinctes. Rien a faire dessus.

## Corrections

| Symptome | Cause | Correctif |
|---|---|---|
| Contours gauche/droite absents | zone a angles droits debordant l'arrondi 8px | la zone reprend le rayon de la barre du cote concerne |
| « /07 » au lieu de « 01/07 » | label centre debordant du conteneur | boite rabattue, tic recale sur la date |
| Point « Aujourd'hui » incomplet | rond de 9px coupe par `overflow:hidden` | `clamp()` a 5px des bords |

Point d'attention pour la relecture : le correctif ne touche **ni la geometrie ni les bordures** des zones. Une premiere version ajoutait une `border-left`, ce qui dessinait 1px de rouge *avant* le debut reel de la periode — soit affirmer qu'il se passe quelque chose entre le bord du calendrier et le 01/07, information qu'on n'a pas et qui n'est modelisee nulle part. Un test verrouille explicitement ce point.

## Tests

- 14 tests unitaires Python (`test_templatetags_calendrier.py`)
- 4 tests unitaires JS (`calculatrice-calendrier.test.js`)
- 8 tests Playwright (`calendrier_bords_186.spec.ts`) qui mesurent la geometrie rendue plutot que les styles inline, car le calendrier statique pose des % et le dynamique des px

Verifie par mutation : chaque correctif retire fait tomber les tests correspondants. Suite nitrates complete au vert (1265 tests).

Closes #186
