### PR TITLE
nitrates(ci): restaure les devDependencies avant de lancer Playwright

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -95,8 +95,17 @@ jobs:
 
       # Les specs testent le JS compile (cascade, flow couvert, carte Leaflet).
       # Sans build, le serveur sert des assets absents -> tout casse.
+      # bin/build_assets.sh est le hook post-compile de SCALINGO : il finit par
+      # `npm prune --production` pour ne pas gonfler /staticfiles. En CI cet
+      # elagage retire @playwright/test, installe juste avant par `npm ci` ->
+      # `npx playwright test` ne le trouve plus et telecharge un playwright
+      # temporaire qui echoue sur « Cannot find module '@playwright/test' ».
+      # On restaure donc les devDependencies APRES le build.
       - name: Build assets
         run: bash bin/build_assets.sh
+
+      - name: Restaurer les devDependencies elaguees par le build
+        run: npm ci
 
       # --- Base : migrations + referentiels + arbres canoniques ------------
       # Les specs interrogent /api/referentiels/ et /api/arbre/ (qui doit
@@ -252,8 +261,17 @@ jobs:
       - name: Install js dependencies
         run: npm ci
 
+      # bin/build_assets.sh est le hook post-compile de SCALINGO : il finit par
+      # `npm prune --production` pour ne pas gonfler /staticfiles. En CI cet
+      # elagage retire @playwright/test, installe juste avant par `npm ci` ->
+      # `npx playwright test` ne le trouve plus et telecharge un playwright
+      # temporaire qui echoue sur « Cannot find module '@playwright/test' ».
+      # On restaure donc les devDependencies APRES le build.
       - name: Build assets
         run: bash bin/build_assets.sh
+
+      - name: Restaurer les devDependencies elaguees par le build
+        run: npm ci
 
       - name: Preparer la base (migrate + referentiels + arbres)
         run: |


### PR DESCRIPTION
Suite du merge de #378 : le job e2e va maintenant jusqu'au bout de la
préparation de base (les deux blocages précédents sont bien levés), mais
échoue sur `Cannot find module '@playwright/test'`.

## Cause

`bin/build_assets.sh` est le hook post-compile de **Scalingo** : il finit par
`npm prune --production` pour ne pas gonfler `/staticfiles`. Légitime au
déploiement, destructeur en CI — l'élagage retire `@playwright/test` que
`npm ci` venait d'installer. `npx playwright test` tombe alors sur un
playwright temporaire incapable de résoudre le module.

## Fix

On restaure les devDependencies après le build, dans les deux jobs. Le script
de déploiement n'est pas touché.

## Vérification

Séquence du runner reproduite en local :

- `npm prune --production` → `@playwright/test` **absent** (bug reproduit)
- `npm ci` → **restauré** (1.50.1)