### PR TITLE
ops: deploy-dev lit le token depuis l'environment dev (#50)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -10,7 +10,13 @@ name: Deploy dev
 #      puis restart web (cache lru).
 #   4. smoke : root repond, cascade arbres OK.
 #
-# Secret requis : SCALINGO_API_TOKEN (repository secret). Aucun autre.
+# Secret requis : SCALINGO_API_TOKEN, dans l'environment `dev`.
+#
+# L'environment `dev` n'a volontairement PAS de required reviewer : ce
+# workflow tourne a chaque push sur main, une approbation manuelle a chaque
+# fois n'aurait aucun sens. Il sert a porter le SECRET, et a restreindre sa
+# lecture aux seuls jobs qui tournent depuis main : un workflow pousse sur une
+# branche arbitraire ne peut plus y acceder.
 
 permissions:
   contents: read
@@ -28,6 +34,10 @@ env:
 jobs:
   deploy-dev:
     runs-on: ubuntu-latest
+    # Porte le secret et restreint sa lecture aux jobs issus de main.
+    environment:
+      name: dev
+      url: https://nitrates-dev.osc-fr1.scalingo.io/
     steps:
       - name: Checkout
         uses: actions/checkout@v7


### PR DESCRIPTION
Suite du chantier CD (#50). Le SCALINGO_API_TOKEN était un secret de dépôt :
tout job, sur n'importe quelle branche, pouvait le lire et l'exfiltrer sans
passer par une revue. Or ce token porte les droits d'admin sur l'ensemble de
l'infra Scalingo.

Il est désormais porté par l'environment `dev`, dont la politique de branche
limite l'accès aux jobs issus de main. Pas de required reviewer : ce workflow
tourne à chaque push sur main.

Les environments `staging` et `production` ont été créés en parallèle, avec
required reviewers (maxblax, Denis-Baudot-BetaGouv, beta-ops) et leur propre
copie du secret.

Une fois ce déploiement vérifié, le secret de dépôt sera supprimé.