### PR TITLE
nitrates(ci): ALLOWED_HOSTS accepte 127.0.0.1 dans les settings de CI

### DIFF
--- a/config/settings/ci.py
+++ b/config/settings/ci.py
@@ -16,9 +16,14 @@ SECRET_KEY = env(
 )
 
 # https://docs.djangoproject.com/en/dev/ref/settings/#allowed-hosts
-ALLOWED_HOSTS = [
-    "localhost",
-]
+# 127.0.0.1 fait partie du defaut : les specs Playwright ciblent cette adresse
+# (cf. playwright.config.nitrates.ts) et un ALLOWED_HOSTS limite a « localhost »
+# renvoyait un DisallowedHost sur chaque page. Surchargeable par
+# DJANGO_ALLOWED_HOSTS, que le workflow e2e positionne deja.
+ALLOWED_HOSTS = env.list(
+    "DJANGO_ALLOWED_HOSTS",
+    default=["localhost", "127.0.0.1"],
+)
 
 # CACHES
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Suite de #378 et #380. Playwright tourne maintenant jusqu'au bout, mais chaque
page renvoie une erreur 500 Django :

```
DisallowedHost: Invalid HTTP_HOST header: '127.0.0.1:8042'.
You may need to add '127.0.0.1' to ALLOWED_HOSTS.
```

## Cause

`config/settings/ci.py` codait `ALLOWED_HOSTS = ["localhost"]` **en dur**. La
variable `DJANGO_ALLOWED_HOSTS` que le workflow e2e positionne n'était donc
jamais lue — le commentaire du workflow supposait l'inverse. Or les specs
ciblent `127.0.0.1` (cf. `playwright.config.nitrates.ts`).

## Fix

On lit la variable, avec `127.0.0.1` dans le défaut pour que la suite marche
aussi sans configuration explicite.

## Vérification

En container, settings `config.settings.ci` :

- défaut → `['localhost', '127.0.0.1']`
- avec `DJANGO_ALLOWED_HOSTS=127.0.0.1,localhost` → `['127.0.0.1', 'localhost']`