### PR TITLE
nitrates(ci): repare le workflow e2e (4 bugs d'infra empiles)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -133,16 +133,28 @@ jobs:
           DJANGO_LOCKDOWN_BEHIND_LOGIN: "False"
           DJANGO_NITRATES_ROOT_OUVERT: "True"
         run: |
-          python manage.py runserver 127.0.0.1:8042 --noreload &
+          # nohup + setsid : le serveur doit survivre a la fin de CE step,
+          # sinon il meurt avant que Playwright ne tourne (chaque step a son
+          # propre shell).
+          nohup python manage.py runserver 127.0.0.1:8042 --noreload \
+            > /tmp/django-e2e.log 2>&1 &
           echo "Attente du serveur sur 127.0.0.1:8042..."
+          # Attention au piege : `curl -w '%{http_code}'` ecrit deja "000" sur
+          # stdout quand la connexion echoue. Avec un `|| echo "000"` en plus,
+          # la variable valait "000000" -> le test `!= "000"` passait des la 1ere
+          # iteration et le step annoncait « Serveur up (HTTP 000000) » alors que
+          # rien n'ecoutait. Toutes les specs echouaient ensuite sur une page
+          # vide. On teste donc le succes de curl, pas le contenu du code.
           for i in $(seq 1 60); do
-            code=$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:8042/ || echo "000")
-            if [ "$code" != "000" ]; then
-              echo "Serveur up (HTTP $code)"; exit 0
+            if code=$(curl -sf -o /dev/null -w '%{http_code}' http://127.0.0.1:8042/); then
+              echo "Serveur up (HTTP $code)"
+              exit 0
             fi
             sleep 2
           done
           echo "ECHEC : le serveur n'a pas demarre en 120s" >&2
+          echo "--- log Django ---" >&2
+          cat /tmp/django-e2e.log >&2
           exit 1
 
       # `bin/build_assets.sh` est le hook de deploiement Scalingo : il finit par

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -145,14 +145,21 @@ jobs:
           echo "ECHEC : le serveur n'a pas demarre en 120s" >&2
           exit 1
 
-      # `npx playwright` NE DOIT PAS etre utilise ici : le repo declare
-      # `@playwright/test` mais pas `playwright`, donc npx ne trouve aucun
-      # binaire local et telecharge un paquet `playwright` autonome (derniere
-      # version) dans son cache. Les commandes s'executent alors depuis ce
-      # cache, dont le node_modules ne contient pas `@playwright/test` ->
-      # `Cannot find module '@playwright/test'` au chargement de la config, et
-      # zero test execute. On appelle donc le binaire local installe par
-      # `npm ci`, qui resout bien les dependances du repo.
+      # `bin/build_assets.sh` est le hook de deploiement Scalingo : il finit par
+      # `npm prune --production` pour ne pas embarquer les devDependencies dans
+      # le slug. Effet de bord ici : ca SUPPRIME `@playwright/test` juste avant
+      # qu'on en ait besoin. Il faut donc reinstaller les deps apres le build.
+      #
+      # C'est la cause du `Cannot find module '@playwright/test'` qui faisait
+      # echouer le workflow sans executer un seul test : `npx playwright` ne
+      # trouvait plus rien en local et telechargeait un paquet `playwright`
+      # autonome, dont le node_modules ne contient pas `@playwright/test`.
+      - name: Reinstaller les deps JS (npm prune les a retirees)
+        run: npm ci
+
+      # Binaire local (installe par le `npm ci` ci-dessus) et pas `npx` : npx
+      # retomberait sur un telechargement autonome si le paquet manquait, ce
+      # qui masquerait le probleme au lieu de le signaler.
       - name: Installer les navigateurs Playwright
         run: ./node_modules/.bin/playwright install --with-deps chromium
 
@@ -318,14 +325,21 @@ jobs:
             exit 1
           fi
 
-      # `npx playwright` NE DOIT PAS etre utilise ici : le repo declare
-      # `@playwright/test` mais pas `playwright`, donc npx ne trouve aucun
-      # binaire local et telecharge un paquet `playwright` autonome (derniere
-      # version) dans son cache. Les commandes s'executent alors depuis ce
-      # cache, dont le node_modules ne contient pas `@playwright/test` ->
-      # `Cannot find module '@playwright/test'` au chargement de la config, et
-      # zero test execute. On appelle donc le binaire local installe par
-      # `npm ci`, qui resout bien les dependances du repo.
+      # `bin/build_assets.sh` est le hook de deploiement Scalingo : il finit par
+      # `npm prune --production` pour ne pas embarquer les devDependencies dans
+      # le slug. Effet de bord ici : ca SUPPRIME `@playwright/test` juste avant
+      # qu'on en ait besoin. Il faut donc reinstaller les deps apres le build.
+      #
+      # C'est la cause du `Cannot find module '@playwright/test'` qui faisait
+      # echouer le workflow sans executer un seul test : `npx playwright` ne
+      # trouvait plus rien en local et telechargeait un paquet `playwright`
+      # autonome, dont le node_modules ne contient pas `@playwright/test`.
+      - name: Reinstaller les deps JS (npm prune les a retirees)
+        run: npm ci
+
+      # Binaire local (installe par le `npm ci` ci-dessus) et pas `npx` : npx
+      # retomberait sur un telechargement autonome si le paquet manquait, ce
+      # qui masquerait le probleme au lieu de le signaler.
       - name: Installer les navigateurs Playwright
         run: ./node_modules/.bin/playwright install --with-deps chromium
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -145,8 +145,16 @@ jobs:
           echo "ECHEC : le serveur n'a pas demarre en 120s" >&2
           exit 1
 
+      # `npx playwright` NE DOIT PAS etre utilise ici : le repo declare
+      # `@playwright/test` mais pas `playwright`, donc npx ne trouve aucun
+      # binaire local et telecharge un paquet `playwright` autonome (derniere
+      # version) dans son cache. Les commandes s'executent alors depuis ce
+      # cache, dont le node_modules ne contient pas `@playwright/test` ->
+      # `Cannot find module '@playwright/test'` au chargement de la config, et
+      # zero test execute. On appelle donc le binaire local installe par
+      # `npm ci`, qui resout bien les dependances du repo.
       - name: Installer les navigateurs Playwright
-        run: npx playwright install --with-deps chromium
+        run: ./node_modules/.bin/playwright install --with-deps chromium
 
       # --- Run --------------------------------------------------------------
       # `capture_*` exclu (outils de capture, pas de la non-reg) ainsi que les
@@ -162,7 +170,7 @@ jobs:
           NITRATES_BASE_URL: "http://127.0.0.1:8042"
           CI: "true"
         run: |
-          npx playwright test \
+          ./node_modules/.bin/playwright test \
             --config playwright.config.nitrates.ts \
             $(ls e2e/nitrates/*.spec.ts \
                 | grep -v '/capture_' \
@@ -310,15 +318,23 @@ jobs:
             exit 1
           fi
 
+      # `npx playwright` NE DOIT PAS etre utilise ici : le repo declare
+      # `@playwright/test` mais pas `playwright`, donc npx ne trouve aucun
+      # binaire local et telecharge un paquet `playwright` autonome (derniere
+      # version) dans son cache. Les commandes s'executent alors depuis ce
+      # cache, dont le node_modules ne contient pas `@playwright/test` ->
+      # `Cannot find module '@playwright/test'` au chargement de la config, et
+      # zero test execute. On appelle donc le binaire local installe par
+      # `npm ci`, qui resout bien les dependances du repo.
       - name: Installer les navigateurs Playwright
-        run: npx playwright install --with-deps chromium
+        run: ./node_modules/.bin/playwright install --with-deps chromium
 
       - name: Run Playwright — parcours client sous lockdown
         env:
           NITRATES_BASE_URL: "http://127.0.0.1:8042"
           CI: "true"
         run: |
-          npx playwright test \
+          ./node_modules/.bin/playwright test \
             --config playwright.config.nitrates.ts \
             e2e/nitrates/root_public_lockdown.spec.ts
 

--- a/config/settings/ci.py
+++ b/config/settings/ci.py
@@ -16,9 +16,16 @@ SECRET_KEY = env(
 )
 
 # https://docs.djangoproject.com/en/dev/ref/settings/#allowed-hosts
-ALLOWED_HOSTS = [
-    "localhost",
-]
+# Pilotable par DJANGO_ALLOWED_HOSTS : le workflow e2e sert le simulateur sur
+# 127.0.0.1 (playwright.config.nitrates.ts cible cette IP pour matcher la Site
+# nitrates via SetUrlConfBasedOnSite). Avec la liste figee a ["localhost"], la
+# variable posee par le workflow etait ignoree et Django repondait 400
+# DisallowedHost sur chaque requete -> toutes les specs echouaient sur une page
+# vide.
+ALLOWED_HOSTS = env.list(
+    "DJANGO_ALLOWED_HOSTS",
+    default=["localhost", "127.0.0.1"],
+)
 
 # CACHES
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Le workflow `E2E nitrates` echouait systematiquement (nightly comme dispatch) **sans executer un seul test**. Quatre bugs d'infra distincts s'empilaient, chacun masquant le suivant.

Aucun n'a de rapport avec le code applicatif : ce sont des defauts du workflow et des settings CI.

## Les 4 causes, dans l'ordre ou elles se sont revelees

**1. `npx playwright` telechargeait un paquet autonome**
Le repo declare `@playwright/test` mais pas `playwright`. `npx` ne trouvait donc aucun binaire local et telechargeait `playwright` (derniere version) dans son cache, dont le `node_modules` ne contient pas `@playwright/test` -> `Cannot find module '@playwright/test'`. On appelle desormais le binaire local.

**2. `bin/build_assets.sh` supprimait `@playwright/test`**
C'est le hook de deploiement Scalingo : il finit par `npm prune --production` pour ne pas gonfler le slug. Reutilise tel quel par l'e2e, il retire les devDependencies juste avant que Playwright n'en ait besoin. On reinstalle les deps apres le build.

Reproduit en local : `npm ci` -> binaire present ; `npm prune --production` -> absent ; `npm ci` -> present.

**3. Le check de demarrage validait un serveur mort**
`curl -w '%{http_code}'` ecrit deja `000` sur stdout quand la connexion echoue ; le `|| echo "000"` en ajoutait un second. La variable valait `"000000"`, donc le test `!= "000"` passait des la 1ere iteration. Le step annoncait « Serveur up (HTTP 000000) » alors que rien n'ecoutait.

On teste desormais le succes de `curl -f`, on lance le serveur avec `nohup` (il doit survivre a la fin du step) et on affiche le log Django en cas d'echec.

**4. `config/settings/ci.py` ignorait `DJANGO_ALLOWED_HOSTS`**
Le workflow posait la variable, mais le settings figeait `ALLOWED_HOSTS = ["localhost"]`. Playwright ciblant `127.0.0.1` (necessaire pour matcher la Site nitrates via `SetUrlConfBasedOnSite`), Django repondait 400 DisallowedHost sur chaque requete. Le defaut inclut maintenant `127.0.0.1` et reste surchargeable par l'env.

## Resultat

| | avant | apres |
|---|---|---|
| `e2e-nitrates` | 0 execute, 39 echecs | **45 passed**, 12 failed |
| `e2e-root-public-lockdown` | echec | **success** |

## Les 12 echecs restants

Ils sont **pre-existants** et enfin visibles. Cette PR ne touche aucun fichier de test (`git diff --stat` = workflow + settings uniquement). Deux familles, toutes deux des donnees absentes en CI :

- `debug_view` / `map_overlays` (4) : attendent une parcelle RPG cliquable, non seedee en CI
- `branche_*` type_0 + `simulateur` + `reset_form` (8) : cas `type_0` / `sol_non_cultive` qui ne resolvent pas sur la base ephemere

A traiter separement : soit en seedant la donnee manquante, soit en marquant ces cas comme necessitant un jeu de donnees complet. Je n'ai pas voulu les corriger ici pour garder la PR sur un seul sujet - reparer la chaine d'execution.
