### PR TITLE
nitrates(ci): e2e — le wait-for-ready validait un serveur mort

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -142,16 +142,25 @@ jobs:
           DJANGO_LOCKDOWN_BEHIND_LOGIN: "False"
           DJANGO_NITRATES_ROOT_OUVERT: "True"
         run: |
-          python manage.py runserver 127.0.0.1:8042 --noreload &
+          python manage.py runserver 127.0.0.1:8042 --noreload \
+            > /tmp/django-e2e.log 2>&1 &
           echo "Attente du serveur sur 127.0.0.1:8042..."
+          # Piege : `curl -w '%{http_code}'` ecrit DEJA "000" sur stdout quand la
+          # connexion echoue. Avec le `|| echo "000"` qui etait ici, la variable
+          # valait "000000" -> le test `!= "000"` etait vrai des la 1ere
+          # iteration : le step annoncait « Serveur up (HTTP 000000) » alors que
+          # rien n'ecoutait encore, et les specs echouaient ensuite sur des pages
+          # vides. On teste donc le SUCCES de curl (-f), pas le contenu du code.
+          # (Le job lockdown ci-dessous n'avait pas ce bug : il compare a "200".)
           for i in $(seq 1 60); do
-            code=$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:8042/ || echo "000")
-            if [ "$code" != "000" ]; then
+            if code=$(curl -sf -o /dev/null -w '%{http_code}' http://127.0.0.1:8042/); then
               echo "Serveur up (HTTP $code)"; exit 0
             fi
             sleep 2
           done
           echo "ECHEC : le serveur n'a pas demarre en 120s" >&2
+          echo "--- log Django ---" >&2
+          cat /tmp/django-e2e.log >&2
           exit 1
 
       - name: Installer les navigateurs Playwright


### PR DESCRIPTION
Dernier bug d'infra du workflow e2e, masque jusqu'ici par ceux que #380 et #382 viennent de corriger.

## Le probleme

`curl -w '%{http_code}'` ecrit **deja** `000` sur stdout quand la connexion echoue. Le `|| echo "000"` en ajoutait un second : la variable valait `"000000"`, donc le test `!= "000"` etait vrai des la premiere iteration.

Resultat : le step annoncait « Serveur up (HTTP 000000) » alors que Django n'ecoutait pas encore. Les specs partaient sur un serveur absent et echouaient toutes sur des pages vides — sans que le log ne donne le moindre indice.

Reproduit en local :

```
ANCIEN:  code='000000' -> test !=000 vaut VRAI_BUG
NOUVEAU: correctement detecte comme DOWN
```

## Le correctif

On teste le **succes de curl** (`-f`) plutot que le contenu du code, et le log Django est affiche en cas d'echec pour ne plus diagnostiquer a l'aveugle.

Le job `e2e-root-public-lockdown` **n'a pas ce bug** (il compare a `"200"`, pas a `!= "000"`) : il n'est pas touche.

## Verification

Run sur cette branche : `Serveur up (HTTP 200)` — un vrai code, plus le `000000` fantoche.

| | avant les 3 PR | apres |
|---|---|---|
| `e2e-nitrates` | 0 test execute | **45 passed**, 12 failed |
| `e2e-root-public-lockdown` | echec | **success** |

## Les 12 echecs restants

**Pre-existants**, et sans rapport avec cette PR qui ne touche aucun fichier de test. Ils sont simplement visibles pour la premiere fois. Verifie : `branche_colza` passe en local (7/7) et n'echoue en CI que sur son cas `type_0`.

Deux familles, toutes deux des donnees absentes de la base ephemere :

- **`debug_view` / `map_overlays` (4)** : attendent une parcelle RPG cliquable, non seedee
- **`branche_*` type_0 / `simulateur` / `reset_form` (8)** : cas `type_0` et `sol_non_cultive` qui ne resolvent pas

A traiter separement (seeder la donnee, ou marquer ces cas comme necessitant un jeu complet). Je ne les corrige pas ici pour garder la PR sur un seul sujet.
