### PR TITLE
nitrates(ci): active les panneaux debug pour l'e2e (ids de règles)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -141,6 +141,13 @@ jobs:
           DJANGO_ALLOWED_HOSTS: "127.0.0.1,localhost"
           DJANGO_LOCKDOWN_BEHIND_LOGIN: "False"
           DJANGO_NITRATES_ROOT_OUVERT: "True"
+          # Les specs de branches assertent l'IDENTIFIANT TECHNIQUE de la regle
+          # (ex r_autres_cultures_tous_types). Cet id n'apparait que dans le
+          # panneau debug developpeur, gate par ce flag (defaut False, True en
+          # settings local). Sans lui le simulateur calcule le bon resultat
+          # mais ne l'ecrit nulle part dans le HTML -> les 12 specs de branches
+          # echouent en CI alors qu'elles passent en local.
+          DJANGO_NITRATES_FORM_DEBUG_PANELS: "True"
         run: |
           python manage.py runserver 127.0.0.1:8042 --noreload &
           echo "Attente du serveur sur 127.0.0.1:8042..."


### PR DESCRIPTION
Dernier maillon de la réparation de l'e2e nocturne (après #378, #380, #382).

## Cause

Les 12 specs de branches échouaient en CI **alors qu'elles passent en local**,
avec les mêmes arbres, les mêmes référentiels et les mêmes données géo.

Elles assertent l'**identifiant technique** de la règle attendue (ex
`r_autres_cultures_tous_types`). Or cet id n'est écrit dans le HTML que par le
panneau debug développeur, gaté par `NITRATES_FORM_DEBUG_PANELS` : `True` dans
`config/settings/local.py`, **`False` par défaut** — donc en CI.

Le simulateur calculait le bon résultat depuis le début. L'identifiant
n'apparaissait simplement nulle part dans la page.

## Vérification

Échec reproduit puis levé en local sous `config.settings.ci` :

- sans le flag → ni id de règle, ni périodes
- avec le flag → `r_autres_cultures_tous_types` + 15/12 et 15/01

## Run grandeur nature

Workflow lancé sur cette branche avant merge :

- `e2e-nitrates` : **110 passed**
- `e2e-root-public-lockdown` : **9 passed**