### PR TITLE
nitrates(e2e): neutralise un flaky sur les 404 de ressources externes

### DIFF
--- a/e2e/nitrates/root_public_lockdown.spec.ts
+++ b/e2e/nitrates/root_public_lockdown.spec.ts
@@ -100,10 +100,34 @@ const CONSOLE_TOLERE = [
 
 function collecteErreursConsole(page: Page): string[] {
   const erreurs: string[] = [];
+
+  // Un echec de chargement de ressource produit un message SANS URL
+  // (« Failed to load resource: the server responded with a status of 404 »),
+  // que le filtre par domaine ci-dessus ne peut donc pas attraper. On note
+  // separement les URLs externes qui ont echoue pour pouvoir les ignorer :
+  // une tuile IGN qui rate est un alea reseau du runner, pas une regression.
+  // Les echecs sur NOTRE origine restent, eux, des erreurs (c'est le sujet du
+  // test : verifier que le lockdown n'intercepte pas /geojson/zv/).
+  let echecsExternes = 0;
+  page.on('requestfailed', (req) => {
+    if (CONSOLE_TOLERE.some((t) => req.url().includes(t))) echecsExternes += 1;
+  });
+  page.on('response', (res) => {
+    if (res.status() >= 400 && CONSOLE_TOLERE.some((t) => res.url().includes(t))) {
+      echecsExternes += 1;
+    }
+  });
+
   page.on('console', (msg) => {
     if (msg.type() !== 'error') return;
     const texte = msg.text();
     if (CONSOLE_TOLERE.some((t) => texte.includes(t))) return;
+    // Message generique de ressource : on ne le compte que s'il ne correspond
+    // pas a un echec externe deja observe.
+    if (texte.includes('Failed to load resource') && echecsExternes > 0) {
+      echecsExternes -= 1;
+      return;
+    }
     erreurs.push(texte);
   });
   page.on('pageerror', (err) => erreurs.push(`pageerror: ${err.message}`));


### PR DESCRIPTION
Le run e2e sur main est passé (110 + 9), mais avec **1 flaky** sur
`la page racine se charge : carte Leaflet + hero, sans erreur console`.

Une gate de déploiement qui passe « au retry » n'est pas fiable : autant la
stabiliser maintenant.

## Cause

Une tuile IGN en 404 fait échouer l'assertion « zéro erreur console ». Le
filtre `CONSOLE_TOLERE` existant matche sur le **domaine**, mais Chromium émet
pour ce cas un message **sans URL** :

```
Failed to load resource: the server responded with a status of 404 ()
```

Il passait donc entre les mailles.

## Fix

On corrèle ce message générique avec les échecs réseau réellement observés sur
les domaines tolérés (`requestfailed` / `response >= 400`). Un échec sur
**notre** origine reste une erreur.

## La couverture ne baisse pas

Vérifié en simulant la régression que ce test cible (lockdown qui intercepte
`/geojson/zv/`, renvoyé en 302 vers le login) : ça ne produit **aucune** erreur
console. Ce qui la détecte, c'est le `poll` sur les couches Leaflet — inchangé.

Autrement dit, l'assertion console ne portait pas le garde-fou ; elle ne
générait que du bruit.

## Vérification

Suite lockdown en local avec le correctif : **9 passed**.