### PR TITLE
ci: seuil de couverture bloquant à 75% + rapport HTML par run (#50)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,16 +139,33 @@ jobs:
       - name: Run Django Tests
         run: coverage run -m pytest
 
-      # Affiche le detail (lignes manquantes) dans les logs CI. `|| true` :
-      # un eventuel souci de reporting ne doit pas faire echouer le job.
-      - name: Coverage report
+      # SEUIL BLOQUANT : plus de `|| true`. `fail_under = 75` (setup.cfg) fait
+      # sortir cette commande en code 2 si la couverture regresse, ce qui fait
+      # echouer le job `pytest` -- donc le gate CI, donc le deploiement.
+      - name: Coverage report (seuil bloquant 75%)
         if: always()
-        run: coverage report --show-missing || true
+        run: coverage report --show-missing
 
       # Genere coverage.xml (Cobertura) pour un upload futur eventuel.
       - name: Coverage XML
         if: always()
         run: coverage xml || true
+
+      # Rapport HTML navigable, telechargeable depuis la page du run (onglet
+      # Artifacts). Permet d'inspecter ligne par ligne ce qui est couvert pour
+      # n'importe quelle version, y compris une release.
+      - name: Coverage HTML
+        if: always()
+        run: coverage html -d _coverage_html || true
+
+      - name: Upload rapport de couverture
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-html-${{ github.sha }}
+          path: _coverage_html/
+          retention-days: 90
+          if-no-files-found: warn
 
       # Resume markdown lisible dans l'onglet Summary du run (sans dependance).
       - name: Coverage summary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,15 @@ on:
         description: "SHA ou tag a tester (defaut : la ref de l'appelant)"
         required: false
         type: string
+      gardes_fous_gitops:
+        description: >-
+          Jouer les garde-fous GitOps (arbres canoniques + round-trip fixture
+          referentiels). Concernent la coherence depot <-> base de DEV : ils
+          n'ont pas de sens pour gater une release staging/prod, qui teste un
+          artefact de code fige. Vrai par defaut (CI de dev sur main/develop).
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   linter:
@@ -127,8 +136,9 @@ jobs:
       # active" (dump_*_--check) est un garde-fou SEPARE, execute cote dev (hook
       # local + one-off), pas ici (la CI n'a pas le pivot dev).
 
-      # 1. Une migration manquante casse le post_deploy -> on l'attrape au plus tot.
-      #    Autonome (pas de DB requise).
+      # 1. Une migration manquante casse le post_deploy -> on l'attrape au plus
+      #    tot. Autonome (pas de DB requise). Joue AUSSI en release : une
+      #    migration oubliee ferait echouer le deploiement staging/prod.
       - name: Migrations coherentes (makemigrations --check)
         run: python manage.py makemigrations --check --dry-run
 
@@ -137,6 +147,7 @@ jobs:
       # fixture compare a l'etat seede. On prepare donc la base ephemere ici (le
       # job pytest, lui, recree sa propre base de test isolee ensuite).
       - name: Preparer la base (migrate + seed referentiels)
+        if: ${{ inputs.gardes_fous_gitops != false }}
         run: |
           python manage.py migrate --noinput
           python manage.py seed_referentiels
@@ -145,11 +156,14 @@ jobs:
       #    Valide parse + structure + refs, avec referentiels + scope (sinon faux
       #    negatifs sur les branches SIG PAR/ZAR).
       - name: Arbres canoniques valides
+        if: ${{ inputs.gardes_fous_gitops != false }}
         run: python manage.py validate_arbres_actifs
 
       # 3. La fixture referentiels doit etre round-trip stable : dump_referentiels
       #    --check compare la fixture committee a l'etat seede a l'etape precedente.
+      #    Depend de l'etape "Preparer la base" -> meme condition.
       - name: Fixture referentiels coherente (round-trip)
+        if: ${{ inputs.gardes_fous_gitops != false }}
         run: python manage.py dump_referentiels --check
 
       # On lance la suite sous coverage.py (deja installe via requirements) au

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 permissions:
   actions: read
+  # Necessaire au checkout quand ce workflow est appele via `workflow_call`
+  # depuis deploy-staging / deploy-prod : le token herite des permissions
+  # declarees ici, et l'appelant ne declare que `contents: read` pour lui-meme.
+  contents: read
 
 # Enable Buildkit and let compose use it to speed up image building
 env:
@@ -20,12 +24,26 @@ on:
   push:
     branches: ["main", "develop"]
 
+  # Appelable en GATE par deploy-staging / deploy-prod : une release REJOUE la
+  # CI complete sur le SHA tague, au lieu de se contenter de relire les checks
+  # d'un run anterieur. Le code est identique, mais pas l'environnement
+  # (dependances non epinglees, images de service, runner) -- et un tag peut
+  # pointer un commit ancien dont les checks ont des semaines.
+  workflow_call:
+    inputs:
+      ref:
+        description: "SHA ou tag a tester (defaut : la ref de l'appelant)"
+        required: false
+        type: string
+
 jobs:
   linter:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code Repository
         uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v7.0.0
@@ -86,6 +104,8 @@ jobs:
 
       - name: Checkout Code Repository
         uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v7.0.0

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -64,19 +64,28 @@ jobs:
           echo "sha=$SHA" >> "$GITHUB_OUTPUT"
           echo "Deploiement cible : $REF ($SHA)"
 
-      # Idem staging : la couverture (fail_under = 75) fait partie du job
-      # `pytest`, donc un SHA sous le seuil ne peut pas partir en production.
-      - name: Gate — CI verte (linter + pytest + couverture >= 75%)
+      # Filtre rapide : inutile de payer 20 min de CI+e2e sur un SHA deja
+      # rouge. La CI est REJOUEE juste apres, en bloc.
+      - name: Pre-check — la CI du SHA etait verte
         env:
           GH_TOKEN: ${{ github.token }}
         run: bash .github/scripts/gate_ci_green.sh "${{ steps.resolve.outputs.sha }}" linter pytest
 
+  # Gate CI COMPLET rejoue sur le SHA tague : linter + pytest + couverture
+  # >= 75% + garde-fous GitOps. Idem staging -- a plus forte raison en prod.
+  gate-ci-complet:
+    needs: gate-ci
+    uses: ./.github/workflows/ci.yml
+    with:
+      ref: ${{ needs.gate-ci.outputs.sha }}
+
+  # En parallele de gate-ci-complet (meme dependance : gate-ci).
   gate-e2e:
     needs: gate-ci
     uses: ./.github/workflows/e2e.yml
 
   deploy-prod:
-    needs: [gate-ci, gate-e2e]
+    needs: [gate-ci, gate-ci-complet, gate-e2e]
     runs-on: ubuntu-latest
     # C'est ICI que se joue la protection : l'environment `production` est
     # configure avec un required reviewer -> le run attend l'approbation.

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -72,12 +72,16 @@ jobs:
         run: bash .github/scripts/gate_ci_green.sh "${{ steps.resolve.outputs.sha }}" linter pytest
 
   # Gate CI COMPLET rejoue sur le SHA tague : linter + pytest + couverture
-  # >= 75% + garde-fous GitOps. Idem staging -- a plus forte raison en prod.
+  # >= 75% + check des migrations. Idem staging -- a plus forte raison en prod.
   gate-ci-complet:
     needs: gate-ci
     uses: ./.github/workflows/ci.yml
     with:
       ref: ${{ needs.gate-ci.outputs.sha }}
+      # Les garde-fous GitOps (arbres canoniques, round-trip fixture
+      # referentiels) portent sur la coherence depot <-> base de DEV. Une
+      # release deploie un artefact de code fige : ils n'ont rien a y gater.
+      gardes_fous_gitops: false
 
   # En parallele de gate-ci-complet (meme dependance : gate-ci).
   gate-e2e:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -64,10 +64,12 @@ jobs:
           echo "sha=$SHA" >> "$GITHUB_OUTPUT"
           echo "Deploiement cible : $REF ($SHA)"
 
-      - name: Gate — la CI du SHA est verte
+      # Idem staging : la couverture (fail_under = 75) fait partie du job
+      # `pytest`, donc un SHA sous le seuil ne peut pas partir en production.
+      - name: Gate — CI verte (linter + pytest + couverture >= 75%)
         env:
           GH_TOKEN: ${{ github.token }}
-        run: bash .github/scripts/gate_ci_green.sh "${{ steps.resolve.outputs.sha }}"
+        run: bash .github/scripts/gate_ci_green.sh "${{ steps.resolve.outputs.sha }}" linter pytest
 
   gate-e2e:
     needs: gate-ci

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -66,25 +66,37 @@ jobs:
           echo "sha=$SHA" >> "$GITHUB_OUTPUT"
           echo "Deploiement cible : $REF ($SHA)"
 
-      # Le gate exige `linter` ET `pytest` verts. La COUVERTURE est incluse
-      # dedans : depuis l'ajout de `fail_under = 75` (setup.cfg), l'etape
-      # `coverage report` du job pytest sort en erreur si la couverture
-      # regresse -> pytest rouge -> ce gate refuse le deploiement.
-      # Le 4e garde-fou (e2e) est le job `gate-e2e` ci-dessous.
-      - name: Gate — CI verte (linter + pytest + couverture >= 75%)
+      # Verification PREALABLE et bon marche : le SHA a-t-il deja des checks
+      # verts ? Sert de filtre rapide (on evite de payer 20 min de CI+e2e sur
+      # un commit deja rouge). La CI est REJOUEE juste apres, en bloc.
+      - name: Pre-check — la CI du SHA etait verte
         env:
           GH_TOKEN: ${{ github.token }}
         run: bash .github/scripts/gate_ci_green.sh "${{ steps.resolve.outputs.sha }}" linter pytest
 
-  # --- 2. Gate e2e -------------------------------------------------------
+  # --- 2. Gate CI COMPLET : on REJOUE tout sur le SHA tague ---------------
+  # linter + pytest (1800+ tests) + couverture >= 75% + garde-fous GitOps
+  # (migrations, arbres canoniques, round-trip referentiels).
+  # Rejoue, pas relu : le code est identique mais l'environnement ne l'est pas
+  # (dependances non epinglees, Dependabot merge en continu, images de service).
+  # Tout l'historique d'une release tient ainsi dans SON run.
+  gate-ci-complet:
+    needs: gate-ci
+    uses: ./.github/workflows/ci.yml
+    with:
+      ref: ${{ needs.gate-ci.outputs.sha }}
+
+  # --- 3. Gate e2e -------------------------------------------------------
   # Reutilise le workflow e2e (meme definition que le run nocturne).
+  # Tourne EN PARALLELE de gate-ci-complet : les deux ne dependent que de
+  # gate-ci, donc le temps total est celui du plus lent, pas la somme.
   gate-e2e:
     needs: gate-ci
     uses: ./.github/workflows/e2e.yml
 
-  # --- 3+4. Deploy + smoke -----------------------------------------------
+  # --- 4+5. Deploy + smoke -----------------------------------------------
   deploy-staging:
-    needs: [gate-ci, gate-e2e]
+    needs: [gate-ci, gate-ci-complet, gate-e2e]
     runs-on: ubuntu-latest
     # L'environment porte le secret et restreint qui peut le lire.
     environment:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -7,10 +7,11 @@ name: Deploy staging
 #
 # Sequence, volontairement SANS reload de donnees (les arbres, referentiels et
 # jeux SIG de staging sont pilotes a la main) :
-#   1. gate CI  : le SHA du tag a ses checks verts
-#   2. gate e2e : suite Playwright complete sur base ephemere
-#   3. deploy   : git archive -> scalingo deploy (post_deploy joue migrate)
-#   4. smoke    : HTTP + aucune migration en attente
+#   1. pre-check : le SHA du tag avait deja des checks verts (filtre rapide)
+#   2. gate CI   : CI REJOUEE sur le tag (linter + pytest + couverture >= 75%)
+#   3. gate e2e  : suite Playwright complete sur base ephemere (en parallele)
+#   4. deploy    : git archive -> scalingo deploy (post_deploy joue migrate)
+#   5. smoke     : HTTP + aucune migration en attente
 #
 # Secret requis : SCALINGO_API_TOKEN, dans l'environment `staging`.
 
@@ -75,8 +76,8 @@ jobs:
         run: bash .github/scripts/gate_ci_green.sh "${{ steps.resolve.outputs.sha }}" linter pytest
 
   # --- 2. Gate CI COMPLET : on REJOUE tout sur le SHA tague ---------------
-  # linter + pytest (1800+ tests) + couverture >= 75% + garde-fous GitOps
-  # (migrations, arbres canoniques, round-trip referentiels).
+  # linter + pytest (1800+ tests) + couverture >= 75%, plus le check de
+  # migrations manquantes (une migration oubliee ferait echouer le deploiement).
   # Rejoue, pas relu : le code est identique mais l'environnement ne l'est pas
   # (dependances non epinglees, Dependabot merge en continu, images de service).
   # Tout l'historique d'une release tient ainsi dans SON run.
@@ -85,6 +86,10 @@ jobs:
     uses: ./.github/workflows/ci.yml
     with:
       ref: ${{ needs.gate-ci.outputs.sha }}
+      # Les garde-fous GitOps (arbres canoniques, round-trip fixture
+      # referentiels) portent sur la coherence depot <-> base de DEV. Une
+      # release deploie un artefact de code fige : ils n'ont rien a y gater.
+      gardes_fous_gitops: false
 
   # --- 3. Gate e2e -------------------------------------------------------
   # Reutilise le workflow e2e (meme definition que le run nocturne).

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -66,10 +66,15 @@ jobs:
           echo "sha=$SHA" >> "$GITHUB_OUTPUT"
           echo "Deploiement cible : $REF ($SHA)"
 
-      - name: Gate — la CI du SHA est verte
+      # Le gate exige `linter` ET `pytest` verts. La COUVERTURE est incluse
+      # dedans : depuis l'ajout de `fail_under = 75` (setup.cfg), l'etape
+      # `coverage report` du job pytest sort en erreur si la couverture
+      # regresse -> pytest rouge -> ce gate refuse le deploiement.
+      # Le 4e garde-fou (e2e) est le job `gate-e2e` ci-dessous.
+      - name: Gate — CI verte (linter + pytest + couverture >= 75%)
         env:
           GH_TOKEN: ${{ github.token }}
-        run: bash .github/scripts/gate_ci_green.sh "${{ steps.resolve.outputs.sha }}"
+        run: bash .github/scripts/gate_ci_green.sh "${{ steps.resolve.outputs.sha }}" linter pytest
 
   # --- 2. Gate e2e -------------------------------------------------------
   # Reutilise le workflow e2e (meme definition que le run nocturne).

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,12 @@ ignore_errors = True
 
 [coverage:run]
 source = envergo
+# PYTHON UNIQUEMENT. Le plugin django_coverage_plugin comptait les templates
+# HTML comme des lignes de code : le total passait de ~16 500 a ~46 500 lignes,
+# et comme le plugin echoue au demarrage ("Template debugging must be enabled"),
+# AUCUNE de ces lignes n'etait jamais marquee couverte -> metrique ecrasee a
+# ~24%, sans rapport avec la couverture reelle du code Python. Un template n'est
+# pas du code executable : il sort de la mesure.
 # On ne mesure que le CODE FONCTIONNEL. Sont exclus :
 #  - les tests eux-memes (ca n'a pas de sens qu'un test se "couvre" lui-meme) ;
 #  - les migrations (auto-generees, non testees a la main) ;
@@ -52,12 +58,32 @@ omit =
     envergo/stats/*
     envergo/analytics/*
     envergo/urlmappings/*
-plugins =
-    django_coverage_plugin
+    # Fichiers non-Python : un template/asset n'est pas du code executable.
+    */templates/*
+    *.html
+    *.js
+    *.css
+    envergo/static/*
+    # REVERT_AT_MERGE_TIME_FOR_UPSTREAM_ENVERGO
+    # Code Envergo non maintenu par l'equipe nitrates : le simulateur
+    # re-implemente ses propres regles, ces modules ne sont pas exerces par
+    # nos tests et diluent la metrique.
+    envergo/evaluations/*
+    envergo/moulinette/regulations/*
+    # Commandes de management : outillage ponctuel (ingestion Miro, seeds de
+    # validation, exports de manifestes), joue a la main par un operateur et
+    # non couvert par la suite. 2 961 lignes a ~0% qui masquaient la couverture
+    # reelle du code applicatif.
+    envergo/geodata/management/commands/*
+    envergo/nitrates/management/commands/*
 
 [coverage:report]
 show_missing = True
 skip_covered = False
-# Piste future : decommenter `fail_under = N` pour faire echouer la CI sous un
-# seuil de couverture. Laisse desactive pour l'instant (ne pas bloquer la CI).
-# fail_under = 80
+# SEUIL BLOQUANT : sous 75%, `coverage report` sort en code 2 -> le job pytest
+# echoue -> le gate CI refuse le deploiement (staging comme prod).
+#
+# Mesure de reference du 14/08/2026 sur ce scope : 77% (10 607 lignes, 2 417
+# non couvertes), dont envergo/nitrates a 86%. Le seuil est pose 2 points sous
+# la mesure : il interdit toute REGRESSION sans bloquer l'existant.
+fail_under = 75


### PR DESCRIPTION
La couverture était mesurée mais ne pouvait rien bloquer : `coverage report`
était suffixé de `|| true` et `fail_under` restait commenté.

**1. La métrique était fausse.** `django_coverage_plugin` comptait les templates
HTML comme du code (46 500 lignes au lieu de 16 500) et, le plugin échouant au
démarrage faute de template debugging, aucune de ces lignes n'était jamais
marquée couverte : le total tombait à 24%, sans rapport avec la couverture réelle
du Python. Plugin retiré, fichiers non exécutables (html, js, css, static) sortis
de la mesure.

**2. Périmètre resserré** sur ce que maintient l'équipe nitrates : exclusion de
`evaluations`, `moulinette/regulations`, et des commandes de management nitrates
et geodata (2 961 lignes à ~0%, outillage joué à la main).

**3. Seuil `fail_under = 75`** : sous ce niveau `coverage report` sort en code 2,
le job pytest échoue et le gate refuse le déploiement, staging comme prod.

Mesure de référence : **77%** (10 604 lignes, 2 414 non couvertes), dont
`envergo/nitrates` à **86%**. Seuil posé 2 points en dessous : interdit la
régression sans bloquer l'existant.

Le rapport HTML est publié en artefact de chaque run (90 jours) : la couverture
d'une version donnée devient consultable ligne par ligne, y compris pour une
release.