### PR TITLE
ci: corrige le startup_failure de ci.yml appelé en workflow_call (#50)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ permissions:
 # Enable Buildkit and let compose use it to speed up image building
 env:
   DATABASE_URL: "postgis://envergo:envergo@localhost:5432/envergo"
-  USE_DOCKER: False
+  USE_DOCKER: "False"
   LANG: "fr_FR.UTF-8"
   LC_ALL: "fr_FR.UTF-8"
   DJANGO_SETTINGS_MODULE: "config.settings.ci"


### PR DESCRIPTION
Depuis que `ci.yml` est appelable via `workflow_call` (#389), les deux
workflows de release échouent en `startup_failure` sans créer aucun job.

Cause : `USE_DOCKER: False` non quoté, donc booléen YAML. Un bloc `env:` de
workflow n'accepte que des chaînes. La validation laissait passer tant que
`ci.yml` n'était déclenché que par push/pull_request ; en workflow réutilisable
elle est stricte et rejette le fichier entier.

`e2e.yml`, réutilisable depuis le début, quotait déjà la sienne.