### PR TITLE
ci: les workflows de release déclarent actions:read pour appeler ci.yml (#50)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -19,6 +19,11 @@ name: Deploy prod
 
 permissions:
   contents: read
+  # `actions: read` est requis parce que ce workflow APPELLE ci.yml, qui le
+  # declare : un workflow appele ne peut pas obtenir plus de permissions que
+  # son appelant, sinon GitHub rejette le fichier entier (startup_failure,
+  # aucun job cree). e2e.yml, lui, se contente de `contents: read`.
+  actions: read
 
 on:
   release:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -17,6 +17,11 @@ name: Deploy staging
 
 permissions:
   contents: read
+  # `actions: read` est requis parce que ce workflow APPELLE ci.yml, qui le
+  # declare : un workflow appele ne peut pas obtenir plus de permissions que
+  # son appelant, sinon GitHub rejette le fichier entier (startup_failure,
+  # aucun job cree). e2e.yml, lui, se contente de `contents: read`.
+  actions: read
 
 on:
   release:


### PR DESCRIPTION
Les deux workflows de release échouaient en `startup_failure` sans créer aucun job : ni linter, ni pytest, ni Playwright.

Un workflow appelé via `workflow_call` ne peut pas obtenir plus de permissions que
son appelant. `ci.yml` déclare `actions: read` ; les appelants ne déclaraient que
`contents: read`, donc GitHub rejetait le fichier entier.

Cela explique pourquoi `gate-e2e` passait et pas `gate-ci-complet` : `e2e.yml` se
contente de `contents: read`, strictement identique à l'appelant.